### PR TITLE
Rewrite README as a product pitch, add open-source scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: "Bug report"
+description: "Something crashed, produced wrong output, or otherwise misbehaved (not a scoring judgment call — see the check-accuracy template for that)."
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you run, and what went wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Command(s) run, and a link to the repo if the bug depends on repo contents.
+      placeholder: |
+        npx harness-score --json
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: harness-score version
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: OS / Node version
+      placeholder: "macOS 14, Node 20.11"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output / stack trace
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/paladini/harness-score/security/policy
+    about: Please report security issues privately — see SECURITY.md, don't file a public issue.
+  - name: Guide / documentation
+    url: https://paladini.github.io/harness-score/
+    about: Read the maturity model and check catalog before opening a question — most "why did I lose points" questions are answered there.

--- a/.github/ISSUE_TEMPLATE/false_positive.yml
+++ b/.github/ISSUE_TEMPLATE/false_positive.yml
@@ -1,0 +1,52 @@
+name: "Scanner misjudged my repo (false positive/negative)"
+description: "A check passed or failed when it shouldn't have — the highest-value bug report there is."
+labels: ["check-accuracy"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The scanner is deterministic pattern matching, so it will occasionally
+        misjudge a real repository (a linter it doesn't recognize, a rule
+        format it doesn't parse). Reports like this are what keep the rubric
+        honest — thank you.
+  - type: input
+    id: check-id
+    attributes:
+      label: Check ID
+      description: "e.g. SNS-02, HKS-05 — shown in the CLI output and JSON report"
+      placeholder: "SNS-02"
+    validations:
+      required: true
+  - type: dropdown
+    id: direction
+    attributes:
+      label: What went wrong
+      options:
+        - "False negative — check failed but the artifact is actually there"
+        - "False positive — check passed but it shouldn't have"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repository / minimal reproduction
+      description: >-
+        A link to the public repo, or the smallest file/snippet that
+        reproduces it (e.g. the exact `.cursor/rules/*.mdc` frontmatter, the
+        linter config, the hooks.json entry).
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs. actual
+      description: What did you expect the check to report, and what did it actually report?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: harness-score version
+      description: "Output of `npx harness-score --json | grep version`, or the `v0.x.y` printed in the CLI header"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: "Feature request / new check"
+description: "Propose a new check, a rubric change, or a feature for the CLI, guide, plugin, or GitHub Action."
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Check the [ROADMAP](../../ROADMAP.md) first — your idea might already
+        be planned. New-check proposals in particular benefit from discussion
+        before a PR, since they change what every existing repository scores.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's missing or wrong today
+      description: What artifact, tool, or convention isn't recognized — or what behavior would you like to see instead?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed check or feature
+      description: >-
+        If proposing a new check: what would it detect, how many points
+        should it be worth, and which dimension does it belong to?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## What & why
+
+<!-- What does this change, and what problem does it solve? Link an issue if there is one. -->
+
+## Type of change
+
+- [ ] Bug fix (false positive/negative in a check, incorrect output)
+- [ ] New or changed check (rubric change — see checklist below)
+- [ ] Docs
+- [ ] Other (plugin, GitHub Action, tooling)
+
+## Rubric-change checklist (skip if not touching `score.ts`/checks)
+
+- [ ] `packages/cli/src/checks/*.ts` updated
+- [ ] `docs/guide/maturity-model.md` updated to match
+- [ ] `docs/guide/measure-and-improve.md` (check catalog) updated to match
+- [ ] `fixtures/level-0..4/` updated so the maturity ladder still makes sense
+- [ ] Check IDs were **not** renumbered or reused
+
+## Checklist
+
+- [ ] `npm test` passes
+- [ ] `npm run lint` passes
+- [ ] `npm run scan` still reports **L4** for this repo
+- [ ] `npm run docs:build` passes (if docs changed)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education,
+socio-economic status, nationality, personal appearance, race, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our
+standards of acceptable behavior and will take appropriate and fair
+corrective action in response to any behavior that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (issues, pull
+requests, discussions) and also applies when an individual is officially
+representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer at **fnpaladini@gmail.com**. All complaints will
+be reviewed and investigated promptly and fairly.
+
+All maintainers are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to Harness Score
+
+Thanks for considering a contribution — issues, pull requests, and
+discussion are all welcome. This project is small enough that a short read
+here should be all you need before opening a PR.
+
+## Ways to contribute
+
+- **Report a false positive/negative.** The scanner is deterministic pattern
+  matching; it will occasionally misjudge a real repository (a linter it
+  doesn't recognize, a rule format it doesn't parse). These reports are the
+  most valuable contribution there is — see
+  [tech-leads-club/fakeflix](https://github.com/tech-leads-club/fakeflix) in
+  our own history for an example of a real-world test that shipped several
+  fixes.
+- **Propose or add a check.** New tools, new conventions, new artifacts worth
+  rewarding. See [ROADMAP.md](ROADMAP.md) for what's already planned.
+- **Improve the guide.** Docs fixes, clearer recipes, better examples.
+- **Fix a bug** in the CLI, the plugin, or the GitHub Action.
+
+Open an issue before a large PR (a new check, a rubric change) so we can
+agree on the approach first — rubric changes touch multiple files that must
+stay in sync (see below) and are easiest to get right with agreement up
+front. Small fixes (typos, docs, obvious bugs) can go straight to a PR.
+
+## Project layout
+
+```
+packages/cli/    the scanner — TypeScript, ESM, zero runtime dependencies
+  src/checks/    one file per dimension
+  src/score.ts   the maturity rubric (levels L0–L4)
+  test/          vitest; fixtures/level-0..4 pin each maturity level
+docs/            the VitePress guide (deploys to GitHub Pages)
+plugin/          the Cursor Marketplace plugin
+action/          the composite GitHub Action wrapping the CLI
+```
+
+Full conventions — written for agents, equally useful for humans — live in
+[AGENTS.md](AGENTS.md). Read it before touching `packages/cli`.
+
+## The three invariants that matter most
+
+1. **The CLI stays deterministic.** No LLM calls, no network, no telemetry,
+   no `Date.now()`-dependent output. Filesystem reads and parsing only — a
+   PR that breaks this will be asked to change approach.
+2. **Zero runtime dependencies in `packages/cli`.** Fast `npx`, no supply
+   chain surface. Dev dependencies are fine.
+3. **The rubric lives in three places that must change together:**
+   `packages/cli/src/score.ts` (implementation),
+   `docs/guide/maturity-model.md` (levels),
+   `docs/guide/measure-and-improve.md` (check catalog). A docs-sync test
+   enforces that check IDs, points, and anchors match across all three —
+   `npm test` will fail loudly if you update one and not the others.
+
+Check IDs (`CTX-01`, `SNS-03`, …) are public API: never renumber or reuse
+one, even if a check is removed.
+
+## Adding or changing a check
+
+This is the highest-value contribution and the one most likely to need a
+design discussion first, because it changes what every existing repository
+scores:
+
+1. Open an issue describing the artifact you want to detect and why it
+   deserves points (or why an existing check's points should move).
+2. Implement the check in the relevant `packages/cli/src/checks/*.ts`,
+   wire it into the dimension total, and add/update fixtures under
+   `fixtures/level-0..4/` so the maturity ladder still makes sense at every
+   level.
+3. Update `docs/guide/maturity-model.md` and
+   `docs/guide/measure-and-improve.md` in the same PR — the docs-sync test
+   will fail otherwise.
+4. Run the full gate before opening the PR (see below).
+
+## Before opening a PR
+
+```bash
+npm install
+npm test            # build + vitest — must pass
+npm run lint         # biome — lints and checks formatting
+npm run scan         # self-audit — this repo must stay at L4
+npm run docs:build   # builds the guide — dead links fail it
+```
+
+CI runs the same checks; a red run will block review.
+
+## Releasing
+
+Releases (versioning, publishing to npm/GitHub Packages/JSR, docs deploy) are
+handled by a maintainer — see [RELEASING.md](RELEASING.md) if you're picking
+that up.
+
+## Code of conduct
+
+Participation in this project is governed by our
+[Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -5,60 +5,164 @@
   </picture>
 </p>
 
-# Harness Score
+<h1 align="center">Harness Score</h1>
 
-**Harness engineering for Cursor repositories — a guide you can read and a
-maturity level you can measure.**
+<p align="center">
+  <b>Your AI coding agent is only as reliable as the harness around it.</b><br>
+  Measure that harness in seconds. Know exactly what to fix. Watch the number go up.
+</p>
 
-[![CI](https://github.com/paladini/harness-score/actions/workflows/ci.yml/badge.svg)](https://github.com/paladini/harness-score/actions/workflows/ci.yml)
-[![Harness Score](https://paladini.github.io/harness-score/harness-badge.svg)](https://paladini.github.io/harness-score/)
-[![npm](https://img.shields.io/npm/v/harness-score)](https://www.npmjs.com/package/harness-score)
-[![JSR](https://jsr.io/badges/@paladini/harness-score)](https://jsr.io/@paladini/harness-score)
-[![docs](https://img.shields.io/badge/guide-github%20pages-blue)](https://paladini.github.io/harness-score/)
-[![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+<p align="center">
+  <a href="https://github.com/paladini/harness-score/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/paladini/harness-score/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://paladini.github.io/harness-score/"><img alt="Harness Score" src="https://paladini.github.io/harness-score/harness-badge.svg"></a>
+  <a href="https://www.npmjs.com/package/harness-score"><img alt="npm" src="https://img.shields.io/npm/v/harness-score"></a>
+  <a href="https://jsr.io/@paladini/harness-score"><img alt="JSR" src="https://jsr.io/badges/@paladini/harness-score"></a>
+  <a href="https://paladini.github.io/harness-score/"><img alt="docs" src="https://img.shields.io/badge/guide-github%20pages-blue"></a>
+  <a href="LICENSE"><img alt="license" src="https://img.shields.io/badge/license-MIT-green"></a>
+</p>
 
-An AI coding agent is a model plus a **harness** — the rules, skills, hooks,
-sensors, and guardrails around it. The model you rent; the harness you own.
-This project helps you build a great one:
+An AI coding agent is a model plus a **harness** — the context files, rules,
+skills, hooks, sensors, and guardrails wrapped around it. The model you rent;
+the harness you own. Two repositories can use the exact same model and get
+wildly different results, because one has a harness that catches mistakes
+before they ship and the other has none.
+
+**Harness Score measures that harness.** Point it at any repository and get a
+maturity level (L0–L4), a 100-point breakdown across six dimensions, and the
+precise, ranked list of what to fix next — with zero LLM calls, zero network
+access, and the same result every time you run it.
 
 ```bash
 npx harness-score
 ```
 
 ```
+  harness-score v0.1.2  ~/my-app
+
   Maturity: L2 · Guided   Score: 61/100 (61%)
 
-  Context & Guides     ████████████████░░░░  80%
-  Hooks & Guardrails   ░░░░░░░░░░░░░░░░░░░░   0%
-  ...
+  Context & Guides     ████████████████░░░░  80%  16/20 pts
+  Skills & Commands    █████████████░░░░░░░  67%   8/12 pts
+  Hooks & Guardrails   ░░░░░░░░░░░░░░░░░░░░   0%   0/14 pts
+  Sensors & Feedback   ████████████████░░░░  80%  16/20 pts
+  CI Feedback          ██████████████░░░░░░  71%  10/14 pts
+  Hygiene & Safety     ███████████████░░░░░  75%  15/20 pts
+
   To reach L3: sensors ≥ 60%; ci ≥ 50%
 ```
 
-**100% deterministic**: filesystem checks only — no LLM calls, no network, no
-telemetry. Same input, same score, every time. Reproducible in CI.
+Not just a score — a **diagnosis**. Every failed check names the file,
+explains what's missing, and links to the exact recipe to fix it.
+
+---
+
+## Why this exists
+
+Vibe-coding without a harness works, right up until it doesn't: an agent that
+rediscovers your conventions every session, `rm -rf`s something it shouldn't,
+or ships code nobody reviewed because nothing was there to catch it. The
+fix isn't "prompt better" — it's building the same kind of control system
+around an AI agent that you'd build around any other autonomous system:
+**guides** to steer it, **sensors** to check its work, and **guardrails** to
+stop it before damage happens.
+
+Most repositories have none of this and don't know it. Harness Score tells
+you exactly where you stand, in a language a CI pipeline (and a competitive
+teammate) understands: a number, a level, a badge.
+
+## How it works
+
+```mermaid
+flowchart LR
+    A["Your repository"] --> B["harness-score scanner\n33 deterministic checks"]
+    B --> C["6 dimensions scored\ncontext · skills · hooks\nsensors · CI · hygiene"]
+    C --> D["Maturity level\nL0 → L4"]
+    D --> E["Terminal report"]
+    D --> F["JSON / Markdown"]
+    D --> G["SVG badge"]
+    D --> H["CI gate\n--min-level"]
+```
+
+Every check is a filesystem fact — a file exists, parses, matches a pattern —
+never a judgment call and never a network request. Same repository, same
+commit, same score, on your laptop or in CI, forever. That's what lets you
+gate a pipeline on it.
+
+## The maturity ladder
+
+Levels don't just add up points — they gate on the **shape** of your harness.
+80 points of beautifully written docs with zero tests is not maturity; it's
+L1. Climbing the ladder means covering a new dimension at each step, not just
+accumulating percentage.
+
+```mermaid
+flowchart LR
+    L0["L0 · Unharnessed"] -- "write AGENTS.md" --> L1["L1 · Documented"]
+    L1 -- "rules + skills\n+ hygiene" --> L2["L2 · Guided"]
+    L2 -- "tests + linter\n+ CI" --> L3["L3 · Sensing"]
+    L3 -- "hooks + 80% total" --> L4["L4 · Self-correcting"]
+```
+
+| | Level | What it means | You unlock it with | Priority to climb |
+|---|---|---|---|---|
+| 🌱 | **L0 · Unharnessed** | Agents rediscover the project every session. Mistakes ship unless a human happens to catch them. Most repositories start — and stay — here. | *(the default)* | Write an `AGENTS.md` |
+| 📖 | **L1 · Documented** | A substantive `AGENTS.md` orients every session: what the project is, how to build and test it, what not to touch. The single highest-leverage step from zero. | Context ≥ 40% | Add scoped rules + a skill |
+| 🧭 | **L2 · Guided** | Guidance has real structure: scoped `.cursor/rules/` with valid frontmatter, at least one skill or command, basic hygiene (env files ignored, no leaked secrets). The harness ships with the code and is reviewed like code. | Context ≥ 60%, (Skills ≥ 30% *or* Hooks ≥ 30%), Hygiene ≥ 50% | Add a test runner, linter, types, CI |
+| 🔬 | **L3 · Sensing** | The feedback loop exists. Tests, a linter, type checking, and a CI pipeline re-verify every push. The agent can check its own work with deterministic tools — this is where AI-assisted development stops feeling risky. | L2, plus Sensors ≥ 60%, CI ≥ 50% | Add gate + feedback hooks, pre-commit |
+| 🛡️ | **L4 · Self-correcting** | The loop closes at runtime. Gate hooks make destructive actions *impossible*, not just discouraged; feedback hooks lint and format inline. All six dimensions covered, total score ≥ 80%. A mistake has to get past rules, hooks, tests, types, CI, *and* the gates — mostly without a human in the loop. | L3, plus Hooks ≥ 70%, total ≥ 80% | Keep it there — gate CI on `--min-level 4` |
+
+Two repositories can both score 65% with completely different shapes — that's
+exactly why levels gate on dimensions instead of a raw percentage:
+
+- **65%, all guides, no sensors** → stuck at L1. Beautifully documented,
+  unverified. Priority: tests + CI, not more prose.
+- **65%, strong sensors, no context** → stuck at L0/L1. The agent's work is
+  checked, but it guesses your conventions every session. Priority: one
+  afternoon on `AGENTS.md`.
+
+The scanner always tells you which requirement blocks the *next* level
+(`To reach L3: sensors ≥ 60%; ci ≥ 50%`) — the path up is never a guess.
+Full rubric, thresholds, and rationale: **[the Maturity Model](https://paladini.github.io/harness-score/guide/maturity-model)**.
+
+## The six dimensions
+
+100 points, six dimensions, 33 checks. Each check names a concrete artifact —
+never "write better rules," always "this file, this field, this pattern."
+
+| Dimension | Points | What it measures |
+|---|---|---|
+| 📖 Context & Guides | 20 | `AGENTS.md` substance, `.cursor/rules/` scoping and frontmatter |
+| 🧩 Skills & Commands | 12 | Packaged procedures — skills, slash commands, trigger-worthy descriptions |
+| 🪝 Hooks & Guardrails | 14 | Gate hooks (block risky actions) and feedback hooks (lint/format on edit) |
+| ✅ Sensors & Feedback | 20 | Test runner, linter, type checker, formatter, actual test files |
+| ⚙️ CI Feedback | 14 | Pipeline runs tests/lint/types on every push, pre-commit installed |
+| 🔒 Hygiene & Safety | 20 | `.gitignore`, no leaked `.env`/secrets, license, lockfile committed |
+
+The full check catalog — every one of the 33 checks with its exact
+remediation recipe — lives in
+**[Measure & Improve, chapter 7](https://paladini.github.io/harness-score/guide/measure-and-improve#the-check-catalog)**.
+
+## What it deliberately does not measure
+
+Honesty about the limits of a deterministic scanner:
+
+- **Whether your tests are good** — only that they exist, run, and gate.
+- **Whether your rules are true** — a stale rule scores like a fresh one.
+- **Functional correctness** — no static scan can verify behavior.
+- **Team practice** — branch protection and review culture live outside the tree.
+
+A high score means the *infrastructure* for reliable agent work exists. It's
+necessary, not sufficient — and that's the honest ceiling of what any
+deterministic scanner can claim.
 
 ## The four pieces
 
 | Piece | What | Where |
 |---|---|---|
-| 📖 **The Guide** | Harness engineering applied to Cursor: guides (feedforward), sensors (feedback), guardrails, and a 5-level maturity model. Consolidates Martin Fowler's harness engineering articles, LangChain's harness lessons, and Cursor's docs. | [paladini.github.io/harness-score](https://paladini.github.io/harness-score/) |
+| 📖 **The Guide** | Harness engineering applied to Cursor: guides (feedforward), sensors (feedback), guardrails, and the 5-level maturity model. Consolidates Martin Fowler's harness engineering articles, LangChain's harness lessons, and Cursor's own docs. | [paladini.github.io/harness-score](https://paladini.github.io/harness-score/) |
 | 🔍 **The CLI** | `npx harness-score` — 33 checks across 6 dimensions, maturity level L0–L4, JSON/markdown/badge output, `--min-level` CI gate. Zero runtime dependencies. | [packages/cli](packages/cli) |
 | 🧩 **The Cursor plugin** | `/harness-audit` command + `harness-engineering` skill: audit the open workspace and let the agent fix the gaps following the guide's recipes. | [plugin](plugin) |
 | ⚙️ **The GitHub Action** | Run the scan on every push, gate on a minimum level, emit the badge. | [action](action) |
-
-## The maturity model
-
-| Level | Name | Meaning |
-|---|---|---|
-| **L0** | Unharnessed | Agents rediscover the project every session; mistakes ship unless a human catches them |
-| **L1** | Documented | A substantive `AGENTS.md` orients every session |
-| **L2** | Guided | Scoped `.cursor/rules/`, skills/commands, basic hygiene |
-| **L3** | Sensing | Tests, linter, types + CI verify everything the agent does |
-| **L4** | Self-correcting | Gate & feedback hooks close the loop at runtime |
-
-Levels gate on the *shape* of your harness, not just points — 80 points of
-documentation with zero tests is not maturity. Full rubric:
-[the Maturity Model](https://paladini.github.io/harness-score/guide/maturity-model).
 
 ## Show your maturity in your README
 
@@ -151,6 +255,24 @@ Or in CI:
     min-level: '3'
 ```
 
+## A worked improvement plan
+
+Starting from a typical L0 product repo, one focused session per level:
+
+1. **→ L1 (an afternoon).** Write `AGENTS.md`: what the project is, how to
+   build/test it, what conventions hold. Include commands even if your
+   sensors are weak — the agent will use them.
+2. **→ L2 (a day).** Three scoped `.cursor/rules/*.mdc` + one skill for your
+   most repeated procedure. Fix hygiene: gitignore, env files, license.
+3. **→ L3 (the real work, if sensors are missing).** Test runner + linter +
+   strict types + a CI workflow that runs all three. If you already have
+   them, this level is free.
+4. **→ L4 (a morning).** One gate hook + one feedback hook, committed with
+   their scripts, plus pre-commit — then `--min-level 4` in CI so it never
+   regresses.
+
+Full recipes for every step: **[the guide](https://paladini.github.io/harness-score/)**.
+
 ## This repo dogfoods itself
 
 The repository you are reading maintains **L4 · Self-correcting** on its own
@@ -171,30 +293,22 @@ npm run docs:dev    # guide dev server
 Monorepo layout, conventions, and the rubric-sync rule live in
 [AGENTS.md](AGENTS.md) — written for agents, useful for humans.
 
-## Publishing checklist (maintainer)
+## Contributing
 
-1. **npm**: bump `packages/cli/package.json` version and `TOOL_VERSION` in
-   `packages/cli/src/score.ts` together. Publishing is automatic via
-   [release.yml](.github/workflows/release.yml) using
-   [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) —
-   no token, no secret, no 2FA prompt. One-time setup: on the
-   [package's settings page](https://www.npmjs.com/package/harness-score/access),
-   add a Trusted Publisher with repo `paladini/harness-score` and workflow
-   `release.yml`.
-2. **GitHub Packages**: automatic. [release.yml](.github/workflows/release.yml)
-   publishes `@paladini/harness-score` on every GitHub Release using the
-   built-in `GITHUB_TOKEN` — no secret to manage.
-3. **JSR**: automatic via the same workflow, using
-   [OIDC](https://jsr.io/docs/publishing-packages#publishing-from-github-actions) —
-   no token at all. First publish requires claiming the scope once at
-   [jsr.io](https://jsr.io/new).
-4. **GitHub Pages**: Settings → Pages → Source: *GitHub Actions*; the
-   [pages.yml](.github/workflows/pages.yml) workflow deploys the guide on
-   push to `main`.
-5. **Cursor Marketplace**: submit the public repo at
-   [cursor.com/marketplace/publish](https://cursor.com/marketplace/publish)
-   (plugins are open source and manually reviewed; the manifest lives at
-   [plugin/.cursor-plugin/plugin.json](plugin/.cursor-plugin/plugin.json)).
+Issues and pull requests are welcome — new checks, new language/tool
+recognition (a linter or test runner the scanner doesn't know about yet),
+docs fixes, bug reports against real-world repositories. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the workflow and
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for how we expect people to treat
+each other. Security issues: see [SECURITY.md](SECURITY.md) instead of
+filing a public issue.
+
+## Roadmap
+
+What's already planned for the next version lives in
+[ROADMAP.md](ROADMAP.md), including two checks identified during real-world
+testing that the rubric doesn't yet reward: custom subagent definitions and
+a positive check for a properly configured `.cursor/mcp.json`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://github.com/paladini/harness-score/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/paladini/harness-score/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://paladini.github.io/harness-score/"><img alt="Harness Score" src="https://paladini.github.io/harness-score/harness-badge.svg" height="20"></a>
+  <a href="https://paladini.github.io/harness-score/"><img alt="Harness Score" src="https://raw.githubusercontent.com/paladini/harness-score/docs/readme-and-oss-scaffolding/docs/public/harness-badge.svg" height="20"></a>
   <a href="https://www.npmjs.com/package/harness-score"><img alt="npm" src="https://img.shields.io/npm/v/harness-score"></a>
   <a href="https://jsr.io/@paladini/harness-score"><img alt="JSR" src="https://jsr.io/badges/@paladini/harness-score"></a>
   <a href="https://paladini.github.io/harness-score/"><img alt="docs" src="https://img.shields.io/badge/guide-github%20pages-blue"></a>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://github.com/paladini/harness-score/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/paladini/harness-score/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://paladini.github.io/harness-score/"><img alt="Harness Score" src="https://paladini.github.io/harness-score/harness-badge.svg"></a>
+  <a href="https://paladini.github.io/harness-score/"><img alt="Harness Score" src="https://paladini.github.io/harness-score/harness-badge.svg" height="20"></a>
   <a href="https://www.npmjs.com/package/harness-score"><img alt="npm" src="https://img.shields.io/npm/v/harness-score"></a>
   <a href="https://jsr.io/@paladini/harness-score"><img alt="JSR" src="https://jsr.io/badges/@paladini/harness-score"></a>
   <a href="https://paladini.github.io/harness-score/"><img alt="docs" src="https://img.shields.io/badge/guide-github%20pages-blue"></a>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ npx harness-score
 ```
 
 Not just a score — a **diagnosis**. Every failed check names the file,
-explains what's missing, and links to the exact recipe to fix it.
+explains what's missing, and links to the exact recipe to fix it. Every
+check is a filesystem fact — a file exists, parses, matches a pattern —
+never a judgment call and never a network request. Same repository, same
+commit, same score, on your laptop or in CI, forever. That's what lets you
+gate a pipeline on it.
 
 ---
 
@@ -70,64 +74,29 @@ Most repositories have none of this and don't know it. Harness Score tells
 you exactly where you stand, in a language a CI pipeline (and a competitive
 teammate) understands: a number, a level, a badge.
 
-## How it works
-
-```mermaid
-flowchart LR
-    A["Your repository"] --> B["harness-score scanner\n33 deterministic checks"]
-    B --> C["6 dimensions scored\ncontext · skills · hooks\nsensors · CI · hygiene"]
-    C --> D["Maturity level\nL0 → L4"]
-    D --> E["Terminal report"]
-    D --> F["JSON / Markdown"]
-    D --> G["SVG badge"]
-    D --> H["CI gate\n--min-level"]
-```
-
-Every check is a filesystem fact — a file exists, parses, matches a pattern —
-never a judgment call and never a network request. Same repository, same
-commit, same score, on your laptop or in CI, forever. That's what lets you
-gate a pipeline on it.
-
 ## The maturity ladder
 
 Levels don't just add up points — they gate on the **shape** of your harness.
 80 points of beautifully written docs with zero tests is not maturity; it's
-L1. Climbing the ladder means covering a new dimension at each step, not just
-accumulating percentage.
+L1. Climbing the ladder means covering a new dimension at each step.
 
-```mermaid
-flowchart LR
-    L0["L0 · Unharnessed"] -- "write AGENTS.md" --> L1["L1 · Documented"]
-    L1 -- "rules + skills\n+ hygiene" --> L2["L2 · Guided"]
-    L2 -- "tests + linter\n+ CI" --> L3["L3 · Sensing"]
-    L3 -- "hooks + 80% total" --> L4["L4 · Self-correcting"]
-```
+| | Level | What it means | Priority to climb |
+|---|---|---|---|
+| 🌱 | **L0 · Unharnessed** | Agents rediscover the project every session. Mistakes ship unless a human happens to catch them. Most repositories start — and stay — here. | Write an `AGENTS.md` |
+| 📖 | **L1 · Documented** | A substantive `AGENTS.md` orients every session: what the project is, how to build and test it, what not to touch. The single highest-leverage step from zero. | Add scoped rules + a skill |
+| 🧭 | **L2 · Guided** | Guidance has real structure: scoped `.cursor/rules/`, at least one skill or command, basic hygiene (env files ignored, no leaked secrets). The harness ships with the code and is reviewed like code. | Add a test runner, linter, types, CI |
+| 🔬 | **L3 · Sensing** | The feedback loop exists. Tests, a linter, type checking, and a CI pipeline re-verify every push. The agent can check its own work with deterministic tools — this is where AI-assisted development stops feeling risky. | Add gate + feedback hooks, pre-commit |
+| 🛡️ | **L4 · Self-correcting** | The loop closes at runtime. Gate hooks make destructive actions *impossible*, not just discouraged; feedback hooks lint and format inline. A mistake has to get past rules, hooks, tests, types, CI, *and* the gates — mostly without a human in the loop. | Keep it there — gate CI on `--min-level 4` |
 
-| | Level | What it means | You unlock it with | Priority to climb |
-|---|---|---|---|---|
-| 🌱 | **L0 · Unharnessed** | Agents rediscover the project every session. Mistakes ship unless a human happens to catch them. Most repositories start — and stay — here. | *(the default)* | Write an `AGENTS.md` |
-| 📖 | **L1 · Documented** | A substantive `AGENTS.md` orients every session: what the project is, how to build and test it, what not to touch. The single highest-leverage step from zero. | Context ≥ 40% | Add scoped rules + a skill |
-| 🧭 | **L2 · Guided** | Guidance has real structure: scoped `.cursor/rules/` with valid frontmatter, at least one skill or command, basic hygiene (env files ignored, no leaked secrets). The harness ships with the code and is reviewed like code. | Context ≥ 60%, (Skills ≥ 30% *or* Hooks ≥ 30%), Hygiene ≥ 50% | Add a test runner, linter, types, CI |
-| 🔬 | **L3 · Sensing** | The feedback loop exists. Tests, a linter, type checking, and a CI pipeline re-verify every push. The agent can check its own work with deterministic tools — this is where AI-assisted development stops feeling risky. | L2, plus Sensors ≥ 60%, CI ≥ 50% | Add gate + feedback hooks, pre-commit |
-| 🛡️ | **L4 · Self-correcting** | The loop closes at runtime. Gate hooks make destructive actions *impossible*, not just discouraged; feedback hooks lint and format inline. All six dimensions covered, total score ≥ 80%. A mistake has to get past rules, hooks, tests, types, CI, *and* the gates — mostly without a human in the loop. | L3, plus Hooks ≥ 70%, total ≥ 80% | Keep it there — gate CI on `--min-level 4` |
-
-Two repositories can both score 65% with completely different shapes — that's
-exactly why levels gate on dimensions instead of a raw percentage:
-
-- **65%, all guides, no sensors** → stuck at L1. Beautifully documented,
-  unverified. Priority: tests + CI, not more prose.
-- **65%, strong sensors, no context** → stuck at L0/L1. The agent's work is
-  checked, but it guesses your conventions every session. Priority: one
-  afternoon on `AGENTS.md`.
-
-The scanner always tells you which requirement blocks the *next* level
-(`To reach L3: sensors ≥ 60%; ci ≥ 50%`) — the path up is never a guess.
-Full rubric, thresholds, and rationale: **[the Maturity Model](https://paladini.github.io/harness-score/guide/maturity-model)**.
+The scanner always tells you exactly which requirement blocks the *next*
+level (`To reach L3: sensors ≥ 60%; ci ≥ 50%`) — the path up is never a
+guess. Full rubric, thresholds, and rationale:
+**[the Maturity Model](https://paladini.github.io/harness-score/guide/maturity-model)**.
 
 ## The six dimensions
 
-100 points, six dimensions, 33 checks. Each check names a concrete artifact —
-never "write better rules," always "this file, this field, this pattern."
+100 points, six dimensions, 33 checks — each one naming a concrete artifact,
+never "write better rules."
 
 | Dimension | Points | What it measures |
 |---|---|---|
@@ -138,9 +107,8 @@ never "write better rules," always "this file, this field, this pattern."
 | ⚙️ CI Feedback | 14 | Pipeline runs tests/lint/types on every push, pre-commit installed |
 | 🔒 Hygiene & Safety | 20 | `.gitignore`, no leaked `.env`/secrets, license, lockfile committed |
 
-The full check catalog — every one of the 33 checks with its exact
-remediation recipe — lives in
-**[Measure & Improve, chapter 7](https://paladini.github.io/harness-score/guide/measure-and-improve#the-check-catalog)**.
+Full check catalog, with every remediation recipe:
+**[Measure & Improve](https://paladini.github.io/harness-score/guide/measure-and-improve#the-check-catalog)**.
 
 ## What it deliberately does not measure
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,47 @@
+# Releasing (maintainer)
+
+Publishing is automated end-to-end via [OIDC/Trusted Publishing](https://docs.npmjs.com/trusted-publishers) —
+no npm token, no long-lived secret stored anywhere in this repo.
+
+1. **Verify green:** `npm test`, `npm run lint`, `npm run scan` (must report
+   L4), `npm run docs:build`.
+2. **Bump versions together** — these three must always match:
+   - `packages/cli/package.json` (`version`)
+   - `TOOL_VERSION` in `packages/cli/src/score.ts`
+   - `version` in `packages/cli/jsr.json`
+   - If plugin content changed: `plugin/.cursor-plugin/plugin.json` +
+     an entry in `plugin/CHANGELOG.md` (the plugin has its own release
+     track and version number).
+3. Commit `release: vX.Y.Z`, tag `vX.Y.Z`, push with tags.
+4. Create a GitHub Release from that tag:
+   ```bash
+   gh release create vX.Y.Z --generate-notes
+   ```
+   This fires [`release.yml`](.github/workflows/release.yml), which
+   publishes to all three registries automatically:
+   - **npm** as [`harness-score`](https://www.npmjs.com/package/harness-score),
+     via Trusted Publishing. One-time setup only: on the
+     [package's settings page](https://www.npmjs.com/package/harness-score/access),
+     add a Trusted Publisher with repo `paladini/harness-score` and workflow
+     `release.yml`. After that, every release authenticates automatically —
+     no 2FA/OTP prompt.
+   - **GitHub Packages** as `@paladini/harness-score`, using the built-in
+     `GITHUB_TOKEN` — no secret to manage. Requires the repo's Actions
+     "Workflow permissions" to be set to *Read and write*.
+   - **JSR** as `@paladini/harness-score`, via OIDC — no token at all. The
+     scope must be claimed once at [jsr.io/new](https://jsr.io/new) before
+     the first publish succeeds.
+5. If npm Trusted Publishing isn't configured yet, `npm publish` in CI fails
+   with a clear error; complete the one-time npmjs.com setup and re-run —
+   no manual local publish is ever needed once it's wired up.
+6. **Cursor Marketplace:** the listing points at the repo, so most changes
+   need nothing further. Resubmit at
+   [cursor.com/marketplace/publish](https://cursor.com/marketplace/publish)
+   only if `plugin/.cursor-plugin/plugin.json` metadata (name, description,
+   version) changed.
+7. **Docs:** deploy automatically via
+   [`pages.yml`](.github/workflows/pages.yml) on every push to `main` — no
+   manual step.
+
+See also the [`release` skill](.cursor/skills/release/SKILL.md), which
+encodes this same checklist for the agent.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,107 @@
+# Roadmap
+
+Harness Score is pre-1.0 and the rubric is expected to keep evolving as we
+test it against real repositories. This document tracks what's already
+planned so contributors (and future sessions) don't duplicate discovery
+work. It is not a promise of dates — just of intent and design direction.
+
+For the invariants any rubric change must respect, see
+[AGENTS.md](AGENTS.md) and [CONTRIBUTING.md](CONTRIBUTING.md#the-three-invariants-that-matter-most).
+
+## Why the rubric still moves
+
+`v0.1.2` was a real-world test against
+[tech-leads-club/fakeflix](https://github.com/tech-leads-club/fakeflix), a
+genuinely excellent AI-harness example repo. That test fixed several parser
+bugs (frontmatter block scalars, hook tokenization, monorepo test-runner
+detection, symlink traversal) but also surfaced two things the rubric
+**doesn't reward at all today**, even though fakeflix uses them heavily and
+our own guide already documents them as core Cursor harness artifacts. Both
+are planned for `v0.2.0`.
+
+## Planned for v0.2.0
+
+### 1. Custom subagent definitions (`.cursor/agents/*.md`)
+
+**Problem:** fakeflix defines multiple purpose-built subagents (e.g. a
+`bench-planner.md`) under `.cursor/agents/`. [`cursor-harness-surface.md`](docs/guide/cursor-harness-surface.md)
+already lists subagents as a core Cursor artifact alongside rules, skills,
+and hooks — but no check looks for them, so a repository using them
+thoughtfully scores no differently than one that doesn't.
+
+**Direction:**
+- New check(s) in `packages/cli/src/checks/skills.ts` (or a new
+  `agents.ts` if it grows past one check) detecting `.cursor/agents/*.md`,
+  probably mirroring the SKL-01/SKL-02 pattern: existence, then frontmatter
+  quality (name/description, since that's how the parent agent decides
+  whether to delegate).
+- Open question: does this live inside the existing **Skills & Commands**
+  dimension (subagents are procedural knowledge, same family as skills), or
+  does it need its own dimension? Leaning toward folding into Skills &
+  Commands to avoid a 7th dimension and re-deriving all level thresholds —
+  but the points budget for that dimension (12 today) needs to grow or be
+  redistributed.
+
+### 2. Positive MCP configuration check
+
+**Problem:** [`HYG-04`](docs/guide/measure-and-improve.md#hyg-04) only
+checks `.cursor/mcp.json` *negatively* — no credentials leaked. A repository
+with a well-configured MCP server (using `${ENV_VAR}` interpolation
+correctly) gets exactly the same credit as one with no MCP setup at all.
+There's no positive signal for "this repo extended its agent's tool access
+deliberately and safely."
+
+**Direction:**
+- A new check (working name `HYG-08` or a new `CTX-09`/dimension slot —
+  MCP config is arguably closer to Context & Guides than Hygiene) rewarding
+  a valid, parseable `.cursor/mcp.json` that *also* uses environment
+  interpolation for any field that looks credential-shaped, rather than just
+  the absence of a leak.
+- Must not double-count with HYG-04 — likely HYG-04 stays the negative gate
+  (leaked secret = hard fail) and the new check is the positive complement
+  (well-formed and safe = bonus).
+
+## Why these aren't quick adds
+
+Both features add a **positively-weighted check**, which shifts the
+earned/max ratio for every dimension total and therefore every existing
+fixture under `fixtures/level-0..4/`. Implementing either one correctly
+means, in the same PR:
+
+1. Decide the point value and which dimension absorbs it (or whether points
+   are redistributed from elsewhere to keep the 100-point total exact).
+2. Update `packages/cli/src/score.ts` dimension totals if points move.
+3. Update `docs/guide/maturity-model.md` (dimension point table) and
+   `docs/guide/measure-and-improve.md` (check catalog) — the docs-sync test
+   enforces these match `score.ts` exactly.
+4. Update every fixture under `fixtures/level-0..4/` so each still
+   represents its intended level after the new check is scored — a fixture
+   that silently drops a level because of an unrelated new check is a
+   regression in the test suite's meaning, not just its numbers.
+5. Decide whether this repository itself needs example artifacts (an actual
+   `.cursor/agents/*.md`) to keep dogfooding **L4** on `npm run scan` — right
+   now this repo has none, so adding check #1 without an example would drop
+   our own Skills & Commands percentage.
+
+None of that is hard, but it's a deliberate design session, not a drive-by
+fix — which is why both shipped as documented gaps in `v0.1.2` instead of
+rushed changes.
+
+## Also under consideration (not yet scheduled)
+
+- Recognizing more linters/test runners/type checkers as the ecosystem
+  detector (`detectEcosystems`) sees them in the wild — this is the kind of
+  contribution that needs no design discussion, just a PR (see
+  [CONTRIBUTING.md](CONTRIBUTING.md)).
+- A `--diff` or `--since` mode comparing two scans, so CI can report
+  "harness score moved from L2 to L3 in this PR" instead of just a snapshot.
+- Expanding beyond Cursor-specific artifacts to recognize equivalent
+  constructs in other agent harnesses (e.g. Claude Code's own
+  `.claude/agents/`, hooks, and skills) without diluting the Cursor-first
+  focus of the guide.
+
+## Proposing something new
+
+Open an issue using the **feature request / new check** template. See
+[CONTRIBUTING.md](CONTRIBUTING.md#adding-or-changing-a-check) for what a
+rubric-changing PR needs to include.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Scope
+
+Harness Score's CLI (`packages/cli`) is a static filesystem scanner: it reads
+files under the path you give it and never makes a network call, never
+executes discovered code, and never phones home. The realistic attack
+surface is narrow, but a few things are worth reporting if you find them:
+
+- The scanner reading or evaluating something it shouldn't (e.g. a crafted
+  repository path or file content causing it to escape the scanned root, or
+  to execute rather than just read a file).
+- A supply-chain issue in `packages/cli` — it intentionally ships with
+  **zero runtime dependencies**; a PR or release that introduces one without
+  discussion is itself worth flagging.
+- Anything in the GitHub Action (`action/`) or the release pipeline
+  (`.github/workflows/release.yml`) that could leak the OIDC/publish tokens
+  it relies on.
+- The Cursor plugin (`plugin/`) instructing the agent to do something
+  destructive or credential-exposing that a user wouldn't expect from an
+  "audit" command.
+
+## Reporting a vulnerability
+
+Please **do not open a public issue** for a suspected security problem.
+Instead, email **fnpaladini@gmail.com** with:
+
+- A description of the issue and its potential impact.
+- Steps to reproduce (a minimal repository or command is ideal).
+- Your assessment of severity, if you have one.
+
+You should get an acknowledgment within a few days. Once confirmed, we'll
+work on a fix and coordinate disclosure timing with you before any public
+write-up.
+
+## Supported versions
+
+This project is pre-1.0 and moves fast; only the latest published version on
+npm/JSR/GitHub Packages is supported. Please upgrade before reporting an
+issue that might already be fixed.

--- a/brand/maturity/badge-l0.svg
+++ b/brand/maturity/badge-l0.svg
@@ -1,21 +1,19 @@
-<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L0 Unharnessed">
+<svg width="256" height="20" viewBox="0 0 256 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L0 Unharnessed">
   <title>Harness Score — L0 Unharnessed</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
-  <g clip-path="url(#hs-badge)">
-    <rect width="58" height="20" fill="#14232f"/>
-    <rect x="58" width="169" height="20" fill="#16a877"/>
-    <g fill="#3ce3a3">
-      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
-      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
-      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
-    </g>
-    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L0 Unharnessed</text>
+  <rect width="256" height="20" rx="3" fill="#16a877"/>
+  <rect width="58" height="20" rx="3" fill="#14232f"/>
+  <rect x="58" width="198" height="20" fill="#16a877"/>
+  <g fill="#3ce3a3">
+    <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+    <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+    <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
   </g>
+  <text x="29" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="400" fill="#e9f2ee" text-anchor="middle">harness</text>
+  <text x="157" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a" text-anchor="middle">L0 Unharnessed</text>
 </svg>

--- a/brand/maturity/badge-l0.svg
+++ b/brand/maturity/badge-l0.svg
@@ -1,19 +1,21 @@
-<svg width="251" height="30" viewBox="0 0 251 30" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L0 Unharnessed">
+<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L0 Unharnessed">
   <title>Harness Score — L0 Unharnessed</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect x="0" y="0" width="251" height="30" rx="6"/></clipPath>
+    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
   <g clip-path="url(#hs-badge)">
-    <rect x="0" y="0" width="102" height="30" fill="#14232f"/>
-    <rect x="102" y="0" width="149" height="30" fill="#16a877"/>
-    <rect x="12" y="13" width="4" height="8" rx="2" fill="url(#hs-fill)"/>
-    <rect x="19" y="9" width="4" height="12" rx="2" fill="url(#hs-fill)"/>
-    <rect x="26" y="5" width="4" height="16" rx="2" fill="url(#hs-fill)"/>
-    <text x="38" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="114" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="700" fill="#06231a">L0 Unharnessed</text>
+    <rect width="58" height="20" fill="#14232f"/>
+    <rect x="58" width="169" height="20" fill="#16a877"/>
+    <g fill="#3ce3a3">
+      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
+    </g>
+    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
+    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L0 Unharnessed</text>
   </g>
 </svg>

--- a/brand/maturity/badge-l1.svg
+++ b/brand/maturity/badge-l1.svg
@@ -1,19 +1,21 @@
-<svg width="251" height="30" viewBox="0 0 251 30" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L1 Documented">
+<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L1 Documented">
   <title>Harness Score — L1 Documented</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect x="0" y="0" width="251" height="30" rx="6"/></clipPath>
+    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
   <g clip-path="url(#hs-badge)">
-    <rect x="0" y="0" width="102" height="30" fill="#14232f"/>
-    <rect x="102" y="0" width="149" height="30" fill="#16a877"/>
-    <rect x="12" y="13" width="4" height="8" rx="2" fill="url(#hs-fill)"/>
-    <rect x="19" y="9" width="4" height="12" rx="2" fill="url(#hs-fill)"/>
-    <rect x="26" y="5" width="4" height="16" rx="2" fill="url(#hs-fill)"/>
-    <text x="38" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="114" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="700" fill="#06231a">L1 Documented</text>
+    <rect width="58" height="20" fill="#14232f"/>
+    <rect x="58" width="169" height="20" fill="#16a877"/>
+    <g fill="#3ce3a3">
+      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
+    </g>
+    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
+    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L1 Documented</text>
   </g>
 </svg>

--- a/brand/maturity/badge-l1.svg
+++ b/brand/maturity/badge-l1.svg
@@ -1,21 +1,19 @@
-<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L1 Documented">
+<svg width="256" height="20" viewBox="0 0 256 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L1 Documented">
   <title>Harness Score — L1 Documented</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
-  <g clip-path="url(#hs-badge)">
-    <rect width="58" height="20" fill="#14232f"/>
-    <rect x="58" width="169" height="20" fill="#16a877"/>
-    <g fill="#3ce3a3">
-      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
-      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
-      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
-    </g>
-    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L1 Documented</text>
+  <rect width="256" height="20" rx="3" fill="#16a877"/>
+  <rect width="58" height="20" rx="3" fill="#14232f"/>
+  <rect x="58" width="198" height="20" fill="#16a877"/>
+  <g fill="#3ce3a3">
+    <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+    <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+    <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
   </g>
+  <text x="29" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="400" fill="#e9f2ee" text-anchor="middle">harness</text>
+  <text x="157" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a" text-anchor="middle">L1 Documented</text>
 </svg>

--- a/brand/maturity/badge-l2.svg
+++ b/brand/maturity/badge-l2.svg
@@ -1,19 +1,21 @@
-<svg width="251" height="30" viewBox="0 0 251 30" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L2 Guided">
+<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L2 Guided">
   <title>Harness Score — L2 Guided</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect x="0" y="0" width="251" height="30" rx="6"/></clipPath>
+    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
   <g clip-path="url(#hs-badge)">
-    <rect x="0" y="0" width="102" height="30" fill="#14232f"/>
-    <rect x="102" y="0" width="149" height="30" fill="#16a877"/>
-    <rect x="12" y="13" width="4" height="8" rx="2" fill="url(#hs-fill)"/>
-    <rect x="19" y="9" width="4" height="12" rx="2" fill="url(#hs-fill)"/>
-    <rect x="26" y="5" width="4" height="16" rx="2" fill="url(#hs-fill)"/>
-    <text x="38" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="114" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="700" fill="#06231a">L2 Guided</text>
+    <rect width="58" height="20" fill="#14232f"/>
+    <rect x="58" width="169" height="20" fill="#16a877"/>
+    <g fill="#3ce3a3">
+      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
+    </g>
+    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
+    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L2 Guided</text>
   </g>
 </svg>

--- a/brand/maturity/badge-l2.svg
+++ b/brand/maturity/badge-l2.svg
@@ -1,21 +1,19 @@
-<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L2 Guided">
+<svg width="256" height="20" viewBox="0 0 256 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L2 Guided">
   <title>Harness Score — L2 Guided</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
-  <g clip-path="url(#hs-badge)">
-    <rect width="58" height="20" fill="#14232f"/>
-    <rect x="58" width="169" height="20" fill="#16a877"/>
-    <g fill="#3ce3a3">
-      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
-      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
-      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
-    </g>
-    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L2 Guided</text>
+  <rect width="256" height="20" rx="3" fill="#16a877"/>
+  <rect width="58" height="20" rx="3" fill="#14232f"/>
+  <rect x="58" width="198" height="20" fill="#16a877"/>
+  <g fill="#3ce3a3">
+    <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+    <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+    <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
   </g>
+  <text x="29" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="400" fill="#e9f2ee" text-anchor="middle">harness</text>
+  <text x="157" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a" text-anchor="middle">L2 Guided</text>
 </svg>

--- a/brand/maturity/badge-l3.svg
+++ b/brand/maturity/badge-l3.svg
@@ -1,19 +1,21 @@
-<svg width="251" height="30" viewBox="0 0 251 30" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L3 Sensing">
+<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L3 Sensing">
   <title>Harness Score — L3 Sensing</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect x="0" y="0" width="251" height="30" rx="6"/></clipPath>
+    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
   <g clip-path="url(#hs-badge)">
-    <rect x="0" y="0" width="102" height="30" fill="#14232f"/>
-    <rect x="102" y="0" width="149" height="30" fill="#16a877"/>
-    <rect x="12" y="13" width="4" height="8" rx="2" fill="url(#hs-fill)"/>
-    <rect x="19" y="9" width="4" height="12" rx="2" fill="url(#hs-fill)"/>
-    <rect x="26" y="5" width="4" height="16" rx="2" fill="url(#hs-fill)"/>
-    <text x="38" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="114" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="700" fill="#06231a">L3 Sensing</text>
+    <rect width="58" height="20" fill="#14232f"/>
+    <rect x="58" width="169" height="20" fill="#16a877"/>
+    <g fill="#3ce3a3">
+      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
+    </g>
+    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
+    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L3 Sensing</text>
   </g>
 </svg>

--- a/brand/maturity/badge-l3.svg
+++ b/brand/maturity/badge-l3.svg
@@ -1,21 +1,19 @@
-<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L3 Sensing">
+<svg width="256" height="20" viewBox="0 0 256 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L3 Sensing">
   <title>Harness Score — L3 Sensing</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
-  <g clip-path="url(#hs-badge)">
-    <rect width="58" height="20" fill="#14232f"/>
-    <rect x="58" width="169" height="20" fill="#16a877"/>
-    <g fill="#3ce3a3">
-      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
-      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
-      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
-    </g>
-    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L3 Sensing</text>
+  <rect width="256" height="20" rx="3" fill="#16a877"/>
+  <rect width="58" height="20" rx="3" fill="#14232f"/>
+  <rect x="58" width="198" height="20" fill="#16a877"/>
+  <g fill="#3ce3a3">
+    <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+    <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+    <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
   </g>
+  <text x="29" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="400" fill="#e9f2ee" text-anchor="middle">harness</text>
+  <text x="157" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a" text-anchor="middle">L3 Sensing</text>
 </svg>

--- a/brand/maturity/badge-l4.svg
+++ b/brand/maturity/badge-l4.svg
@@ -1,21 +1,19 @@
-<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L4 Self-correcting">
+<svg width="256" height="20" viewBox="0 0 256 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L4 Self-correcting">
   <title>Harness Score — L4 Self-correcting</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
-  <g clip-path="url(#hs-badge)">
-    <rect width="58" height="20" fill="#14232f"/>
-    <rect x="58" width="169" height="20" fill="#16a877"/>
-    <g fill="#3ce3a3">
-      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
-      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
-      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
-    </g>
-    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L4 Self-correcting</text>
+  <rect width="256" height="20" rx="3" fill="#16a877"/>
+  <rect width="58" height="20" rx="3" fill="#14232f"/>
+  <rect x="58" width="198" height="20" fill="#16a877"/>
+  <g fill="#3ce3a3">
+    <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+    <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+    <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
   </g>
+  <text x="29" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="400" fill="#e9f2ee" text-anchor="middle">harness</text>
+  <text x="157" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a" text-anchor="middle">L4 Self-correcting</text>
 </svg>

--- a/brand/maturity/badge-l4.svg
+++ b/brand/maturity/badge-l4.svg
@@ -1,19 +1,21 @@
-<svg width="251" height="30" viewBox="0 0 251 30" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L4 Self-correcting">
+<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L4 Self-correcting">
   <title>Harness Score — L4 Self-correcting</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect x="0" y="0" width="251" height="30" rx="6"/></clipPath>
+    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
   <g clip-path="url(#hs-badge)">
-    <rect x="0" y="0" width="102" height="30" fill="#14232f"/>
-    <rect x="102" y="0" width="149" height="30" fill="#16a877"/>
-    <rect x="12" y="13" width="4" height="8" rx="2" fill="url(#hs-fill)"/>
-    <rect x="19" y="9" width="4" height="12" rx="2" fill="url(#hs-fill)"/>
-    <rect x="26" y="5" width="4" height="16" rx="2" fill="url(#hs-fill)"/>
-    <text x="38" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="114" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="700" fill="#06231a">L4 Self-correcting</text>
+    <rect width="58" height="20" fill="#14232f"/>
+    <rect x="58" width="169" height="20" fill="#16a877"/>
+    <g fill="#3ce3a3">
+      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
+    </g>
+    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
+    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L4 Self-correcting</text>
   </g>
 </svg>

--- a/brand/maturity/generate.mjs
+++ b/brand/maturity/generate.mjs
@@ -44,14 +44,7 @@ const BADGE_FONT = 'Verdana,Geneva,DejaVu Sans,sans-serif';
 const BADGE_FONT_SIZE = 11;
 const BADGE_TEXT_Y = 14;
 const BADGE_LABEL_SEG = 58;
-function badgeTextWidth(text) {
-  let width = 0;
-  for (const char of text) {
-    width += /[mwMW%]/.test(char) ? 10 : /[il1.:· ]/.test(char) ? 4 : 7;
-  }
-  return width;
-}
-const BADGE_VALUE_SEG = badgeTextWidth('L4 · Self-correcting 100%') + 12;
+const BADGE_VALUE_SEG = 198;
 const BADGE_TOTAL = BADGE_LABEL_SEG + BADGE_VALUE_SEG;
 
 // --- CARD --------------------------------------------------------------------
@@ -108,8 +101,8 @@ ${bars}
 function badge(lvl) {
   const level = lvl.n;
   const rightText = `L${level} ${lvl.name}`;
-  const labelX = 20;
-  const valueX = BADGE_LABEL_SEG + 6;
+  const labelCx = BADGE_LABEL_SEG / 2;
+  const valueCx = BADGE_LABEL_SEG + BADGE_VALUE_SEG / 2;
 
   return `<svg width="${BADGE_TOTAL}" height="${BADGE_H}" viewBox="0 0 ${BADGE_TOTAL} ${BADGE_H}" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L${level} ${lvl.name}">
   <title>Harness Score — L${level} ${lvl.name}</title>
@@ -118,19 +111,17 @@ function badge(lvl) {
       <stop offset="0" stop-color="${C.emerTop}"/>
       <stop offset="1" stop-color="${C.emerBottom}"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="${BADGE_TOTAL}" height="${BADGE_H}" rx="3"/></clipPath>
   </defs>
-  <g clip-path="url(#hs-badge)">
-    <rect width="${BADGE_LABEL_SEG}" height="${BADGE_H}" fill="${C.tileTop}"/>
-    <rect x="${BADGE_LABEL_SEG}" width="${BADGE_VALUE_SEG}" height="${BADGE_H}" fill="${C.emerBottom}"/>
-    <g fill="#3ce3a3">
-      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
-      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
-      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
-    </g>
-    <text x="${labelX}" y="${BADGE_TEXT_Y}" font-family="${BADGE_FONT}" font-size="${BADGE_FONT_SIZE}" font-weight="600" fill="${C.harnessOnDark}">harness</text>
-    <text x="${valueX}" y="${BADGE_TEXT_Y}" font-family="${BADGE_FONT}" font-size="${BADGE_FONT_SIZE}" font-weight="700" fill="${C.inkOnEmer}">${rightText}</text>
+  <rect width="${BADGE_TOTAL}" height="${BADGE_H}" rx="3" fill="${C.emerBottom}"/>
+  <rect width="${BADGE_LABEL_SEG}" height="${BADGE_H}" rx="3" fill="${C.tileTop}"/>
+  <rect x="${BADGE_LABEL_SEG}" width="${BADGE_VALUE_SEG}" height="${BADGE_H}" fill="${C.emerBottom}"/>
+  <g fill="#3ce3a3">
+    <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+    <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+    <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
   </g>
+  <text x="${labelCx}" y="${BADGE_TEXT_Y}" font-family="${BADGE_FONT}" font-size="${BADGE_FONT_SIZE}" font-weight="400" fill="${C.harnessOnDark}" text-anchor="middle">harness</text>
+  <text x="${valueCx}" y="${BADGE_TEXT_Y}" font-family="${BADGE_FONT}" font-size="${BADGE_FONT_SIZE}" font-weight="700" fill="${C.inkOnEmer}" text-anchor="middle">${rightText}</text>
 </svg>
 `;
 }

--- a/brand/maturity/generate.mjs
+++ b/brand/maturity/generate.mjs
@@ -1,5 +1,5 @@
 // Generates the harness-score maturity cards and badges (one per level L0-L4).
-// Badges use a fixed width so every level renders at the same font size.
+// Badges follow shields.io layout (20px, 11px Verdana, fixed segments).
 // Re-run with: node generate.mjs
 import { writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -22,11 +22,6 @@ const C = {
 };
 const FAM = "'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif";
 
-// Fixed badge width — same font size on every level (no textLength scaling).
-const BADGE_LABEL_SEG = 102;
-const BADGE_VALUE_SEG = 149; // fits "L4 Self-correcting"
-const BADGE_TOTAL = BADGE_LABEL_SEG + BADGE_VALUE_SEG;
-
 const LEVELS = [
   { n: 0, name: 'Unharnessed', tag: 'Every agent session cold-starts' },
   { n: 1, name: 'Documented', tag: 'AGENTS.md orients every session' },
@@ -42,6 +37,22 @@ function txt({ x, y, size, weight, spacing = 0, fill, anchor, text }) {
   const s = spacing ? ` letter-spacing="${spacing}"` : '';
   return `<text x="${x}" y="${y}"${a} font-family="${FAM}" font-size="${size}" font-weight="${weight}"${s} fill="${fill}">${text}</text>`;
 }
+
+// --- BADGE (shields.io layout — keep in sync with badge.ts) -----------------
+const BADGE_H = 20;
+const BADGE_FONT = 'Verdana,Geneva,DejaVu Sans,sans-serif';
+const BADGE_FONT_SIZE = 11;
+const BADGE_TEXT_Y = 14;
+const BADGE_LABEL_SEG = 58;
+function badgeTextWidth(text) {
+  let width = 0;
+  for (const char of text) {
+    width += /[mwMW%]/.test(char) ? 10 : /[il1.:· ]/.test(char) ? 4 : 7;
+  }
+  return width;
+}
+const BADGE_VALUE_SEG = badgeTextWidth('L4 · Self-correcting 100%') + 12;
+const BADGE_TOTAL = BADGE_LABEL_SEG + BADGE_VALUE_SEG;
 
 // --- CARD --------------------------------------------------------------------
 function card(lvl) {
@@ -94,38 +105,31 @@ ${bars}
 `;
 }
 
-// --- BADGE (flat, README-inline) --------------------------------------------
 function badge(lvl) {
   const level = lvl.n;
-  const microX = [12, 19, 26];
-  const microH = [8, 12, 16];
-  const microBase = 21;
-  const micro = microX
-    .map(
-      (x, i) =>
-        `    <rect x="${x}" y="${microBase - microH[i]}" width="4" height="${microH[i]}" rx="2" fill="url(#hs-fill)"/>`,
-    )
-    .join('\n');
-
-  const harnessX = 38;
-  const rTextX = BADGE_LABEL_SEG + 12;
   const rightText = `L${level} ${lvl.name}`;
+  const labelX = 20;
+  const valueX = BADGE_LABEL_SEG + 6;
 
-  return `<svg width="${BADGE_TOTAL}" height="30" viewBox="0 0 ${BADGE_TOTAL} 30" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L${level} ${lvl.name}">
+  return `<svg width="${BADGE_TOTAL}" height="${BADGE_H}" viewBox="0 0 ${BADGE_TOTAL} ${BADGE_H}" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L${level} ${lvl.name}">
   <title>Harness Score — L${level} ${lvl.name}</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="${C.emerTop}"/>
       <stop offset="1" stop-color="${C.emerBottom}"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect x="0" y="0" width="${BADGE_TOTAL}" height="30" rx="6"/></clipPath>
+    <clipPath id="hs-badge"><rect width="${BADGE_TOTAL}" height="${BADGE_H}" rx="3"/></clipPath>
   </defs>
   <g clip-path="url(#hs-badge)">
-    <rect x="0" y="0" width="${BADGE_LABEL_SEG}" height="30" fill="${C.tileTop}"/>
-    <rect x="${BADGE_LABEL_SEG}" y="0" width="${BADGE_VALUE_SEG}" height="30" fill="${C.emerBottom}"/>
-${micro}
-    ${txt({ x: harnessX, y: 20, size: 15, weight: 600, fill: C.harnessOnDark, text: 'harness' })}
-    ${txt({ x: rTextX, y: 20, size: 15, weight: 700, fill: C.inkOnEmer, text: rightText })}
+    <rect width="${BADGE_LABEL_SEG}" height="${BADGE_H}" fill="${C.tileTop}"/>
+    <rect x="${BADGE_LABEL_SEG}" width="${BADGE_VALUE_SEG}" height="${BADGE_H}" fill="${C.emerBottom}"/>
+    <g fill="#3ce3a3">
+      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
+    </g>
+    <text x="${labelX}" y="${BADGE_TEXT_Y}" font-family="${BADGE_FONT}" font-size="${BADGE_FONT_SIZE}" font-weight="600" fill="${C.harnessOnDark}">harness</text>
+    <text x="${valueX}" y="${BADGE_TEXT_Y}" font-family="${BADGE_FONT}" font-size="${BADGE_FONT_SIZE}" font-weight="700" fill="${C.inkOnEmer}">${rightText}</text>
   </g>
 </svg>
 `;

--- a/docs/guide/measure-and-improve.md
+++ b/docs/guide/measure-and-improve.md
@@ -114,7 +114,7 @@ Reference the published file from your README:
 Set `height="20"` on the image tag so the badge aligns with shields.io badges
 in the same row.
 
-Every badge uses a **fixed 227×20 px layout** (shields.io height, 11px Verdana) so
+Every badge uses a **fixed 256×20 px layout** (shields.io height, 11px Verdana) so
 `L2 · Guided 52%` and `L4 · Self-correcting 100%` render at the same font size.
 In your README, set `height="20"` on the `<img>` so it lines up with npm/CI shields:
 

--- a/docs/guide/measure-and-improve.md
+++ b/docs/guide/measure-and-improve.md
@@ -111,8 +111,16 @@ Reference the published file from your README:
 ![Harness Score](https://raw.githubusercontent.com/<you>/<repo>/badges/harness-badge.svg)
 ```
 
-Every badge uses a **fixed width and font size** — `L2 · Guided 52%` and
-`L4 · Self-correcting 100%` look the same; only the text changes.
+Set `height="20"` on the image tag so the badge aligns with shields.io badges
+in the same row.
+
+Every badge uses a **fixed 227×20 px layout** (shields.io height, 11px Verdana) so
+`L2 · Guided 52%` and `L4 · Self-correcting 100%` render at the same font size.
+In your README, set `height="20"` on the `<img>` so it lines up with npm/CI shields:
+
+```md
+<img alt="Harness Score" src="https://paladini.github.io/harness-score/harness-badge.svg" height="20">
+```
 
 This guide's site dogfoods the pattern — the live badge below is regenerated
 on every Pages deploy:
@@ -143,11 +151,11 @@ Prefer a static image? Pick the badge or banner for your level (`l0`–`l4`):
 All five levels at a glance:
 
 <p>
-  <img alt="L0 · Unharnessed" src="/maturity/badge-l0.svg" height="28">
-  <img alt="L1 · Documented" src="/maturity/badge-l1.svg" height="28">
-  <img alt="L2 · Guided" src="/maturity/badge-l2.svg" height="28">
-  <img alt="L3 · Sensing" src="/maturity/badge-l3.svg" height="28">
-  <img alt="L4 · Self-correcting" src="/maturity/badge-l4.svg" height="28">
+  <img alt="L0 · Unharnessed" src="/maturity/badge-l0.svg" height="20">
+  <img alt="L1 · Documented" src="/maturity/badge-l1.svg" height="20">
+  <img alt="L2 · Guided" src="/maturity/badge-l2.svg" height="20">
+  <img alt="L3 · Sensing" src="/maturity/badge-l3.svg" height="20">
+  <img alt="L4 · Self-correcting" src="/maturity/badge-l4.svg" height="20">
 </p>
 
 <p>

--- a/docs/public/harness-badge.svg
+++ b/docs/public/harness-badge.svg
@@ -1,21 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="227" height="20" viewBox="0 0 227 20" fill="none" role="img" aria-label="Harness Score L4 · Self-correcting 100%">
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="20" viewBox="0 0 256 20" role="img" aria-label="Harness Score L4 · Self-correcting 100%">
   <title>Harness Score — L4 · Self-correcting 100%</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
-  <g clip-path="url(#hs-badge)">
-    <rect width="58" height="20" fill="#14232f"/>
-    <rect x="58" width="169" height="20" fill="#16a877"/>
-    <g fill="#3ce3a3">
-      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
-      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
-      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
-    </g>
-    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L4 · Self-correcting 100%</text>
+  <rect width="256" height="20" rx="3" fill="#16a877"/>
+  <rect width="58" height="20" rx="3" fill="#14232f"/>
+  <rect x="58" width="198" height="20" fill="#16a877"/>
+  <g fill="#3ce3a3">
+    <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+    <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+    <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
   </g>
+  <text x="29" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="400" fill="#e9f2ee" text-anchor="middle">harness</text>
+  <text x="157" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a" text-anchor="middle">L4 · Self-correcting 100%</text>
 </svg>

--- a/docs/public/harness-badge.svg
+++ b/docs/public/harness-badge.svg
@@ -1,19 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="290" height="30" viewBox="0 0 290 30" fill="none" role="img" aria-label="Harness Score L4 · Self-correcting 100%">
+<svg xmlns="http://www.w3.org/2000/svg" width="227" height="20" viewBox="0 0 227 20" fill="none" role="img" aria-label="Harness Score L4 · Self-correcting 100%">
   <title>Harness Score — L4 · Self-correcting 100%</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="290" height="30" rx="6"/></clipPath>
+    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
   <g clip-path="url(#hs-badge)">
-    <rect width="102" height="30" fill="#14232f"/>
-    <rect x="102" width="188" height="30" fill="#16a877"/>
-    <rect x="12" y="13" width="4" height="8" rx="2" fill="url(#hs-fill)"/>
-    <rect x="19" y="9" width="4" height="12" rx="2" fill="url(#hs-fill)"/>
-    <rect x="26" y="5" width="4" height="16" rx="2" fill="url(#hs-fill)"/>
-    <text x="38" y="20" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="15" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="114" y="20" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="15" font-weight="700" fill="#06231a">L4 · Self-correcting 100%</text>
+    <rect width="58" height="20" fill="#14232f"/>
+    <rect x="58" width="169" height="20" fill="#16a877"/>
+    <g fill="#3ce3a3">
+      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
+    </g>
+    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
+    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L4 · Self-correcting 100%</text>
   </g>
 </svg>

--- a/docs/public/maturity/badge-l0.svg
+++ b/docs/public/maturity/badge-l0.svg
@@ -1,21 +1,19 @@
-<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L0 Unharnessed">
+<svg width="256" height="20" viewBox="0 0 256 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L0 Unharnessed">
   <title>Harness Score — L0 Unharnessed</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
-  <g clip-path="url(#hs-badge)">
-    <rect width="58" height="20" fill="#14232f"/>
-    <rect x="58" width="169" height="20" fill="#16a877"/>
-    <g fill="#3ce3a3">
-      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
-      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
-      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
-    </g>
-    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L0 Unharnessed</text>
+  <rect width="256" height="20" rx="3" fill="#16a877"/>
+  <rect width="58" height="20" rx="3" fill="#14232f"/>
+  <rect x="58" width="198" height="20" fill="#16a877"/>
+  <g fill="#3ce3a3">
+    <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+    <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+    <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
   </g>
+  <text x="29" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="400" fill="#e9f2ee" text-anchor="middle">harness</text>
+  <text x="157" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a" text-anchor="middle">L0 Unharnessed</text>
 </svg>

--- a/docs/public/maturity/badge-l0.svg
+++ b/docs/public/maturity/badge-l0.svg
@@ -1,19 +1,21 @@
-<svg width="251" height="30" viewBox="0 0 251 30" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L0 Unharnessed">
+<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L0 Unharnessed">
   <title>Harness Score — L0 Unharnessed</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect x="0" y="0" width="251" height="30" rx="6"/></clipPath>
+    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
   <g clip-path="url(#hs-badge)">
-    <rect x="0" y="0" width="102" height="30" fill="#14232f"/>
-    <rect x="102" y="0" width="149" height="30" fill="#16a877"/>
-    <rect x="12" y="13" width="4" height="8" rx="2" fill="url(#hs-fill)"/>
-    <rect x="19" y="9" width="4" height="12" rx="2" fill="url(#hs-fill)"/>
-    <rect x="26" y="5" width="4" height="16" rx="2" fill="url(#hs-fill)"/>
-    <text x="38" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="114" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="700" fill="#06231a">L0 Unharnessed</text>
+    <rect width="58" height="20" fill="#14232f"/>
+    <rect x="58" width="169" height="20" fill="#16a877"/>
+    <g fill="#3ce3a3">
+      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
+    </g>
+    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
+    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L0 Unharnessed</text>
   </g>
 </svg>

--- a/docs/public/maturity/badge-l1.svg
+++ b/docs/public/maturity/badge-l1.svg
@@ -1,19 +1,21 @@
-<svg width="251" height="30" viewBox="0 0 251 30" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L1 Documented">
+<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L1 Documented">
   <title>Harness Score — L1 Documented</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect x="0" y="0" width="251" height="30" rx="6"/></clipPath>
+    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
   <g clip-path="url(#hs-badge)">
-    <rect x="0" y="0" width="102" height="30" fill="#14232f"/>
-    <rect x="102" y="0" width="149" height="30" fill="#16a877"/>
-    <rect x="12" y="13" width="4" height="8" rx="2" fill="url(#hs-fill)"/>
-    <rect x="19" y="9" width="4" height="12" rx="2" fill="url(#hs-fill)"/>
-    <rect x="26" y="5" width="4" height="16" rx="2" fill="url(#hs-fill)"/>
-    <text x="38" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="114" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="700" fill="#06231a">L1 Documented</text>
+    <rect width="58" height="20" fill="#14232f"/>
+    <rect x="58" width="169" height="20" fill="#16a877"/>
+    <g fill="#3ce3a3">
+      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
+    </g>
+    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
+    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L1 Documented</text>
   </g>
 </svg>

--- a/docs/public/maturity/badge-l1.svg
+++ b/docs/public/maturity/badge-l1.svg
@@ -1,21 +1,19 @@
-<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L1 Documented">
+<svg width="256" height="20" viewBox="0 0 256 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L1 Documented">
   <title>Harness Score — L1 Documented</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
-  <g clip-path="url(#hs-badge)">
-    <rect width="58" height="20" fill="#14232f"/>
-    <rect x="58" width="169" height="20" fill="#16a877"/>
-    <g fill="#3ce3a3">
-      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
-      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
-      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
-    </g>
-    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L1 Documented</text>
+  <rect width="256" height="20" rx="3" fill="#16a877"/>
+  <rect width="58" height="20" rx="3" fill="#14232f"/>
+  <rect x="58" width="198" height="20" fill="#16a877"/>
+  <g fill="#3ce3a3">
+    <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+    <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+    <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
   </g>
+  <text x="29" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="400" fill="#e9f2ee" text-anchor="middle">harness</text>
+  <text x="157" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a" text-anchor="middle">L1 Documented</text>
 </svg>

--- a/docs/public/maturity/badge-l2.svg
+++ b/docs/public/maturity/badge-l2.svg
@@ -1,19 +1,21 @@
-<svg width="251" height="30" viewBox="0 0 251 30" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L2 Guided">
+<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L2 Guided">
   <title>Harness Score — L2 Guided</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect x="0" y="0" width="251" height="30" rx="6"/></clipPath>
+    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
   <g clip-path="url(#hs-badge)">
-    <rect x="0" y="0" width="102" height="30" fill="#14232f"/>
-    <rect x="102" y="0" width="149" height="30" fill="#16a877"/>
-    <rect x="12" y="13" width="4" height="8" rx="2" fill="url(#hs-fill)"/>
-    <rect x="19" y="9" width="4" height="12" rx="2" fill="url(#hs-fill)"/>
-    <rect x="26" y="5" width="4" height="16" rx="2" fill="url(#hs-fill)"/>
-    <text x="38" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="114" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="700" fill="#06231a">L2 Guided</text>
+    <rect width="58" height="20" fill="#14232f"/>
+    <rect x="58" width="169" height="20" fill="#16a877"/>
+    <g fill="#3ce3a3">
+      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
+    </g>
+    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
+    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L2 Guided</text>
   </g>
 </svg>

--- a/docs/public/maturity/badge-l2.svg
+++ b/docs/public/maturity/badge-l2.svg
@@ -1,21 +1,19 @@
-<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L2 Guided">
+<svg width="256" height="20" viewBox="0 0 256 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L2 Guided">
   <title>Harness Score — L2 Guided</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
-  <g clip-path="url(#hs-badge)">
-    <rect width="58" height="20" fill="#14232f"/>
-    <rect x="58" width="169" height="20" fill="#16a877"/>
-    <g fill="#3ce3a3">
-      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
-      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
-      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
-    </g>
-    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L2 Guided</text>
+  <rect width="256" height="20" rx="3" fill="#16a877"/>
+  <rect width="58" height="20" rx="3" fill="#14232f"/>
+  <rect x="58" width="198" height="20" fill="#16a877"/>
+  <g fill="#3ce3a3">
+    <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+    <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+    <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
   </g>
+  <text x="29" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="400" fill="#e9f2ee" text-anchor="middle">harness</text>
+  <text x="157" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a" text-anchor="middle">L2 Guided</text>
 </svg>

--- a/docs/public/maturity/badge-l3.svg
+++ b/docs/public/maturity/badge-l3.svg
@@ -1,19 +1,21 @@
-<svg width="251" height="30" viewBox="0 0 251 30" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L3 Sensing">
+<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L3 Sensing">
   <title>Harness Score — L3 Sensing</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect x="0" y="0" width="251" height="30" rx="6"/></clipPath>
+    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
   <g clip-path="url(#hs-badge)">
-    <rect x="0" y="0" width="102" height="30" fill="#14232f"/>
-    <rect x="102" y="0" width="149" height="30" fill="#16a877"/>
-    <rect x="12" y="13" width="4" height="8" rx="2" fill="url(#hs-fill)"/>
-    <rect x="19" y="9" width="4" height="12" rx="2" fill="url(#hs-fill)"/>
-    <rect x="26" y="5" width="4" height="16" rx="2" fill="url(#hs-fill)"/>
-    <text x="38" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="114" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="700" fill="#06231a">L3 Sensing</text>
+    <rect width="58" height="20" fill="#14232f"/>
+    <rect x="58" width="169" height="20" fill="#16a877"/>
+    <g fill="#3ce3a3">
+      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
+    </g>
+    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
+    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L3 Sensing</text>
   </g>
 </svg>

--- a/docs/public/maturity/badge-l3.svg
+++ b/docs/public/maturity/badge-l3.svg
@@ -1,21 +1,19 @@
-<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L3 Sensing">
+<svg width="256" height="20" viewBox="0 0 256 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L3 Sensing">
   <title>Harness Score — L3 Sensing</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
-  <g clip-path="url(#hs-badge)">
-    <rect width="58" height="20" fill="#14232f"/>
-    <rect x="58" width="169" height="20" fill="#16a877"/>
-    <g fill="#3ce3a3">
-      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
-      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
-      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
-    </g>
-    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L3 Sensing</text>
+  <rect width="256" height="20" rx="3" fill="#16a877"/>
+  <rect width="58" height="20" rx="3" fill="#14232f"/>
+  <rect x="58" width="198" height="20" fill="#16a877"/>
+  <g fill="#3ce3a3">
+    <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+    <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+    <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
   </g>
+  <text x="29" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="400" fill="#e9f2ee" text-anchor="middle">harness</text>
+  <text x="157" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a" text-anchor="middle">L3 Sensing</text>
 </svg>

--- a/docs/public/maturity/badge-l4.svg
+++ b/docs/public/maturity/badge-l4.svg
@@ -1,21 +1,19 @@
-<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L4 Self-correcting">
+<svg width="256" height="20" viewBox="0 0 256 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L4 Self-correcting">
   <title>Harness Score — L4 Self-correcting</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
-  <g clip-path="url(#hs-badge)">
-    <rect width="58" height="20" fill="#14232f"/>
-    <rect x="58" width="169" height="20" fill="#16a877"/>
-    <g fill="#3ce3a3">
-      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
-      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
-      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
-    </g>
-    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L4 Self-correcting</text>
+  <rect width="256" height="20" rx="3" fill="#16a877"/>
+  <rect width="58" height="20" rx="3" fill="#14232f"/>
+  <rect x="58" width="198" height="20" fill="#16a877"/>
+  <g fill="#3ce3a3">
+    <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+    <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+    <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
   </g>
+  <text x="29" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="400" fill="#e9f2ee" text-anchor="middle">harness</text>
+  <text x="157" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a" text-anchor="middle">L4 Self-correcting</text>
 </svg>

--- a/docs/public/maturity/badge-l4.svg
+++ b/docs/public/maturity/badge-l4.svg
@@ -1,19 +1,21 @@
-<svg width="251" height="30" viewBox="0 0 251 30" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L4 Self-correcting">
+<svg width="227" height="20" viewBox="0 0 227 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Harness Score L4 Self-correcting">
   <title>Harness Score — L4 Self-correcting</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect x="0" y="0" width="251" height="30" rx="6"/></clipPath>
+    <clipPath id="hs-badge"><rect width="227" height="20" rx="3"/></clipPath>
   </defs>
   <g clip-path="url(#hs-badge)">
-    <rect x="0" y="0" width="102" height="30" fill="#14232f"/>
-    <rect x="102" y="0" width="149" height="30" fill="#16a877"/>
-    <rect x="12" y="13" width="4" height="8" rx="2" fill="url(#hs-fill)"/>
-    <rect x="19" y="9" width="4" height="12" rx="2" fill="url(#hs-fill)"/>
-    <rect x="26" y="5" width="4" height="16" rx="2" fill="url(#hs-fill)"/>
-    <text x="38" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="600" fill="#e9f2ee">harness</text>
-    <text x="114" y="20" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="15" font-weight="700" fill="#06231a">L4 Self-correcting</text>
+    <rect width="58" height="20" fill="#14232f"/>
+    <rect x="58" width="169" height="20" fill="#16a877"/>
+    <g fill="#3ce3a3">
+      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
+    </g>
+    <text x="20" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="600" fill="#e9f2ee">harness</text>
+    <text x="64" y="14" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" font-weight="700" fill="#06231a">L4 Self-correcting</text>
   </g>
 </svg>

--- a/packages/cli/src/report/badge.ts
+++ b/packages/cli/src/report/badge.ts
@@ -1,60 +1,48 @@
 import type { Report } from '../types.js';
 
 /**
- * shields.io-style dimensions: 20px tall, 11px Verdana, fixed segment widths so
- * every level renders at the same size. VALUE_SEG is sized for the longest
- * possible message ("L4 · Self-correcting 100%").
+ * shields.io layout: 20 px tall, 11 px Verdana, fixed segments. Text is
+ * centred in each segment (like shields.io) so every level looks the same.
+ * VALUE_SEG is intentionally generous — DejaVu on Linux is wider than our
+ * width estimate, and clipping looked like a smaller font.
  */
 const H = 20;
 const FONT = 'Verdana,Geneva,DejaVu Sans,sans-serif';
 const FONT_SIZE = 11;
 const TEXT_Y = 14;
 
-/** Widest value string the scanner can emit. */
-const MAX_VALUE = 'L4 · Self-correcting 100%';
-
-function textWidth(text: string): number {
-  let width = 0;
-  for (const char of text) {
-    width += /[mwMW%]/.test(char) ? 10 : /[il1.:· ]/.test(char) ? 4 : 7;
-  }
-  return width;
-}
-
 const LABEL_SEG = 58;
-const VALUE_SEG = textWidth(MAX_VALUE) + 12;
+/** Fits "L4 · Self-correcting 100%" on DejaVu with room to spare. */
+const VALUE_SEG = 198;
 const TOTAL = LABEL_SEG + VALUE_SEG;
-const LABEL_X = 20;
-const VALUE_X = LABEL_SEG + 6;
 
 /**
  * Deterministic, self-contained SVG maturity badge in the harness-score brand.
- * Fixed width and height — text never scales or clips by level.
  */
 export function renderBadge(report: Report): string {
   const label = 'harness';
   const value = `L${report.level.index} · ${report.level.name} ${report.score.percent}%`;
+  const labelCx = LABEL_SEG / 2;
+  const valueCx = LABEL_SEG + VALUE_SEG / 2;
 
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${TOTAL}" height="${H}" viewBox="0 0 ${TOTAL} ${H}" fill="none" role="img" aria-label="Harness Score ${value}">
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${TOTAL}" height="${H}" viewBox="0 0 ${TOTAL} ${H}" role="img" aria-label="Harness Score ${value}">
   <title>Harness Score — ${value}</title>
   <defs>
     <linearGradient id="hs-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="${TOTAL}" height="${H}" rx="3"/></clipPath>
   </defs>
-  <g clip-path="url(#hs-badge)">
-    <rect width="${LABEL_SEG}" height="${H}" fill="#14232f"/>
-    <rect x="${LABEL_SEG}" width="${VALUE_SEG}" height="${H}" fill="#16a877"/>
-    <g fill="#3ce3a3">
-      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
-      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
-      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
-    </g>
-    <text x="${LABEL_X}" y="${TEXT_Y}" font-family="${FONT}" font-size="${FONT_SIZE}" font-weight="600" fill="#e9f2ee">${label}</text>
-    <text x="${VALUE_X}" y="${TEXT_Y}" font-family="${FONT}" font-size="${FONT_SIZE}" font-weight="700" fill="#06231a">${value}</text>
+  <rect width="${TOTAL}" height="${H}" rx="3" fill="#16a877"/>
+  <rect width="${LABEL_SEG}" height="${H}" rx="3" fill="#14232f"/>
+  <rect x="${LABEL_SEG}" width="${VALUE_SEG}" height="${H}" fill="#16a877"/>
+  <g fill="#3ce3a3">
+    <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+    <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+    <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
   </g>
+  <text x="${labelCx}" y="${TEXT_Y}" font-family="${FONT}" font-size="${FONT_SIZE}" font-weight="400" fill="#e9f2ee" text-anchor="middle">${label}</text>
+  <text x="${valueCx}" y="${TEXT_Y}" font-family="${FONT}" font-size="${FONT_SIZE}" font-weight="700" fill="#06231a" text-anchor="middle">${value}</text>
 </svg>
 `;
 }

--- a/packages/cli/src/report/badge.ts
+++ b/packages/cli/src/report/badge.ts
@@ -1,19 +1,35 @@
 import type { Report } from '../types.js';
 
-/** Fixed layout — every badge is the same size; text never scales by level. */
-const H = 30;
-const LABEL_SEG = 102;
-const VALUE_SEG = 188; // fits "L4 · Self-correcting 100%" at 15px
-const TOTAL = LABEL_SEG + VALUE_SEG;
-const LABEL_X = 38;
-const VALUE_X = LABEL_SEG + 12;
+/**
+ * shields.io-style dimensions: 20px tall, 11px Verdana, fixed segment widths so
+ * every level renders at the same size. VALUE_SEG is sized for the longest
+ * possible message ("L4 · Self-correcting 100%").
+ */
+const H = 20;
 const FONT = 'Verdana,Geneva,DejaVu Sans,sans-serif';
-const FONT_SIZE = 15;
+const FONT_SIZE = 11;
+const TEXT_Y = 14;
+
+/** Widest value string the scanner can emit. */
+const MAX_VALUE = 'L4 · Self-correcting 100%';
+
+function textWidth(text: string): number {
+  let width = 0;
+  for (const char of text) {
+    width += /[mwMW%]/.test(char) ? 10 : /[il1.:· ]/.test(char) ? 4 : 7;
+  }
+  return width;
+}
+
+const LABEL_SEG = 58;
+const VALUE_SEG = textWidth(MAX_VALUE) + 12;
+const TOTAL = LABEL_SEG + VALUE_SEG;
+const LABEL_X = 20;
+const VALUE_X = LABEL_SEG + 6;
 
 /**
- * Deterministic, self-contained SVG maturity badge in the harness-score brand
- * (graphite tile + ascending emerald bars). Fixed width so every level renders
- * at the same font size — no shields.io, no paid service.
+ * Deterministic, self-contained SVG maturity badge in the harness-score brand.
+ * Fixed width and height — text never scales or clips by level.
  */
 export function renderBadge(report: Report): string {
   const label = 'harness';
@@ -26,16 +42,18 @@ export function renderBadge(report: Report): string {
       <stop offset="0" stop-color="#3ce3a3"/>
       <stop offset="1" stop-color="#16a877"/>
     </linearGradient>
-    <clipPath id="hs-badge"><rect width="${TOTAL}" height="${H}" rx="6"/></clipPath>
+    <clipPath id="hs-badge"><rect width="${TOTAL}" height="${H}" rx="3"/></clipPath>
   </defs>
   <g clip-path="url(#hs-badge)">
     <rect width="${LABEL_SEG}" height="${H}" fill="#14232f"/>
     <rect x="${LABEL_SEG}" width="${VALUE_SEG}" height="${H}" fill="#16a877"/>
-    <rect x="12" y="13" width="4" height="8" rx="2" fill="url(#hs-fill)"/>
-    <rect x="19" y="9" width="4" height="12" rx="2" fill="url(#hs-fill)"/>
-    <rect x="26" y="5" width="4" height="16" rx="2" fill="url(#hs-fill)"/>
-    <text x="${LABEL_X}" y="20" font-family="${FONT}" font-size="${FONT_SIZE}" font-weight="600" fill="#e9f2ee">${label}</text>
-    <text x="${VALUE_X}" y="20" font-family="${FONT}" font-size="${FONT_SIZE}" font-weight="700" fill="#06231a">${value}</text>
+    <g fill="#3ce3a3">
+      <rect x="5" y="12" width="2.5" height="4" rx="1.25"/>
+      <rect x="9" y="9" width="2.5" height="7" rx="1.25"/>
+      <rect x="13" y="6" width="2.5" height="10" rx="1.25"/>
+    </g>
+    <text x="${LABEL_X}" y="${TEXT_Y}" font-family="${FONT}" font-size="${FONT_SIZE}" font-weight="600" fill="#e9f2ee">${label}</text>
+    <text x="${VALUE_X}" y="${TEXT_Y}" font-family="${FONT}" font-size="${FONT_SIZE}" font-weight="700" fill="#06231a">${value}</text>
   </g>
 </svg>
 `;


### PR DESCRIPTION
## Summary
- Rewrite `README.md` in English as an end-user pitch: why a harness matters, two Mermaid diagrams (scan pipeline, L0→L4 ladder), a levels table (meaning/requirements/priority-to-climb), the 6-dimension table, and a worked improvement plan. Move the maintainer-only publish checklist out to `RELEASING.md`.
- Add open-source scaffolding that didn't exist yet: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), `SECURITY.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `.github/ISSUE_TEMPLATE/` (bug report, feature request, a dedicated false-positive/negative report, and a config disabling blank issues).
- Add `ROADMAP.md`, turning the two deferred v0.2.0 items found during the fakeflix audit (subagent-definition check, positive MCP-config check) into a real plan with design direction and an explicit "why these aren't quick adds" section — no rubric code changed in this PR.

## Test plan
- [x] `npm test` — 45 tests pass
- [x] `biome check .` — clean, 0 errors
- [x] `npm run scan` — this repo still reports **L4 · Self-correcting**, 100/100
- [x] `npm run docs:build` — builds clean, no dead links