### PR TITLE
test(cli): comprehensive unit/integration/e2e coverage + CI-enforced gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       - run: npm ci
       - name: Lint (biome)
         run: npm run lint
-      - name: Build & test
-        run: npm test
+      - name: Build, test & coverage gate
+        run: npm run test:coverage
       - name: Self-audit — this repo must stay L4
         run: node packages/cli/dist/cli.js . --min-level 4
       - name: Docs build

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,15 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
   "files": {
-    "includes": ["**", "!fixtures", "!**/dist", "!docs/.vitepress/cache", "!package-lock.json", "!.claude"]
+    "includes": [
+      "**",
+      "!fixtures",
+      "!**/dist",
+      "!**/coverage",
+      "!docs/.vitepress/cache",
+      "!package-lock.json",
+      "!.claude"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -278,6 +278,20 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -326,6 +340,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -962,12 +986,83 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
@@ -1560,6 +1655,40 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.7.tgz",
+      "integrity": "sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.7",
+        "vitest": "3.2.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
@@ -1962,6 +2091,32 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1972,6 +2127,45 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/birpc": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
@@ -1980,6 +2174,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/cac": {
@@ -2052,6 +2259,26 @@
         "node": ">= 16"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -2077,6 +2304,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/csstype": {
@@ -2137,6 +2379,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex-xs": {
       "version": "1.0.0",
@@ -2249,6 +2505,23 @@
         "tabbable": "^6.4.0"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2264,9 +2537,74 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/harness-score": {
       "resolved": "packages/cli",
       "link": true
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
@@ -2313,6 +2651,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -2340,6 +2685,16 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-what": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
@@ -2351,6 +2706,83 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/js-tokens": {
@@ -2367,6 +2799,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2375,6 +2814,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mark.js": {
@@ -2500,6 +2967,32 @@
       ],
       "license": "MIT"
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/minisearch": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
@@ -2550,6 +3043,40 @@
         "emoji-regex-xs": "^1.0.0",
         "regex": "^6.0.1",
         "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pathe": {
@@ -2742,6 +3269,42 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shiki": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
@@ -2765,6 +3328,19 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2811,6 +3387,70 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -2824,6 +3464,46 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-literal": {
@@ -2852,12 +3532,40 @@
         "node": ">=16"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
       "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -3275,6 +3983,22 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3287,6 +4011,104 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -3305,13 +4127,14 @@
     },
     "packages/cli": {
       "name": "harness-score",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "bin": {
         "harness-score": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
         "typescript": "^5.6.0",
         "vitest": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "npm run build -w harness-score",
     "test": "npm run test -w harness-score",
+    "test:coverage": "npm run test:coverage -w harness-score",
     "scan": "node packages/cli/dist/cli.js .",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && vitest run",
+    "test:coverage": "npm run build && vitest run --coverage",
     "prepublishOnly": "npm run build"
   },
   "keywords": [
@@ -43,6 +44,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
+    "@vitest/coverage-v8": "^3.0.0",
     "typescript": "^5.6.0",
     "vitest": "^3.0.0"
   }

--- a/packages/cli/test/badge.test.ts
+++ b/packages/cli/test/badge.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+import { renderBadge } from '../src/report/badge.js';
+import type { Report } from '../src/types.js';
+
+function makeReport(levelIndex: number): Report {
+  return {
+    tool: { name: 'harness-score', version: '0.3.0' },
+    root: '/fake',
+    truncated: false,
+    level: { index: levelIndex, name: 'x', nextLevelGaps: [] },
+    score: { earned: 0, max: 108, percent: 0 },
+    dimensions: [],
+    checks: [],
+  };
+}
+
+describe('renderBadge', () => {
+  test.each([0, 1, 2, 3, 4])('renders L%i in the value text, aria-label and title', (level) => {
+    const svg = renderBadge(makeReport(level));
+    expect(svg.startsWith('<svg')).toBe(true);
+    expect(svg).toContain(`>L${level}<`);
+    expect(svg).toContain(`aria-label="Harness Score L${level}"`);
+    expect(svg).toContain(`<title>Harness Score: L${level}</title>`);
+  });
+
+  test('viewBox width matches the sum of the label and value segments', () => {
+    const svg = renderBadge(makeReport(2));
+    expect(svg).toContain('viewBox="0 0 112 20"');
+    expect(svg).toContain('width="112"');
+  });
+});

--- a/packages/cli/test/checks.test.ts
+++ b/packages/cli/test/checks.test.ts
@@ -1,15 +1,52 @@
 import { describe, expect, test } from 'vitest';
+import { ALL_CHECKS } from '../src/checks/index.js';
 import { check, fakeContext } from './helpers.js';
 
 describe('context checks', () => {
+  test('CTX-01 fails with no AGENTS.md or CLAUDE.md', async () => {
+    const ctx = fakeContext({});
+    expect((await check('CTX-01')).run(ctx).passed).toBe(false);
+  });
+
+  test('CTX-01 passes when AGENTS.md exists', async () => {
+    const ctx = fakeContext({ 'AGENTS.md': '# Hi' });
+    expect((await check('CTX-01')).run(ctx).passed).toBe(true);
+  });
+
   test('CTX-02 fails on a thin AGENTS.md', async () => {
     const ctx = fakeContext({ 'AGENTS.md': '# Hi\nuse good code\n' });
     expect((await check('CTX-02')).run(ctx).passed).toBe(false);
   });
 
+  test('CTX-03 fails with no rules under .cursor/rules/', async () => {
+    const ctx = fakeContext({});
+    expect((await check('CTX-03')).run(ctx).passed).toBe(false);
+  });
+
+  test('CTX-03 passes with at least one .mdc rule', async () => {
+    const ctx = fakeContext({ '.cursor/rules/style.mdc': '---\ndescription: x\n---\nbody' });
+    expect((await check('CTX-03')).run(ctx).passed).toBe(true);
+  });
+
   test('CTX-04 rejects rules without frontmatter', async () => {
     const ctx = fakeContext({ '.cursor/rules/naked.mdc': 'Just some prose, no frontmatter.' });
     expect((await check('CTX-04')).run(ctx).passed).toBe(false);
+  });
+
+  test('CTX-05 fails when every rule is always-on with none scoped', async () => {
+    const ctx = fakeContext({
+      '.cursor/rules/a.mdc': '---\nalwaysApply: true\n---\na',
+      '.cursor/rules/b.mdc': '---\nalwaysApply: true\n---\nb',
+    });
+    expect((await check('CTX-05')).run(ctx).passed).toBe(false);
+  });
+
+  test('CTX-05 passes when at least one rule is glob-scoped', async () => {
+    const ctx = fakeContext({
+      '.cursor/rules/a.mdc': '---\nalwaysApply: true\n---\na',
+      '.cursor/rules/b.mdc': '---\nglobs: src/**\n---\nb',
+    });
+    expect((await check('CTX-05')).run(ctx).passed).toBe(true);
   });
 
   test('CTX-06 flags a 600-line rule', async () => {
@@ -19,9 +56,71 @@ describe('context checks', () => {
     expect((await check('CTX-06')).run(ctx).passed).toBe(false);
   });
 
+  test('CTX-07 fails with no README.md', async () => {
+    const ctx = fakeContext({});
+    expect((await check('CTX-07')).run(ctx).passed).toBe(false);
+  });
+
+  test('CTX-07 passes when README.md exists', async () => {
+    const ctx = fakeContext({ 'README.md': '# Project' });
+    expect((await check('CTX-07')).run(ctx).passed).toBe(true);
+  });
+
   test('CTX-08 flags legacy .cursorrules', async () => {
     const ctx = fakeContext({ '.cursorrules': 'old style' });
     expect((await check('CTX-08')).run(ctx).passed).toBe(false);
+  });
+});
+
+describe('skills checks', () => {
+  test('SKL-01 fails with no SKILL.md anywhere', async () => {
+    const ctx = fakeContext({});
+    expect((await check('SKL-01')).run(ctx).passed).toBe(false);
+  });
+
+  test('SKL-01 passes with at least one SKILL.md', async () => {
+    const ctx = fakeContext({
+      '.cursor/skills/deploy/SKILL.md': '---\nname: deploy\ndescription: short\n---\n',
+    });
+    expect((await check('SKL-01')).run(ctx).passed).toBe(true);
+  });
+
+  test('SKL-02 fails when a skill is missing name/description frontmatter', async () => {
+    const ctx = fakeContext({ '.cursor/skills/deploy/SKILL.md': '# Deploy\nNo frontmatter.' });
+    expect((await check('SKL-02')).run(ctx).passed).toBe(false);
+  });
+
+  test('SKL-02 passes when every skill declares name and description', async () => {
+    const ctx = fakeContext({
+      '.cursor/skills/deploy/SKILL.md':
+        '---\nname: deploy\ndescription: Use when deploying the app to production.\n---\nbody',
+    });
+    expect((await check('SKL-02')).run(ctx).passed).toBe(true);
+  });
+
+  test('SKL-03 fails with no .cursor/commands/*.md', async () => {
+    const ctx = fakeContext({});
+    expect((await check('SKL-03')).run(ctx).passed).toBe(false);
+  });
+
+  test('SKL-03 passes with at least one slash command', async () => {
+    const ctx = fakeContext({ '.cursor/commands/release.md': '# /release' });
+    expect((await check('SKL-03')).run(ctx).passed).toBe(true);
+  });
+
+  test('SKL-04 fails when a skill description is under 40 characters', async () => {
+    const ctx = fakeContext({
+      '.cursor/skills/deploy/SKILL.md': '---\nname: deploy\ndescription: short\n---\n',
+    });
+    expect((await check('SKL-04')).run(ctx).passed).toBe(false);
+  });
+
+  test('SKL-04 passes when every skill description is 40+ characters', async () => {
+    const ctx = fakeContext({
+      '.cursor/skills/deploy/SKILL.md':
+        '---\nname: deploy\ndescription: Use when deploying the app to production.\n---\nbody',
+    });
+    expect((await check('SKL-04')).run(ctx).passed).toBe(true);
   });
 });
 
@@ -81,9 +180,53 @@ describe('hook checks', () => {
     });
     expect((await check('HKS-05')).run(ctx).passed).toBe(true);
   });
+
+  test('HKS-03 fails with no gate hook registered', async () => {
+    const ctx = fakeContext({
+      '.cursor/hooks.json': JSON.stringify({ version: 1, hooks: { afterFileEdit: [{ command: 'x' }] } }),
+    });
+    expect((await check('HKS-03')).run(ctx).passed).toBe(false);
+  });
+
+  test('HKS-03 passes with a beforeShellExecution gate hook', async () => {
+    const ctx = fakeContext({
+      '.cursor/hooks.json': JSON.stringify({
+        version: 1,
+        hooks: { beforeShellExecution: [{ command: 'x' }] },
+      }),
+    });
+    expect((await check('HKS-03')).run(ctx).passed).toBe(true);
+  });
+
+  test('HKS-04 fails with no feedback hook registered', async () => {
+    const ctx = fakeContext({
+      '.cursor/hooks.json': JSON.stringify({
+        version: 1,
+        hooks: { beforeShellExecution: [{ command: 'x' }] },
+      }),
+    });
+    expect((await check('HKS-04')).run(ctx).passed).toBe(false);
+  });
+
+  test('HKS-04 passes with an afterFileEdit feedback hook', async () => {
+    const ctx = fakeContext({
+      '.cursor/hooks.json': JSON.stringify({ version: 1, hooks: { afterFileEdit: [{ command: 'x' }] } }),
+    });
+    expect((await check('HKS-04')).run(ctx).passed).toBe(true);
+  });
 });
 
 describe('ci checks', () => {
+  test('CI-01 fails with no CI configuration', async () => {
+    const ctx = fakeContext({});
+    expect((await check('CI-01')).run(ctx).passed).toBe(false);
+  });
+
+  test('CI-01 passes with a GitHub Actions workflow', async () => {
+    const ctx = fakeContext({ '.github/workflows/ci.yml': 'run: npm test' });
+    expect((await check('CI-01')).run(ctx).passed).toBe(true);
+  });
+
   test('CI-02 recognizes turbo/nx/pnpm-filter monorepo test invocations', async () => {
     const turbo = fakeContext({ '.github/workflows/ci.yml': 'run: turbo run test' });
     expect((await check('CI-02')).run(turbo).passed).toBe(true);
@@ -96,9 +239,49 @@ describe('ci checks', () => {
     const ctx = fakeContext({ '.github/workflows/ci.yml': 'run: echo "latest build attestation"' });
     expect((await check('CI-02')).run(ctx).passed).toBe(false);
   });
+
+  test('CI-03 fails when CI does not run lint/typecheck', async () => {
+    const ctx = fakeContext({ '.github/workflows/ci.yml': 'run: npm test' });
+    expect((await check('CI-03')).run(ctx).passed).toBe(false);
+  });
+
+  test('CI-03 passes when CI runs eslint/tsc', async () => {
+    const ctx = fakeContext({ '.github/workflows/ci.yml': 'run: npx eslint .' });
+    expect((await check('CI-03')).run(ctx).passed).toBe(true);
+  });
+
+  test('CI-04 fails with no pre-commit tooling', async () => {
+    const ctx = fakeContext({ 'package.json': JSON.stringify({}) });
+    expect((await check('CI-04')).run(ctx).passed).toBe(false);
+  });
+
+  test('CI-04 passes with a .husky/ directory', async () => {
+    const ctx = fakeContext({ '.husky/pre-commit': 'npm test' });
+    expect((await check('CI-04')).run(ctx).passed).toBe(true);
+  });
 });
 
 describe('hygiene checks', () => {
+  test('HYG-01 fails with no .gitignore', async () => {
+    const ctx = fakeContext({});
+    expect((await check('HYG-01')).run(ctx).passed).toBe(false);
+  });
+
+  test('HYG-01 passes with a .gitignore', async () => {
+    const ctx = fakeContext({ '.gitignore': 'node_modules/\n' });
+    expect((await check('HYG-01')).run(ctx).passed).toBe(true);
+  });
+
+  test('HYG-02 fails when .gitignore has no .env pattern', async () => {
+    const ctx = fakeContext({ '.gitignore': 'node_modules/\n' });
+    expect((await check('HYG-02')).run(ctx).passed).toBe(false);
+  });
+
+  test('HYG-02 passes when .gitignore covers .env', async () => {
+    const ctx = fakeContext({ '.gitignore': 'node_modules/\n.env\n' });
+    expect((await check('HYG-02')).run(ctx).passed).toBe(true);
+  });
+
   test('HYG-03 fails on an unignored .env', async () => {
     const ctx = fakeContext({ '.env': 'API_KEY=oops', '.gitignore': 'node_modules/\n' });
     expect((await check('HYG-03')).run(ctx).passed).toBe(false);
@@ -193,6 +376,39 @@ describe('hygiene checks', () => {
     expect(outcome.passed).toBe(false);
     expect(outcome.evidence).toContain('not valid JSON');
   });
+
+  test('HYG-05 fails with no LICENSE file', async () => {
+    const ctx = fakeContext({});
+    expect((await check('HYG-05')).run(ctx).passed).toBe(false);
+  });
+
+  test('HYG-05 passes with a LICENSE file', async () => {
+    const ctx = fakeContext({ LICENSE: 'MIT' });
+    expect((await check('HYG-05')).run(ctx).passed).toBe(true);
+  });
+
+  test('HYG-06 fails when a harness file contains a credential signature', async () => {
+    const ctx = fakeContext({ 'AGENTS.md': 'token: sk-abcdefghijklmnopqrstuvwx1234' });
+    expect((await check('HYG-06')).run(ctx).passed).toBe(false);
+  });
+
+  test('HYG-06 passes with clean harness files', async () => {
+    const ctx = fakeContext({ 'AGENTS.md': '# Project\nNo secrets here.' });
+    expect((await check('HYG-06')).run(ctx).passed).toBe(true);
+  });
+
+  test('HYG-07 fails when a manifest exists but no lockfile is committed', async () => {
+    const ctx = fakeContext({ 'package.json': JSON.stringify({ name: 'x' }) });
+    expect((await check('HYG-07')).run(ctx).passed).toBe(false);
+  });
+
+  test('HYG-07 passes when the lockfile is committed', async () => {
+    const ctx = fakeContext({
+      'package.json': JSON.stringify({ name: 'x' }),
+      'package-lock.json': '{}',
+    });
+    expect((await check('HYG-07')).run(ctx).passed).toBe(true);
+  });
 });
 
 describe('agent checks', () => {
@@ -228,5 +444,49 @@ describe('sensor checks', () => {
     const outcome = (await check('SNS-03')).run(ctx);
     expect(outcome.passed).toBe(true);
     expect(outcome.evidence).toContain('go');
+  });
+
+  test('SNS-02 fails with no linter configuration', async () => {
+    const ctx = fakeContext({});
+    expect((await check('SNS-02')).run(ctx).passed).toBe(false);
+  });
+
+  test('SNS-02 passes with an eslintrc', async () => {
+    const ctx = fakeContext({ '.eslintrc.json': '{}' });
+    expect((await check('SNS-02')).run(ctx).passed).toBe(true);
+  });
+
+  test('SNS-04 fails with no formatter configuration', async () => {
+    const ctx = fakeContext({});
+    expect((await check('SNS-04')).run(ctx).passed).toBe(false);
+  });
+
+  test('SNS-04 passes with a .prettierrc', async () => {
+    const ctx = fakeContext({ '.prettierrc': '{}' });
+    expect((await check('SNS-04')).run(ctx).passed).toBe(true);
+  });
+
+  test('SNS-05 fails with no test files', async () => {
+    const ctx = fakeContext({});
+    expect((await check('SNS-05')).run(ctx).passed).toBe(false);
+  });
+
+  test('SNS-05 passes with at least one test file', async () => {
+    const ctx = fakeContext({ 'src/foo.test.ts': 'test stuff' });
+    expect((await check('SNS-05')).run(ctx).passed).toBe(true);
+  });
+});
+
+describe('every check has a direct test', () => {
+  test("every ALL_CHECKS id appears at least once in check('...') calls in this file", async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const { fileURLToPath } = await import('node:url');
+    const self = fs.readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), 'checks.test.ts'),
+      'utf8',
+    );
+    const missing = ALL_CHECKS.map((c) => c.id).filter((id) => !self.includes(`check('${id}')`));
+    expect(missing).toEqual([]);
   });
 });

--- a/packages/cli/test/diff.test.ts
+++ b/packages/cli/test/diff.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
-import { computeDiff, score } from '../dist/index.js';
+import { computeDiff, score } from '../src/index.js';
 
 const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'fixtures');
 

--- a/packages/cli/test/docs.test.ts
+++ b/packages/cli/test/docs.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
-import { ALL_CHECKS } from '../dist/index.js';
+import { ALL_CHECKS } from '../src/index.js';
 
 const GUIDE = path.join(
   path.dirname(fileURLToPath(import.meta.url)),

--- a/packages/cli/test/e2e.test.ts
+++ b/packages/cli/test/e2e.test.ts
@@ -1,0 +1,108 @@
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.join(here, '..', 'dist', 'cli.js');
+const FIXTURES = path.join(here, '..', '..', '..', 'fixtures');
+const REPO_ROOT = path.join(here, '..', '..', '..');
+
+function run(args: string[]) {
+  return spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8' });
+}
+
+function tmpFile(name: string): string {
+  return path.join(os.tmpdir(), `hs-e2e-${process.pid}-${name}`);
+}
+
+describe('e2e — real usage scenarios', () => {
+  test('scanning a zero-harness repo produces consistent JSON, terminal, markdown, and badge output', () => {
+    const jsonResult = run([path.join(FIXTURES, 'level-0'), '--json']);
+    expect(jsonResult.status).toBe(0);
+    const report = JSON.parse(jsonResult.stdout);
+    expect(report.level.index).toBe(0);
+
+    const terminalResult = run([path.join(FIXTURES, 'level-0')]);
+    expect(terminalResult.stdout).toContain('Improvements (');
+    expect(terminalResult.stdout).not.toContain('fully harnessed');
+
+    const mdResult = run([path.join(FIXTURES, 'level-0'), '--md', '-', '--quiet']);
+    expect(mdResult.stdout).toContain('# Harness Score Report');
+    expect(mdResult.stdout).toContain('## Recommended improvements');
+
+    const badgePath = tmpFile('badge-level0.svg');
+    const badgeResult = run([path.join(FIXTURES, 'level-0'), '--badge', badgePath, '--quiet']);
+    expect(badgeResult.status).toBe(0);
+    expect(fs.readFileSync(badgePath, 'utf8')).toContain('>L0<');
+    fs.unlinkSync(badgePath);
+  });
+
+  test('baseline-then-diff flow surfaces the full diff section in the markdown report', () => {
+    const baselinePath = tmpFile('baseline.json');
+    const baseline = run([path.join(FIXTURES, 'level-2'), '--json', '--quiet']);
+    fs.writeFileSync(baselinePath, baseline.stdout, 'utf8');
+
+    const mdResult = run([path.join(FIXTURES, 'level-4'), '--diff', baselinePath, '--md', '-', '--quiet']);
+    expect(mdResult.status).toBe(0);
+    expect(mdResult.stdout).toContain('## Compared to baseline');
+    expect(mdResult.stdout).toContain('**Level:** L2 · Guided → L4 · Self-correcting (+2)');
+    expect(mdResult.stdout).toMatch(/\| Dimension \| Before \| After \| Δ \|/);
+
+    fs.unlinkSync(baselinePath);
+  });
+
+  test("--min-level gates exactly at the repository's own boundary", () => {
+    const atLevel = run([path.join(FIXTURES, 'level-3'), '--min-level', '3', '--quiet']);
+    expect(atLevel.status).toBe(0);
+
+    const aboveLevel = run([path.join(FIXTURES, 'level-3'), '--min-level', '4', '--quiet']);
+    expect(aboveLevel.status).toBe(1);
+    expect(aboveLevel.stderr).toContain('below required L4');
+    expect(aboveLevel.stderr).toContain('hooks');
+  });
+
+  test('self-audit: scanning the monorepo itself stays at L4 with a high score, mirroring CI', () => {
+    const result = run([REPO_ROOT, '--json', '--quiet', '--min-level', '4']);
+    expect(result.status).toBe(0);
+    const report = JSON.parse(result.stdout);
+    expect(report.level.index).toBe(4);
+    expect(report.score.percent).toBeGreaterThanOrEqual(80);
+  });
+
+  test('combined --json/--md/--badge flags in one invocation all produce correct output together', () => {
+    const mdPath = tmpFile('combined.md');
+    const badgePath = tmpFile('combined.svg');
+    const result = run([
+      path.join(FIXTURES, 'level-1'),
+      '--json',
+      '--md',
+      mdPath,
+      '--badge',
+      badgePath,
+      '--min-level',
+      '0',
+      '--quiet',
+    ]);
+    expect(result.status).toBe(0);
+    const report = JSON.parse(result.stdout);
+    expect(report.level.index).toBe(1);
+    expect(fs.readFileSync(mdPath, 'utf8')).toContain('# Harness Score Report');
+    expect(fs.readFileSync(badgePath, 'utf8')).toContain('>L1<');
+    fs.unlinkSync(mdPath);
+    fs.unlinkSync(badgePath);
+  });
+
+  test('rejects an unknown flag and a non-integer --min-level without crashing', () => {
+    const unknownFlag = run([path.join(FIXTURES, 'level-0'), '--nonexistent-flag']);
+    expect(unknownFlag.status).toBe(2);
+    expect(unknownFlag.stderr).toContain('Unknown option: --nonexistent-flag');
+    expect(unknownFlag.stderr).toContain('Usage:');
+
+    const badMinLevel = run([path.join(FIXTURES, 'level-0'), '--min-level', 'abc']);
+    expect(badMinLevel.status).toBe(2);
+    expect(badMinLevel.stderr).toContain('--min-level must be an integer between 0 and 4');
+  });
+});

--- a/packages/cli/test/helpers.ts
+++ b/packages/cli/test/helpers.ts
@@ -1,4 +1,4 @@
-import type { ScanContext } from '../dist/index.js';
+import type { ScanContext } from '../src/index.js';
 
 /** In-memory ScanContext for unit-testing individual checks. */
 export function fakeContext(files: Record<string, string>): ScanContext {
@@ -15,7 +15,7 @@ export function fakeContext(files: Record<string, string>): ScanContext {
 
 export function check(id: string) {
   // Lazy import indirection keeps this helper synchronous for tests.
-  return import('../dist/index.js').then(({ ALL_CHECKS }) => {
+  return import('../src/index.js').then(({ ALL_CHECKS }) => {
     const found = ALL_CHECKS.find((c) => c.id === id);
     if (!found) throw new Error(`no such check: ${id}`);
     return found;

--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -1,0 +1,44 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+import { ALL_CHECKS } from '../src/checks/index.js';
+import { computeDiff } from '../src/diff.js';
+import { score } from '../src/index.js';
+import { renderBadge } from '../src/report/badge.js';
+import { renderMarkdown } from '../src/report/markdown.js';
+import { renderTerminal } from '../src/report/terminal.js';
+import { createScanContext } from '../src/scan.js';
+import { buildReport, DOCS_BASE_URL, LEVEL_NAMES, LEVEL_REQUIREMENTS, TOOL_VERSION } from '../src/score.js';
+
+const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'fixtures');
+
+describe('score()', () => {
+  test('composes createScanContext + buildReport identically to calling them directly', () => {
+    const fixture = path.join(FIXTURES, 'level-2');
+    const viaScore = score(fixture);
+    const viaDirect = buildReport(createScanContext(fixture));
+    expect(viaScore).toEqual(viaDirect);
+  });
+});
+
+describe('public export surface', () => {
+  test('every documented export is defined', () => {
+    const exports: Array<[string, unknown]> = [
+      ['ALL_CHECKS', ALL_CHECKS],
+      ['computeDiff', computeDiff],
+      ['renderBadge', renderBadge],
+      ['renderMarkdown', renderMarkdown],
+      ['renderTerminal', renderTerminal],
+      ['createScanContext', createScanContext],
+      ['buildReport', buildReport],
+      ['DOCS_BASE_URL', DOCS_BASE_URL],
+      ['LEVEL_NAMES', LEVEL_NAMES],
+      ['LEVEL_REQUIREMENTS', LEVEL_REQUIREMENTS],
+      ['TOOL_VERSION', TOOL_VERSION],
+      ['score', score],
+    ];
+    for (const [name, value] of exports) {
+      expect(value, `expected export "${name}" to be defined`).toBeDefined();
+    }
+  });
+});

--- a/packages/cli/test/levels.test.ts
+++ b/packages/cli/test/levels.test.ts
@@ -1,9 +1,11 @@
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
-import { score } from '../dist/index.js';
+import { ALL_CHECKS } from '../src/checks/index.js';
+import { score } from '../src/index.js';
 
 const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'fixtures');
+const ALL_FIXTURES = ['level-0', 'level-1', 'level-2', 'level-3', 'level-4'];
 
 describe('maturity levels on fixture repositories', () => {
   test.each([
@@ -40,5 +42,19 @@ describe('maturity levels on fixture repositories', () => {
   test('level gaps explain what is missing', () => {
     const report = score(path.join(FIXTURES, 'level-3'));
     expect(report.level.nextLevelGaps.join(' ')).toContain('hooks');
+  });
+
+  test.each(ALL_FIXTURES)('%s runs every registered check exactly once', (fixture) => {
+    const report = score(path.join(FIXTURES, fixture));
+    expect(report.checks).toHaveLength(ALL_CHECKS.length);
+    expect(new Set(report.checks.map((c) => c.id)).size).toBe(ALL_CHECKS.length);
+  });
+
+  test.each(ALL_FIXTURES)('%s dimension percentages are internally consistent', (fixture) => {
+    const report = score(path.join(FIXTURES, fixture));
+    for (const dim of report.dimensions) {
+      const expected = dim.max === 0 ? 0 : Math.round((dim.earned / dim.max) * 100);
+      expect(dim.percent, `${dim.id}: ${dim.earned}/${dim.max}`).toBe(expected);
+    }
   });
 });

--- a/packages/cli/test/markdown.test.ts
+++ b/packages/cli/test/markdown.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'vitest';
+import type { ReportDiff } from '../src/diff.js';
+import { renderMarkdown } from '../src/report/markdown.js';
+import type { CheckResult, DimensionScore, Report } from '../src/types.js';
+import { DIMENSIONS } from '../src/types.js';
+
+function makeDimensions(): DimensionScore[] {
+  return DIMENSIONS.map((d) => ({ id: d.id, title: d.title, earned: 5, max: 20, percent: 25 }));
+}
+
+function makeCheck(overrides: Partial<CheckResult> = {}): CheckResult {
+  return {
+    id: 'CTX-01',
+    dimension: 'context',
+    title: 'Agent context file present',
+    points: 4,
+    earned: 0,
+    passed: false,
+    evidence: 'No AGENTS.md found.',
+    remediation: 'Create an AGENTS.md.',
+    docsUrl: 'https://paladini.github.io/harness-score/guide/measure-and-improve#ctx-01',
+    ...overrides,
+  };
+}
+
+function makeReport(overrides: Partial<Report> = {}): Report {
+  return {
+    tool: { name: 'harness-score', version: '0.3.0' },
+    root: '/fake',
+    truncated: false,
+    level: { index: 1, name: 'Documented', nextLevelGaps: [] },
+    score: { earned: 50, max: 108, percent: 46 },
+    dimensions: makeDimensions(),
+    checks: [makeCheck()],
+    ...overrides,
+  };
+}
+
+function makeDiff(overrides: Partial<ReportDiff> = {}): ReportDiff {
+  return {
+    level: { before: 1, beforeName: 'Documented', after: 1, afterName: 'Documented', delta: 0 },
+    score: {
+      before: { earned: 50, max: 108, percent: 46 },
+      after: { earned: 50, max: 108, percent: 46 },
+      deltaEarned: 0,
+      deltaPercent: 0,
+    },
+    dimensions: DIMENSIONS.map((d) => ({ id: d.id, title: d.title, before: 0, after: 0, delta: 0 })),
+    checksChanged: [],
+    rubricChanged: false,
+    ...overrides,
+  };
+}
+
+describe('renderMarkdown', () => {
+  test('renders header, dimensions table, and checks table', () => {
+    const out = renderMarkdown(makeReport());
+    expect(out).toContain('# Harness Score Report');
+    expect(out).toContain('**Maturity level:** L1 · Documented');
+    expect(out).toContain('| Dimension | Score | % |');
+    expect(out).toContain(`| ${DIMENSIONS[0]!.title} | 5/20 | 25% |`);
+    expect(out).toContain('| | Check | Points | Evidence |');
+    expect(out).toContain('❌');
+  });
+
+  test('escapes pipe characters inside evidence so the table does not break', () => {
+    const out = renderMarkdown(makeReport({ checks: [makeCheck({ evidence: 'found a | in the value' })] }));
+    expect(out).toContain('found a \\| in the value');
+    expect(out).not.toContain('found a | in the value');
+  });
+
+  test('shows the recommended-improvements section only when a check fails', () => {
+    const withFailure = renderMarkdown(makeReport({ checks: [makeCheck({ passed: false })] }));
+    expect(withFailure).toContain('## Recommended improvements');
+
+    const allPassing = renderMarkdown(makeReport({ checks: [makeCheck({ passed: true })] }));
+    expect(allPassing).not.toContain('## Recommended improvements');
+  });
+
+  test('shows the next-level-gaps line only when gaps exist', () => {
+    const withGaps = renderMarkdown(
+      makeReport({ level: { index: 1, name: 'Documented', nextLevelGaps: ['context ≥ 60%'] } }),
+    );
+    expect(withGaps).toContain('**To reach L2:**');
+
+    const noGaps = renderMarkdown(
+      makeReport({ level: { index: 4, name: 'Self-correcting', nextLevelGaps: [] } }),
+    );
+    expect(noGaps).not.toContain('**To reach L');
+  });
+
+  test('diff table renders only changed dimensions', () => {
+    const diff = makeDiff({
+      dimensions: DIMENSIONS.map((d, i) => ({
+        id: d.id,
+        title: d.title,
+        before: 0,
+        after: i === 0 ? 50 : 0,
+        delta: i === 0 ? 50 : 0,
+      })),
+    });
+    const out = renderMarkdown(makeReport(), diff);
+    expect(out).toContain('## Compared to baseline');
+    expect(out).toContain(`| ${DIMENSIONS[0]!.title} | 0% | 50% | +50pp |`);
+    for (const d of DIMENSIONS.slice(1)) {
+      expect(out).not.toContain(`| ${d.title} | 0% | 0% |`);
+    }
+  });
+
+  test('diff falls back to "No change since baseline." when nothing changed', () => {
+    const out = renderMarkdown(makeReport(), makeDiff());
+    expect(out).toContain('No change since baseline.');
+  });
+
+  test('diff warns when rubricChanged is true', () => {
+    const out = renderMarkdown(makeReport(), makeDiff({ rubricChanged: true }));
+    expect(out).toContain('Baseline is from a different tool version');
+  });
+});

--- a/packages/cli/test/scan.test.ts
+++ b/packages/cli/test/scan.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, test } from 'vitest';
-import { createScanContext } from '../dist/scan.js';
+import { createScanContext } from '../src/scan.js';
 
 const tmpDirs: string[] = [];
 

--- a/packages/cli/test/score.test.ts
+++ b/packages/cli/test/score.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest';
+import { buildReport, LEVEL_REQUIREMENTS, TOOL_VERSION } from '../src/score.js';
+import type { DimensionId, DimensionScore } from '../src/types.js';
+import { DIMENSIONS } from '../src/types.js';
+import { fakeContext } from './helpers.js';
+
+/** Synthetic dimension map for exercising LEVEL_REQUIREMENTS in isolation, without a full scan. */
+function makeDims(overrides: Partial<Record<DimensionId, number>>): Map<DimensionId, DimensionScore> {
+  return new Map(
+    DIMENSIONS.map((d) => [
+      d.id,
+      { id: d.id, title: d.title, earned: 0, max: 100, percent: overrides[d.id] ?? 0 },
+    ]),
+  );
+}
+
+describe('LEVEL_REQUIREMENTS boundaries', () => {
+  test('L1 context requirement is exact at the 40% boundary', () => {
+    const [contextReq] = LEVEL_REQUIREMENTS[0]!;
+    expect(contextReq!.met(makeDims({ context: 39 }), 0)).toBe(false);
+    expect(contextReq!.met(makeDims({ context: 40 }), 0)).toBe(true);
+    expect(contextReq!.met(makeDims({ context: 41 }), 0)).toBe(true);
+  });
+
+  test('L2 "skills ≥30% or hooks ≥30%" requirement is a true OR', () => {
+    const orReq = LEVEL_REQUIREMENTS[1]![1]!;
+    expect(orReq.label).toBe('skills ≥ 30% or hooks ≥ 30%');
+    expect(orReq.met(makeDims({ skills: 30, hooks: 0 }), 0)).toBe(true);
+    expect(orReq.met(makeDims({ skills: 0, hooks: 30 }), 0)).toBe(true);
+    expect(orReq.met(makeDims({ skills: 29, hooks: 29 }), 0)).toBe(false);
+  });
+
+  test('L4 "hooks ≥70%" requirement is exact at the boundary', () => {
+    const hooksReq = LEVEL_REQUIREMENTS[3]![0]!;
+    expect(hooksReq.met(makeDims({ hooks: 69 }), 0)).toBe(false);
+    expect(hooksReq.met(makeDims({ hooks: 70 }), 0)).toBe(true);
+  });
+
+  test('L4 "total ≥80%" requirement reads totalPercent, ignoring the dims map', () => {
+    const totalReq = LEVEL_REQUIREMENTS[3]![1]!;
+    expect(totalReq.label).toBe('total ≥ 80%');
+    expect(totalReq.met(makeDims({}), 79)).toBe(false);
+    expect(totalReq.met(makeDims({}), 80)).toBe(true);
+    expect(totalReq.met(makeDims({}), 81)).toBe(true);
+  });
+});
+
+describe('computeLevel — stops at the first unmet level', () => {
+  test('a context-only repo fails at L1 and reports only L1 gaps', () => {
+    // Empty repo: fails L1's context requirement outright, so the loop must
+    // break before ever evaluating L2/L3/L4 — gaps should be L1-only.
+    const report = buildReport(fakeContext({}));
+    expect(report.level.index).toBe(0);
+    expect(report.level.nextLevelGaps).toEqual(['context ≥ 40%']);
+  });
+});
+
+describe('buildReport shape', () => {
+  test('carries tool version, root, and truncated straight from the context', () => {
+    const ctx = fakeContext({ 'AGENTS.md': '# hi' });
+    const report = buildReport(ctx);
+    expect(report.tool.name).toBe('harness-score');
+    expect(report.tool.version).toBe(TOOL_VERSION);
+    expect(report.root).toBe(ctx.root);
+    expect(report.truncated).toBe(ctx.truncated);
+  });
+});

--- a/packages/cli/test/scoring-integration.test.ts
+++ b/packages/cli/test/scoring-integration.test.ts
@@ -1,0 +1,44 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+import { score } from '../src/index.js';
+import { renderBadge } from '../src/report/badge.js';
+import { buildReport } from '../src/score.js';
+import { fakeContext } from './helpers.js';
+
+const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'fixtures');
+
+describe('dimension roll-up (score.ts aggregating checks/*.ts output)', () => {
+  test('a partial pass within the skills dimension rolls up to the exact expected fraction', () => {
+    // Only SKL-01 can pass here: a SKILL.md with no frontmatter and no
+    // commands/subagents present, so SKL-02/03/04 and AGT-01/02 all fail.
+    const ctx = fakeContext({ '.cursor/skills/deploy/SKILL.md': '# Deploy\nNo frontmatter here.' });
+    const report = buildReport(ctx);
+    const skills = report.dimensions.find((d) => d.id === 'skills')!;
+
+    const skillsChecks = report.checks.filter((c) => c.dimension === 'skills');
+    const expectedMax = skillsChecks.reduce((sum, c) => sum + c.points, 0);
+    const expectedEarned = skillsChecks.find((c) => c.id === 'SKL-01')!.points;
+
+    expect(skills.max).toBe(expectedMax);
+    expect(skills.earned).toBe(expectedEarned);
+    expect(skills.percent).toBe(Math.round((expectedEarned / expectedMax) * 100));
+    expect(report.checks.find((c) => c.id === 'SKL-01')!.passed).toBe(true);
+    expect(report.checks.find((c) => c.id === 'SKL-02')!.passed).toBe(false);
+    expect(report.checks.find((c) => c.id === 'SKL-03')!.passed).toBe(false);
+    expect(report.checks.find((c) => c.id === 'AGT-01')!.passed).toBe(false);
+  });
+});
+
+describe('badge pipeline integrates with score() across all fixture levels', () => {
+  test.each([
+    ['level-0', 0],
+    ['level-1', 1],
+    ['level-2', 2],
+    ['level-3', 3],
+    ['level-4', 4],
+  ])('%s → renderBadge(score(...)) embeds L%i', (fixture, expected) => {
+    const svg = renderBadge(score(path.join(FIXTURES, fixture)));
+    expect(svg).toContain(`>L${expected}<`);
+  });
+});

--- a/packages/cli/test/terminal.test.ts
+++ b/packages/cli/test/terminal.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'vitest';
+import type { ReportDiff } from '../src/diff.js';
+import { renderTerminal } from '../src/report/terminal.js';
+import type { CheckResult, DimensionScore, Report } from '../src/types.js';
+import { DIMENSIONS } from '../src/types.js';
+
+function makeDimensions(overrides: Partial<Record<string, number>> = {}): DimensionScore[] {
+  return DIMENSIONS.map((d) => ({
+    id: d.id,
+    title: d.title,
+    earned: overrides[d.id] ?? 0,
+    max: 20,
+    percent: overrides[d.id] ?? 0,
+  }));
+}
+
+function makeCheck(overrides: Partial<CheckResult> = {}): CheckResult {
+  return {
+    id: 'CTX-01',
+    dimension: 'context',
+    title: 'Agent context file present',
+    points: 4,
+    earned: 0,
+    passed: false,
+    evidence: 'No AGENTS.md found.',
+    remediation: 'Create an AGENTS.md.',
+    docsUrl: 'https://paladini.github.io/harness-score/guide/measure-and-improve#ctx-01',
+    ...overrides,
+  };
+}
+
+function makeReport(overrides: Partial<Report> = {}): Report {
+  return {
+    tool: { name: 'harness-score', version: '0.3.0' },
+    root: '/fake',
+    truncated: false,
+    level: { index: 1, name: 'Documented', nextLevelGaps: [] },
+    score: { earned: 50, max: 108, percent: 46 },
+    dimensions: makeDimensions(),
+    checks: [makeCheck()],
+    ...overrides,
+  };
+}
+
+function makeDiff(overrides: Partial<ReportDiff> = {}): ReportDiff {
+  return {
+    level: { before: 1, beforeName: 'Documented', after: 1, afterName: 'Documented', delta: 0 },
+    score: {
+      before: { earned: 50, max: 108, percent: 46 },
+      after: { earned: 50, max: 108, percent: 46 },
+      deltaEarned: 0,
+      deltaPercent: 0,
+    },
+    dimensions: DIMENSIONS.map((d) => ({ id: d.id, title: d.title, before: 0, after: 0, delta: 0 })),
+    checksChanged: [],
+    rubricChanged: false,
+    ...overrides,
+  };
+}
+
+describe('renderTerminal', () => {
+  test('shows the truncated-scan banner only when report.truncated is true', () => {
+    expect(renderTerminal(makeReport({ truncated: true }))).toContain('Scan stopped early');
+    expect(renderTerminal(makeReport({ truncated: false }))).not.toContain('Scan stopped early');
+  });
+
+  test('shows "fully harnessed" when every check passed', () => {
+    const report = makeReport({ checks: [makeCheck({ passed: true })] });
+    const out = renderTerminal(report);
+    expect(out).toContain('fully harnessed');
+    expect(out).not.toContain('Improvements (');
+  });
+
+  test('lists improvements with remediation/evidence/docsUrl when checks fail', () => {
+    const report = makeReport({ checks: [makeCheck({ passed: false })] });
+    const out = renderTerminal(report);
+    expect(out).toContain('Improvements (1):');
+    expect(out).toContain('Create an AGENTS.md.');
+    expect(out).toContain('No AGENTS.md found.');
+    expect(out).toContain('measure-and-improve#ctx-01');
+  });
+
+  test('shows next-level gaps only when present', () => {
+    const withGaps = makeReport({
+      level: { index: 1, name: 'Documented', nextLevelGaps: ['context ≥ 60%'] },
+    });
+    expect(renderTerminal(withGaps)).toContain('To reach L2:');
+
+    const noGaps = makeReport({ level: { index: 4, name: 'Self-correcting', nextLevelGaps: [] } });
+    expect(renderTerminal(noGaps)).not.toContain('To reach L');
+  });
+
+  test('diff section warns when rubricChanged is true', () => {
+    const out = renderTerminal(makeReport(), makeDiff({ rubricChanged: true }));
+    expect(out).toContain('Baseline is from a different tool version');
+  });
+
+  test('diff section renders only non-zero dimension deltas', () => {
+    const diff = makeDiff({
+      dimensions: DIMENSIONS.map((d, i) => ({
+        id: d.id,
+        title: d.title,
+        before: 0,
+        after: i === 0 ? 50 : 0,
+        delta: i === 0 ? 50 : 0,
+      })),
+    });
+    const out = renderTerminal(makeReport(), diff);
+    expect(out).toContain(`${DIMENSIONS[0]!.title.padEnd(20)} 0% → 50% (+50pp)`);
+    for (const d of DIMENSIONS.slice(1)) {
+      expect(out).not.toContain(`${d.title.padEnd(20)} 0% → 0%`);
+    }
+  });
+
+  test('diff section shows only newly-passing checks when nothing failed', () => {
+    const diff = makeDiff({
+      checksChanged: [{ id: 'CTX-01', title: 'x', points: 4, change: 'newly-passing' }],
+    });
+    const out = renderTerminal(makeReport(), diff);
+    expect(out).toContain('Newly passing:');
+    expect(out).not.toContain('Newly failing:');
+  });
+
+  test('diff section shows only newly-failing checks when nothing improved', () => {
+    const diff = makeDiff({
+      checksChanged: [{ id: 'CTX-01', title: 'x', points: 4, change: 'newly-failing' }],
+    });
+    const out = renderTerminal(makeReport(), diff);
+    expect(out).toContain('Newly failing:');
+    expect(out).not.toContain('Newly passing:');
+  });
+
+  test('diff section shows "No change." when nothing changed at all', () => {
+    const out = renderTerminal(makeReport(), makeDiff());
+    expect(out).toContain('No change.');
+  });
+});

--- a/packages/cli/test/util.test.ts
+++ b/packages/cli/test/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { findSecret, parseFrontmatter, safeJsonParse } from '../dist/util.js';
+import { findSecret, parseFrontmatter, safeJsonParse } from '../src/util.js';
 
 describe('parseFrontmatter', () => {
   test('plain single-line values still work', () => {

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.ts', 'src/types.ts', 'src/cli.ts'],
+      reporter: ['text', 'lcov', 'html'],
+      thresholds: {
+        lines: 95,
+        statements: 95,
+        functions: 95,
+        branches: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `@vitest/coverage-v8` with a mandatory coverage threshold (lines/statements 95%, functions 95%, branches 80%) wired into CI as `npm run test:coverage` — the build now fails if coverage regresses.
- Switches the test suite to import from `src/` instead of the compiled `dist/` output (except `cli.test.ts`, which intentionally exercises the real built artifact via subprocess), so coverage numbers reflect actual source lines.
- Closes real test gaps: `score.ts`'s maturity-level boundary logic (exact-percent assertions for every L1–L4 requirement), all 19 previously-untested check IDs (including all 4 of `skills.ts`, which had zero direct tests), `report/terminal.ts`, `report/markdown.ts`, `report/badge.ts`, and `index.ts`'s public export surface.
- Adds a self-enforcing meta-test asserting every check ID in `ALL_CHECKS` has a direct test, so this can't silently regress.
- Adds dimension roll-up and badge↔score integration tests, plus 6 subprocess-based end-to-end scenarios covering full real-world flows: fresh-repo scan (JSON+terminal+markdown+badge), baseline→diff→markdown, `--min-level` gating at the exact boundary, self-audit dogfooding of this repo, combined flags in one invocation, and malformed-input rejection.
- Coverage moved from ~84% lines (with `report/*` at 0–10%) to **97.46% lines, 100% functions, 83.95% branches**.

## Test plan
- [x] `npm run test:coverage` — 161 tests pass, coverage gate passes against configured thresholds
- [x] Verified the gate actually fails on a regression (temporarily inflated a threshold, confirmed non-zero exit, reverted)
- [x] `npm run scan` — repo still self-scores L4 · 108/108 (100%)
- [x] `npm run lint` (biome) — clean
- [x] `npm run docs:build` — clean