### PR TITLE
fix(cli): HKS-05 resolves unbraced $VAR/... hook command paths

### DIFF
--- a/.changeset/fix-hks-05-unbraced-var.md
+++ b/.changeset/fix-hks-05-unbraced-var.md
@@ -1,0 +1,10 @@
+---
+"harness-score": minor
+---
+
+Fix `HKS-05` (hook scripts exist in the repository) to resolve both Claude Code interpolation forms for hook command paths:
+
+- **Unbraced `$VAR/...` form:** `hookCommandPathsResolve` only stripped the braced `${VAR}/...` prefix before checking whether a hook command references a committed file. The unbraced form (`$CLAUDE_PROJECT_DIR/.claude/hooks/setup.sh`) is equally valid Claude Code syntax and was reported as a missing script even when the file exists and is committed — a false negative costing 2 points.
+- **`node_modules/.bin/` binaries:** a hook command referencing a package-manager-installed binary (e.g. `${CLAUDE_PROJECT_DIR}/node_modules/.bin/block-no-verify`) is now treated as resolved. These are populated by `npm install`, not scripts a repository is expected to commit — the previous "commit the script" remediation didn't apply to them.
+
+Found via [harness-maturity-analysis](https://github.com/paladini/harness-maturity-analysis)'s corpus study, corroborated independently in `cline` (unbraced `$VAR`) and `promptfoo` (`node_modules/.bin/`).

--- a/packages/cli/src/harness/hooks.ts
+++ b/packages/cli/src/harness/hooks.ts
@@ -179,8 +179,12 @@ export function hookCommandPathsResolve(
     const resolvable = pathTokens.some((t) => {
       const unquoted = t.replace(/^["']|["']$/g, '');
       const normalized = unquoted.replace(/^\.[\\/]/, '').replace(/\\/g, '/');
-      // Claude uses ${CLAUDE_PROJECT_DIR}/.claude/hooks/... — strip env prefix for resolution.
-      const stripped = normalized.replace(/^\$\{[^}]+\}\//, '');
+      // Claude uses either ${CLAUDE_PROJECT_DIR}/... or the unbraced $CLAUDE_PROJECT_DIR/...
+      // — both are valid interpolation forms, so strip either one for resolution.
+      const stripped = normalized.replace(/^\$\{[^}]+\}\/|^\$[A-Za-z_][A-Za-z0-9_]*\//, '');
+      // A node_modules/.bin/ binary is populated by the package manager, not
+      // something a repository is expected to commit — treat it as resolved.
+      if (/(^|\/)node_modules\/\.bin\//.test(stripped)) return true;
       return has(stripped) || has(normalized);
     });
     if (!resolvable) missing.push(command);

--- a/packages/cli/test/checks.test.ts
+++ b/packages/cli/test/checks.test.ts
@@ -223,6 +223,51 @@ describe('hook checks', () => {
     expect((await check('HKS-05')).run(ctx).passed).toBe(true);
   });
 
+  test('HKS-05 resolves the unbraced $VAR form (Claude Code) when the script exists', async () => {
+    const ctx = fakeContext({
+      '.claude/settings.json': JSON.stringify({
+        hooks: {
+          SessionStart: [
+            { hooks: [{ type: 'command', command: '$CLAUDE_PROJECT_DIR/.claude/hooks/setup.sh' }] },
+          ],
+        },
+      }),
+      '.claude/hooks/setup.sh': '#!/bin/sh',
+    });
+    expect((await check('HKS-05')).run(ctx).passed).toBe(true);
+  });
+
+  test('HKS-05 flags the unbraced $VAR form when the script is actually missing', async () => {
+    const ctx = fakeContext({
+      '.claude/settings.json': JSON.stringify({
+        hooks: {
+          SessionStart: [
+            { hooks: [{ type: 'command', command: '$CLAUDE_PROJECT_DIR/.claude/hooks/missing.sh' }] },
+          ],
+        },
+      }),
+    });
+    expect((await check('HKS-05')).run(ctx).passed).toBe(false);
+  });
+
+  test('HKS-05 treats a node_modules/.bin/ command as resolved without requiring it committed', async () => {
+    const ctx = fakeContext({
+      '.claude/settings.json': JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [
+                { type: 'command', command: '${CLAUDE_PROJECT_DIR}/node_modules/.bin/block-no-verify' },
+              ],
+            },
+          ],
+        },
+      }),
+    });
+    expect((await check('HKS-05')).run(ctx).passed).toBe(true);
+  });
+
   test('HKS-03 fails with no gate hook registered', async () => {
     const ctx = fakeContext({
       '.cursor/hooks.json': JSON.stringify({ version: 1, hooks: { afterFileEdit: [{ command: 'x' }] } }),


### PR DESCRIPTION
## Summary

- `hookCommandPathsResolve` (`packages/cli/src/harness/hooks.ts`) only stripped the braced `${VAR}/...` interpolation form before checking whether a hook command references a committed file. The unbraced `$VAR/...` form is equally valid Claude Code syntax and was reported as a missing script even when the file exists and is committed — a false negative costing 2 points.
- Also treats `node_modules/.bin/`-referenced commands as resolved without requiring the binary to be committed, since it's populated by the package manager, not something a repository is expected to commit.

Both cases were found by [harness-maturity-analysis](https://github.com/paladini/harness-maturity-analysis)'s 20-repository corpus study — full writeup in [`analysis/findings.md` §1](https://github.com/paladini/harness-maturity-analysis/blob/main/analysis/findings.md#1-bug-hks-05-misses-the-unbraced-var-hook-path-form) and the proposal in [`proposals/001-hks-05-unbraced-var.md`](https://github.com/paladini/harness-maturity-analysis/blob/main/proposals/001-hks-05-unbraced-var.md). Corroborating evidence: `cline`'s committed `.claude/settings.json` uses the unbraced form and was losing 2 points it legitimately earned; `promptfoo` was failing on a `node_modules/.bin/` reference.

## Test plan

- [x] Added 3 regression tests to `packages/cli/test/checks.test.ts`: unbraced `$VAR` resolving when the script exists, unbraced `$VAR` still flagging when the script is genuinely missing, and a `node_modules/.bin/` command resolving without being committed.
- [x] `npm test` — 198/198 tests pass (build + typecheck + typecheck:consumer + vitest, all 17 files).
- [x] `npm run lint` — clean (only 17 pre-existing, unrelated `docs/.vitepress` CSS warnings, confirmed present on `main` via `git stash` before this change).
- [x] `npm run scan` — this repo stays L4 · 108/108 (100%).
- [x] `npm run docs:build` — no dead links.
- [x] Manually built the CLI and ran it against a throwaway fixture using the unbraced `$CLAUDE_PROJECT_DIR/...` form — `HKS-05` now passes where it previously failed.
- [x] Changeset added (`minor`, matching this repo's own precedent for scoring-affecting bug fixes, e.g. the v0.5.0 equivalence-gap fix).

No fixture changes under `fixtures/level-0..4` — none of them use the unbraced form, so no existing level regressed or changed.