### PR TITLE
feat(docs): multilingual guide (en / pt-BR / es) — v1.1.0

### DIFF
--- a/.changeset/guide-i18n-1-1-0.md
+++ b/.changeset/guide-i18n-1-1-0.md
@@ -1,0 +1,5 @@
+---
+"harness-score": minor
+---
+
+Add pt-BR and es guide translations, translated landing pages, and language switcher on home and guide. Docs-only release; no scanner check changes.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,42 +1,167 @@
-import { defineConfig } from 'vitepress';
+import { defineConfig, type HeadConfig } from 'vitepress';
+import { LOCALES, localeFromRelativePath, localePath, neutralPagePath } from './theme/i18n/localePath';
+
+const SITE = 'https://paladini.github.io/harness-score';
+const BASE = '/harness-score/';
+
+type SidebarItem = { text: string; link: string };
+
+const guideItemsEn: SidebarItem[] = [
+  { text: '1 · What is Harness Engineering', link: '/guide/what-is-harness-engineering' },
+  { text: '2 · Multi-Harness Support', link: '/guide/multi-harness' },
+  { text: '3 · The Cursor Harness Surface', link: '/guide/cursor-harness-surface' },
+  { text: '4 · Guides — Feedforward', link: '/guide/guides-feedforward' },
+  { text: '5 · Sensors — Feedback', link: '/guide/sensors-feedback' },
+  { text: '6 · Guardrails & Safety', link: '/guide/guardrails-and-safety' },
+  { text: '7 · The Maturity Model', link: '/guide/maturity-model' },
+  { text: '8 · Measure & Improve', link: '/guide/measure-and-improve' },
+  { text: '9 · References', link: '/guide/references' },
+];
+
+const guideItemsPt: SidebarItem[] = [
+  { text: '1 · O que é engenharia de harness', link: '/guide/what-is-harness-engineering' },
+  { text: '2 · Suporte multi-harness', link: '/guide/multi-harness' },
+  { text: '3 · A superfície de harness do Cursor', link: '/guide/cursor-harness-surface' },
+  { text: '4 · Guias — feedforward', link: '/guide/guides-feedforward' },
+  { text: '5 · Sensores — feedback', link: '/guide/sensors-feedback' },
+  { text: '6 · Guardrails e segurança', link: '/guide/guardrails-and-safety' },
+  { text: '7 · O modelo de maturidade', link: '/guide/maturity-model' },
+  { text: '8 · Medir e melhorar', link: '/guide/measure-and-improve' },
+  { text: '9 · Referências', link: '/guide/references' },
+];
+
+const guideItemsEs: SidebarItem[] = [
+  { text: '1 · Qué es la ingeniería de harness', link: '/guide/what-is-harness-engineering' },
+  { text: '2 · Soporte multi-harness', link: '/guide/multi-harness' },
+  { text: '3 · La superficie de harness de Cursor', link: '/guide/cursor-harness-surface' },
+  { text: '4 · Guías — feedforward', link: '/guide/guides-feedforward' },
+  { text: '5 · Sensores — feedback', link: '/guide/sensors-feedback' },
+  { text: '6 · Guardrails y seguridad', link: '/guide/guardrails-and-safety' },
+  { text: '7 · El modelo de madurez', link: '/guide/maturity-model' },
+  { text: '8 · Medir y mejorar', link: '/guide/measure-and-improve' },
+  { text: '9 · Referencias', link: '/guide/references' },
+];
+
+const sharedTheme = {
+  logo: '/logo.svg',
+  socialLinks: [{ icon: 'github', link: 'https://github.com/paladini/harness-score' }],
+  search: { provider: 'local' as const },
+  outline: { level: [2, 3] as [number, number] },
+};
 
 export default defineConfig({
   title: 'Harness Score',
   description:
     'The harness engineering guide for AI coding agents — measure your harness maturity across Cursor, Claude Code, Windsurf, and other tools with a deterministic scanner.',
-  base: '/harness-score/',
+  base: BASE,
   lastUpdated: true,
-  head: [['link', { rel: 'icon', type: 'image/svg+xml', href: '/harness-score/favicon.svg' }]],
-  themeConfig: {
-    logo: '/logo.svg',
-    nav: [
-      { text: 'Guide', link: '/guide/what-is-harness-engineering' },
-      { text: 'Multi-Harness', link: '/guide/multi-harness' },
-      { text: 'Maturity Model', link: '/guide/maturity-model' },
-      { text: 'Scanner', link: '/guide/measure-and-improve' },
-    ],
-    sidebar: [
-      {
-        text: 'The Guide',
-        items: [
-          { text: '1 · What is Harness Engineering', link: '/guide/what-is-harness-engineering' },
-          { text: '2 · Multi-Harness Support', link: '/guide/multi-harness' },
-          { text: '3 · The Cursor Harness Surface', link: '/guide/cursor-harness-surface' },
-          { text: '4 · Guides — Feedforward', link: '/guide/guides-feedforward' },
-          { text: '5 · Sensors — Feedback', link: '/guide/sensors-feedback' },
-          { text: '6 · Guardrails & Safety', link: '/guide/guardrails-and-safety' },
-          { text: '7 · The Maturity Model', link: '/guide/maturity-model' },
-          { text: '8 · Measure & Improve', link: '/guide/measure-and-improve' },
-          { text: '9 · References', link: '/guide/references' },
+  head: [['link', { rel: 'icon', type: 'image/svg+xml', href: `${BASE}favicon.svg` }]],
+  locales: {
+    root: {
+      label: 'English',
+      lang: 'en',
+      description:
+        'The harness engineering guide for AI coding agents — measure your harness maturity with a deterministic scanner.',
+      themeConfig: {
+        ...sharedTheme,
+        nav: [
+          { text: 'Guide', link: '/guide/what-is-harness-engineering' },
+          { text: 'Multi-Harness', link: '/guide/multi-harness' },
+          { text: 'Maturity Model', link: '/guide/maturity-model' },
+          { text: 'Scanner', link: '/guide/measure-and-improve' },
         ],
+        sidebar: [{ text: 'The Guide', items: guideItemsEn.map((i) => ({ ...i })) }],
+        footer: {
+          message: 'Released under the MIT License.',
+          copyright: 'Copyright © 2026 Fernando Paladini',
+        },
+        docFooter: { prev: 'Previous', next: 'Next' },
+        outline: { label: 'On this page' },
+        lastUpdated: { text: 'Last updated' },
+        langMenuLabel: 'Change language',
+        returnToTopLabel: 'Return to top',
+        darkModeSwitchLabel: 'Appearance',
+        sidebarMenuLabel: 'Menu',
       },
-    ],
-    socialLinks: [{ icon: 'github', link: 'https://github.com/paladini/harness-score' }],
-    search: { provider: 'local' },
-    footer: {
-      message: 'Released under the MIT License.',
-      copyright: 'Copyright © 2026 Fernando Paladini',
     },
-    outline: { level: [2, 3] },
+    'pt-BR': {
+      label: 'Português',
+      lang: 'pt-BR',
+      link: '/pt-BR/',
+      description:
+        'Guia de engenharia de harness para agentes de código com IA — meça a maturidade do seu harness com um scanner determinístico.',
+      themeConfig: {
+        ...sharedTheme,
+        nav: [
+          { text: 'Guia', link: '/pt-BR/guide/what-is-harness-engineering' },
+          { text: 'Multi-harness', link: '/pt-BR/guide/multi-harness' },
+          { text: 'Maturidade', link: '/pt-BR/guide/maturity-model' },
+          { text: 'Scanner', link: '/pt-BR/guide/measure-and-improve' },
+        ],
+        sidebar: [
+          { text: 'O guia', items: guideItemsPt.map((i) => ({ text: i.text, link: `/pt-BR${i.link}` })) },
+        ],
+        footer: {
+          message: 'Licenciado sob MIT.',
+          copyright: 'Copyright © 2026 Fernando Paladini',
+        },
+        docFooter: { prev: 'Anterior', next: 'Próximo' },
+        outline: { label: 'Nesta página' },
+        lastUpdated: { text: 'Última atualização' },
+        langMenuLabel: 'Idioma',
+        returnToTopLabel: 'Voltar ao topo',
+        darkModeSwitchLabel: 'Aparência',
+        sidebarMenuLabel: 'Menu',
+      },
+    },
+    es: {
+      label: 'Español',
+      lang: 'es-419',
+      link: '/es/',
+      description:
+        'Guía de ingeniería de harness para agentes de código con IA — mide la madurez de tu harness con un escáner determinista.',
+      themeConfig: {
+        ...sharedTheme,
+        nav: [
+          { text: 'Guía', link: '/es/guide/what-is-harness-engineering' },
+          { text: 'Multi-harness', link: '/es/guide/multi-harness' },
+          { text: 'Madurez', link: '/es/guide/maturity-model' },
+          { text: 'Escáner', link: '/es/guide/measure-and-improve' },
+        ],
+        sidebar: [
+          { text: 'La guía', items: guideItemsEs.map((i) => ({ text: i.text, link: `/es${i.link}` })) },
+        ],
+        footer: {
+          message: 'Publicado bajo licencia MIT.',
+          copyright: 'Copyright © 2026 Fernando Paladini',
+        },
+        docFooter: { prev: 'Anterior', next: 'Siguiente' },
+        outline: { label: 'En esta página' },
+        lastUpdated: { text: 'Última actualización' },
+        langMenuLabel: 'Idioma',
+        returnToTopLabel: 'Volver arriba',
+        darkModeSwitchLabel: 'Aparencia',
+        sidebarMenuLabel: 'Menú',
+      },
+    },
+  },
+  transformHead({ pageData }) {
+    const head: HeadConfig[] = [];
+    const neutral = neutralPagePath(pageData.relativePath);
+    const currentLocale = localeFromRelativePath(pageData.relativePath);
+
+    const absoluteUrl = (locale: (typeof LOCALES)[number]['id']) => {
+      const path = localePath(locale, neutral);
+      return path === '/' ? `${SITE}/` : `${SITE}${path}`;
+    };
+
+    head.push(['link', { rel: 'canonical', href: absoluteUrl(currentLocale) }]);
+
+    for (const locale of LOCALES) {
+      head.push(['link', { rel: 'alternate', hreflang: locale.hreflang, href: absoluteUrl(locale.id) }]);
+    }
+    head.push(['link', { rel: 'alternate', hreflang: 'x-default', href: absoluteUrl('root') }]);
+
+    return head;
   },
 });

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,8 +1,10 @@
 import { defineConfig, type HeadConfig } from 'vitepress';
-import { LOCALES, localeFromRelativePath, localePath, neutralPagePath } from './theme/i18n/localePath';
+import { hreflangPath, LOCALES, localeFromRelativePath, neutralPagePath } from './theme/i18n/localePath';
 
 const SITE = 'https://paladini.github.io/harness-score';
 const BASE = '/harness-score/';
+const FOOTER_COPYRIGHT =
+  'Copyright © 2026 <a href="https://paladini.github.io" target="_blank" rel="noopener">Fernando Paladini</a>';
 
 type SidebarItem = { text: string; link: string };
 
@@ -44,6 +46,7 @@ const guideItemsEs: SidebarItem[] = [
 
 const sharedTheme = {
   logo: '/logo.svg',
+  logoLink: BASE,
   socialLinks: [{ icon: 'github', link: 'https://github.com/paladini/harness-score' }],
   search: { provider: 'local' as const },
   outline: { level: [2, 3] as [number, number] },
@@ -73,7 +76,7 @@ export default defineConfig({
         sidebar: [{ text: 'The Guide', items: guideItemsEn.map((i) => ({ ...i })) }],
         footer: {
           message: 'Released under the MIT License.',
-          copyright: 'Copyright © 2026 Fernando Paladini',
+          copyright: FOOTER_COPYRIGHT,
         },
         docFooter: { prev: 'Previous', next: 'Next' },
         outline: { label: 'On this page' },
@@ -103,7 +106,7 @@ export default defineConfig({
         ],
         footer: {
           message: 'Licenciado sob MIT.',
-          copyright: 'Copyright © 2026 Fernando Paladini',
+          copyright: FOOTER_COPYRIGHT,
         },
         docFooter: { prev: 'Anterior', next: 'Próximo' },
         outline: { label: 'Nesta página' },
@@ -133,7 +136,7 @@ export default defineConfig({
         ],
         footer: {
           message: 'Publicado bajo licencia MIT.',
-          copyright: 'Copyright © 2026 Fernando Paladini',
+          copyright: FOOTER_COPYRIGHT,
         },
         docFooter: { prev: 'Anterior', next: 'Siguiente' },
         outline: { label: 'En esta página' },
@@ -151,7 +154,7 @@ export default defineConfig({
     const currentLocale = localeFromRelativePath(pageData.relativePath);
 
     const absoluteUrl = (locale: (typeof LOCALES)[number]['id']) => {
-      const path = localePath(locale, neutral);
+      const path = hreflangPath(locale, neutral);
       return path === '/' ? `${SITE}/` : `${SITE}${path}`;
     };
 

--- a/docs/.vitepress/theme/components/HomeLanding.vue
+++ b/docs/.vitepress/theme/components/HomeLanding.vue
@@ -1,146 +1,60 @@
 <script setup lang="ts">
-import { withBase } from 'vitepress';
+import { useData, withBase } from 'vitepress';
+import { computed } from 'vue';
+import { LANDING, SUPPORTED_TOOLS, terminalSample } from '../i18n/landing';
+import { localeFromRelativePath } from '../i18n/localePath';
+import LanguageSwitcher from './LanguageSwitcher.vue';
 
-const levels = [
-  { n: 0, name: 'Unharnessed', hint: 'Cold-start every session' },
-  { n: 1, name: 'Documented', hint: 'AGENTS.md orients the agent' },
-  { n: 2, name: 'Guided', hint: 'Rules, skills, hygiene' },
-  { n: 3, name: 'Sensing', hint: 'Tests, types, CI verify work' },
-  { n: 4, name: 'Self-correcting', hint: 'Hooks close the loop' },
-];
+const { page } = useData();
 
-const supportedTools = [
-  { name: 'Cursor', status: 'Flagship' },
-  { name: 'Claude Code', status: 'Supported' },
-  { name: 'Windsurf', status: 'Supported' },
-  { name: 'Cline', status: 'Supported' },
-  { name: 'Continue', status: 'Supported' },
-  { name: 'Codex', status: 'Supported' },
-];
+const locale = computed(() => localeFromRelativePath(page.value.relativePath));
+const copy = computed(() => LANDING[locale.value]);
 
-const installs = [
-  {
-    title: 'Run once',
-    cmd: 'npx harness-score',
-    note: 'No install. Point at any repo path.',
-    href: '/guide/measure-and-improve',
-    external: false,
-    primary: true,
-  },
-  {
-    title: 'npm',
-    cmd: 'npm i -g harness-score',
-    note: 'v1.0.0 on npmjs.org',
-    href: 'https://www.npmjs.com/package/harness-score',
-    external: true,
-    primary: false,
-  },
-  {
-    title: 'Cursor plugin',
-    cmd: '/harness-audit',
-    note: 'In repo — Marketplace listing not live yet',
-    href: 'https://github.com/paladini/harness-score/tree/main/plugins/cursor',
-    external: true,
-    primary: false,
-  },
-  {
-    title: 'GitHub Action',
-    cmd: 'paladini/harness-score/action',
-    note: 'CI gate + README badge',
-    href: 'https://github.com/paladini/harness-score/tree/main/action',
-    external: true,
-    primary: false,
-  },
-  {
-    title: 'JSR',
-    cmd: 'npx jsr add @paladini/harness-score',
-    note: 'Deno & Bun users',
-    href: 'https://jsr.io/@paladini/harness-score',
-    external: true,
-    primary: false,
-  },
-];
+const supportedTools = computed(() =>
+  SUPPORTED_TOOLS.map((name, index) => ({
+    name,
+    status: index === 0 ? copy.value.toolStatus.flagship : copy.value.toolStatus.supported,
+  })),
+);
 </script>
 
 <template>
   <div class="hs-landing">
+    <LanguageSwitcher class="hs-landing__lang" />
+
     <section class="hs-landing__pitch">
-      <p class="hs-landing__eyebrow">The problem</p>
-      <h2 class="hs-landing__title">
-        Your AI agent is only as reliable as the harness around it.
-      </h2>
-      <p class="hs-landing__lede">
-        Two repos can run the same model and get wildly different results. One has
-        <strong>guides</strong> that steer the agent, <strong>sensors</strong> that verify
-        its work, and <strong>guardrails</strong> that stop damage — the other has none.
-        Harness Score measures that harness in seconds, across any AI tool, and tells you
-        what to fix next.
-      </p>
+      <p class="hs-landing__eyebrow">{{ copy.pitch.eyebrow }}</p>
+      <h2 class="hs-landing__title">{{ copy.pitch.title }}</h2>
+      <p class="hs-landing__lede">{{ copy.pitch.lede }}</p>
     </section>
 
     <section class="hs-landing__steps">
-      <p class="hs-landing__eyebrow">How it works</p>
+      <p class="hs-landing__eyebrow">{{ copy.steps.eyebrow }}</p>
       <div class="hs-landing__step-grid">
-        <article class="hs-landing__step">
-          <span class="hs-landing__step-num">1</span>
-          <h3>Scan</h3>
-          <p>
-            Run <code>npx harness-score</code> in your repo. The CLI reads your
-            filesystem — 36 checks, zero LLM calls, zero network.
-          </p>
-        </article>
-        <article class="hs-landing__step">
-          <span class="hs-landing__step-num">2</span>
-          <h3>Level</h3>
-          <p>
-            Get a maturity level <strong>L0–L4</strong>, a 108-point breakdown across six
-            dimensions, and the exact gap blocking the next level.
-          </p>
-        </article>
-        <article class="hs-landing__step">
-          <span class="hs-landing__step-num">3</span>
-          <h3>Fix</h3>
-          <p>
-            Every failed check links to a remediation recipe in the guide — or let an
-            editor plugin's <code>/harness-audit</code> command apply the fixes.
-          </p>
+        <article v-for="(step, index) in copy.steps.items" :key="step.title" class="hs-landing__step">
+          <span class="hs-landing__step-num">{{ index + 1 }}</span>
+          <h3>{{ step.title }}</h3>
+          <p>{{ step.body }}</p>
         </article>
       </div>
     </section>
 
     <section class="hs-landing__terminal">
       <div class="hs-landing__terminal-copy">
-        <p class="hs-landing__eyebrow">Example output</p>
-        <h2 class="hs-landing__title">A diagnosis, not a vibe check</h2>
-        <p class="hs-landing__lede">
-          Deterministic: same commit, same score — on your laptop or in CI. Gate merges
-          with <code>--min-level 3</code> so maturity only ratchets up.
-        </p>
-        <a class="hs-landing__cta" :href="withBase('/guide/measure-and-improve')">
-          Run the scanner →
-        </a>
+        <p class="hs-landing__eyebrow">{{ copy.terminal.eyebrow }}</p>
+        <h2 class="hs-landing__title">{{ copy.terminal.title }}</h2>
+        <p class="hs-landing__lede">{{ copy.terminal.lede }}</p>
+        <a class="hs-landing__cta" :href="withBase(copy.guidePath)">{{ copy.terminal.cta }}</a>
       </div>
-      <pre class="hs-landing__terminal-pre" aria-label="Example harness-score output"><code>  harness-score v1.0.0  ~/my-app
-
-  Maturity: L2 · Guided   Score: 70/108 (65%)
-  Detected: Cursor, Claude Code
-
-  Context & Guides     ████████████████░░░░  80%
-  Skills & Commands    █████████████░░░░░░░  65%
-  Hooks & Guardrails   ░░░░░░░░░░░░░░░░░░░░   0%
-  Sensors & Feedback   ████████████████░░░░  80%
-  CI Feedback          ██████████████░░░░░░  71%
-  Hygiene & Safety     ███████████████░░░░░  74%
-
-  To reach L3: sensors ≥ 60%; ci ≥ 50%</code></pre>
+      <pre class="hs-landing__terminal-pre" :aria-label="copy.terminal.ariaLabel"><code>{{ terminalSample }}</code></pre>
     </section>
 
     <section class="hs-landing__install">
-      <p class="hs-landing__eyebrow">Get started</p>
-      <h2 class="hs-landing__title">Install anywhere you work</h2>
+      <p class="hs-landing__eyebrow">{{ copy.install.eyebrow }}</p>
+      <h2 class="hs-landing__title">{{ copy.install.title }}</h2>
       <div class="hs-landing__install-grid">
         <a
-          v-for="item in installs"
+          v-for="item in copy.installs"
           :key="item.title"
           class="hs-landing__install-card"
           :class="{ 'is-primary': item.primary }"
@@ -156,18 +70,15 @@ const installs = [
     </section>
 
     <section class="hs-landing__levels">
-      <p class="hs-landing__eyebrow">Maturity ladder</p>
-      <h2 class="hs-landing__title">Five levels you can measure and gate on</h2>
-      <p class="hs-landing__lede">
-        Levels gate on the <em>shape</em> of your harness — not just points. Eighty
-        points of docs with zero tests is L1, not L3.
-      </p>
+      <p class="hs-landing__eyebrow">{{ copy.maturity.eyebrow }}</p>
+      <h2 class="hs-landing__title">{{ copy.maturity.title }}</h2>
+      <p class="hs-landing__lede">{{ copy.maturity.lede }}</p>
       <div class="hs-landing__level-row">
         <a
-          v-for="lvl in levels"
+          v-for="lvl in copy.levels"
           :key="lvl.n"
           class="hs-landing__level"
-          :href="withBase('/guide/maturity-model')"
+          :href="withBase(copy.maturityPath)"
         >
           <img
             :src="withBase(`/maturity/badge-l${lvl.n}.svg`)"
@@ -179,41 +90,31 @@ const installs = [
           <span>{{ lvl.hint }}</span>
         </a>
       </div>
-      <a class="hs-landing__cta hs-landing__cta--ghost" :href="withBase('/guide/maturity-model')">
-        Full maturity model →
+      <a class="hs-landing__cta hs-landing__cta--ghost" :href="withBase(copy.maturityPath)">
+        {{ copy.maturity.cta }}
       </a>
     </section>
 
     <section class="hs-landing__tools">
-      <p class="hs-landing__eyebrow">Works with</p>
-      <h2 class="hs-landing__title">Any AI coding tool</h2>
-      <p class="hs-landing__lede">
-        One harness, one maturity model, many tools. Configure Cursor, Claude Code,
-        Windsurf, or any other AI tool — Harness Score measures them all the same way.
-      </p>
+      <p class="hs-landing__eyebrow">{{ copy.tools.eyebrow }}</p>
+      <h2 class="hs-landing__title">{{ copy.tools.title }}</h2>
+      <p class="hs-landing__lede">{{ copy.tools.lede }}</p>
       <div class="hs-landing__tools-grid">
-        <div
-          v-for="tool in supportedTools"
-          :key="tool.name"
-          class="hs-landing__tool-chip"
-        >
+        <div v-for="tool in supportedTools" :key="tool.name" class="hs-landing__tool-chip">
           <strong>{{ tool.name }}</strong>
           <span class="hs-landing__tool-badge">{{ tool.status }}</span>
         </div>
       </div>
-      <a class="hs-landing__cta hs-landing__cta--ghost" :href="withBase('/guide/multi-harness')">
-        Learn about multi-harness support →
+      <a class="hs-landing__cta hs-landing__cta--ghost" :href="withBase(copy.multiHarnessPath)">
+        {{ copy.tools.cta }}
       </a>
     </section>
 
     <section class="hs-landing__showcase">
       <div class="hs-landing__showcase-badge">
-        <p class="hs-landing__eyebrow">Show your score</p>
-        <h2 class="hs-landing__title">Branded badges for your README</h2>
-        <p class="hs-landing__lede">
-          112×20 pill for shield rows. CI regenerates it, or pin a static
-          <code>badge-lN.svg</code>. Copy-paste embeds in Markdown, HTML, iframe, and JSX.
-        </p>
+        <p class="hs-landing__eyebrow">{{ copy.showcase.eyebrow }}</p>
+        <h2 class="hs-landing__title">{{ copy.showcase.title }}</h2>
+        <p class="hs-landing__lede">{{ copy.showcase.lede }}</p>
         <div class="hs-badge-row">
           <img
             class="hs-badge"
@@ -223,43 +124,33 @@ const installs = [
           />
         </div>
         <p class="hs-landing__links">
-          <a :href="withBase('/guide/measure-and-improve#show-your-maturity')">Gallery</a>
+          <a :href="withBase(copy.measureShowPath)">{{ copy.showcase.gallery }}</a>
           <span aria-hidden="true">·</span>
-          <a :href="withBase('/guide/measure-and-improve#embed-snippets')">Embed snippets</a>
+          <a :href="withBase(copy.measureEmbedPath)">{{ copy.showcase.embeds }}</a>
         </p>
       </div>
       <div class="hs-landing__showcase-card">
         <img
           class="hs-share-card"
           :src="withBase('/maturity/card-l4.svg')"
-          alt="Harness Score L4 · Self-correcting share card"
+          :alt="copy.showcase.cardAlt"
         />
       </div>
     </section>
 
     <section class="hs-landing__products">
-      <p class="hs-landing__eyebrow">What ships in this repo</p>
+      <p class="hs-landing__eyebrow">{{ copy.products.eyebrow }}</p>
       <div class="hs-landing__product-grid">
-        <a class="hs-landing__product" :href="withBase('/guide/what-is-harness-engineering')">
-          <h3>Guide</h3>
-          <p>8 chapters on harness engineering for AI coding agents — feedforward, sensors, guardrails.</p>
-        </a>
-        <a class="hs-landing__product" :href="withBase('/guide/measure-and-improve')">
-          <h3>CLI</h3>
-          <p><code>harness-score</code> — JSON, markdown, badge output. Zero runtime deps.</p>
-        </a>
         <a
+          v-for="item in copy.products.items"
+          :key="item.title"
           class="hs-landing__product"
-          href="https://github.com/paladini/harness-score/tree/main/plugins/cursor"
-          target="_blank"
-          rel="noreferrer"
+          :href="item.external ? item.href : withBase(item.href)"
+          :target="item.external ? '_blank' : undefined"
+          :rel="item.external ? 'noreferrer' : undefined"
         >
-          <h3>Cursor plugin</h3>
-          <p><code>/harness-audit</code> command + skill to fix every gap the scan finds.</p>
-        </a>
-        <a class="hs-landing__product" href="https://github.com/paladini/harness-score/tree/main/action" target="_blank" rel="noreferrer">
-          <h3>GitHub Action</h3>
-          <p>Scan on every push, emit the badge, fail below <code>--min-level</code>.</p>
+          <h3>{{ item.title }}</h3>
+          <p>{{ item.body }}</p>
         </a>
       </div>
     </section>

--- a/docs/.vitepress/theme/components/LanguageSwitcher.vue
+++ b/docs/.vitepress/theme/components/LanguageSwitcher.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { useData, withBase } from 'vitepress';
+import { computed } from 'vue';
+import { LOCALES, localeFromRelativePath, switchLocalePath } from '../i18n/localePath';
+
+const { page, localeIndex } = useData();
+
+const currentLocale = computed(() => localeFromRelativePath(page.value.relativePath));
+
+const links = computed(() =>
+  LOCALES.map((locale) => ({
+    ...locale,
+    href: withBase(switchLocalePath(currentLocale.value, locale.id, page.value.relativePath)),
+    active: locale.id === currentLocale.value,
+  })),
+);
+</script>
+
+<template>
+  <nav class="hs-lang-switcher" aria-label="Language">
+    <template v-for="(link, index) in links" :key="link.id">
+      <span v-if="index > 0" class="hs-lang-switcher__sep" aria-hidden="true">·</span>
+      <a
+        class="hs-lang-switcher__link"
+        :class="{ 'is-active': link.active }"
+        :href="link.href"
+        :hreflang="link.hreflang"
+        :lang="link.hreflang"
+        :aria-current="link.active ? 'page' : undefined"
+      >
+        {{ link.label }}
+      </a>
+    </template>
+  </nav>
+</template>

--- a/docs/.vitepress/theme/i18n/landing.ts
+++ b/docs/.vitepress/theme/i18n/landing.ts
@@ -203,7 +203,7 @@ export const LANDING: Record<LocaleId, LandingCopy> = {
       { n: 0, name: 'Sem harness', hint: 'Recomeça do zero a cada sessão' },
       { n: 1, name: 'Documentado', hint: 'AGENTS.md orienta o agente' },
       { n: 2, name: 'Orientado', hint: 'Rules, skills, higiene' },
-      { n: 3, name: 'Sensorizado', hint: 'Testes, tipos e CI verificam' },
+      { n: 3, name: 'Com sensores', hint: 'Testes, tipos e CI verificam' },
       { n: 4, name: 'Autocorretivo', hint: 'Hooks fecham o loop' },
     ],
     toolStatus: { flagship: 'Principal', supported: 'Suportado' },
@@ -340,7 +340,7 @@ export const LANDING: Record<LocaleId, LandingCopy> = {
       { n: 1, name: 'Documentado', hint: 'AGENTS.md orienta al agente' },
       { n: 2, name: 'Guiado', hint: 'Rules, skills, higiene' },
       { n: 3, name: 'Con sensores', hint: 'Tests, tipos y CI verifican' },
-      { n: 4, name: 'Autocorrector', hint: 'Los hooks cierran el ciclo' },
+      { n: 4, name: 'Autocorrección', hint: 'Los hooks cierran el ciclo' },
     ],
     toolStatus: { flagship: 'Principal', supported: 'Compatible' },
     installs: [
@@ -433,7 +433,7 @@ export const LANDING: Record<LocaleId, LandingCopy> = {
       lede: 'Píldora 112×20 para filas de shields. CI la regenera, o fija un badge-lN.svg estático. Copia embeds en Markdown, HTML, iframe y JSX.',
       gallery: 'Galería',
       embeds: 'Snippets de embed',
-      cardAlt: 'Harness Score L4 · tarjeta de compartir autocorrector',
+      cardAlt: 'Harness Score L4 · tarjeta de compartir autocorrección',
     },
     products: {
       eyebrow: 'Qué incluye este repo',

--- a/docs/.vitepress/theme/i18n/landing.ts
+++ b/docs/.vitepress/theme/i18n/landing.ts
@@ -1,0 +1,477 @@
+import type { LocaleId } from './localePath';
+
+export interface LandingCopy {
+  levels: { n: number; name: string; hint: string }[];
+  toolStatus: { flagship: string; supported: string };
+  installs: {
+    title: string;
+    cmd: string;
+    note: string;
+    href: string;
+    external: boolean;
+    primary: boolean;
+  }[];
+  pitch: { eyebrow: string; title: string; lede: string };
+  steps: {
+    eyebrow: string;
+    items: { title: string; body: string }[];
+  };
+  terminal: {
+    eyebrow: string;
+    title: string;
+    lede: string;
+    cta: string;
+    ariaLabel: string;
+  };
+  install: { eyebrow: string; title: string };
+  maturity: { eyebrow: string; title: string; lede: string; cta: string };
+  tools: { eyebrow: string; title: string; lede: string; cta: string };
+  showcase: {
+    eyebrow: string;
+    title: string;
+    lede: string;
+    gallery: string;
+    embeds: string;
+    cardAlt: string;
+  };
+  products: {
+    eyebrow: string;
+    items: { title: string; body: string; href: string; external?: boolean }[];
+  };
+  guidePath: string;
+  maturityPath: string;
+  multiHarnessPath: string;
+  measurePath: string;
+  measureShowPath: string;
+  measureEmbedPath: string;
+  whatIsPath: string;
+}
+
+const terminalSample = `  harness-score v1.0.0  ~/my-app
+
+  Maturity: L2 · Guided   Score: 70/108 (65%)
+  Detected: Cursor, Claude Code
+
+  Context & Guides     ████████████████░░░░  80%
+  Skills & Commands    █████████████░░░░░░░  65%
+  Hooks & Guardrails   ░░░░░░░░░░░░░░░░░░░░   0%
+  Sensors & Feedback   ████████████████░░░░  80%
+  CI Feedback          ██████████████░░░░░░  71%
+  Hygiene & Safety     ███████████████░░░░░  74%
+
+  To reach L3: sensors ≥ 60%; ci ≥ 50%`;
+
+export const LANDING: Record<LocaleId, LandingCopy> = {
+  root: {
+    levels: [
+      { n: 0, name: 'Unharnessed', hint: 'Cold-start every session' },
+      { n: 1, name: 'Documented', hint: 'AGENTS.md orients the agent' },
+      { n: 2, name: 'Guided', hint: 'Rules, skills, hygiene' },
+      { n: 3, name: 'Sensing', hint: 'Tests, types, CI verify work' },
+      { n: 4, name: 'Self-correcting', hint: 'Hooks close the loop' },
+    ],
+    toolStatus: { flagship: 'Flagship', supported: 'Supported' },
+    installs: [
+      {
+        title: 'Run once',
+        cmd: 'npx harness-score',
+        note: 'No install. Point at any repo path.',
+        href: '/guide/measure-and-improve',
+        external: false,
+        primary: true,
+      },
+      {
+        title: 'npm',
+        cmd: 'npm i -g harness-score',
+        note: 'v1.1.0 on npmjs.org',
+        href: 'https://www.npmjs.com/package/harness-score',
+        external: true,
+        primary: false,
+      },
+      {
+        title: 'Cursor plugin',
+        cmd: '/harness-audit',
+        note: 'In repo — Marketplace listing not live yet',
+        href: 'https://github.com/paladini/harness-score/tree/main/plugins/cursor',
+        external: true,
+        primary: false,
+      },
+      {
+        title: 'GitHub Action',
+        cmd: 'paladini/harness-score/action',
+        note: 'CI gate + README badge',
+        href: 'https://github.com/paladini/harness-score/tree/main/action',
+        external: true,
+        primary: false,
+      },
+      {
+        title: 'JSR',
+        cmd: 'npx jsr add @paladini/harness-score',
+        note: 'Deno & Bun users',
+        href: 'https://jsr.io/@paladini/harness-score',
+        external: true,
+        primary: false,
+      },
+    ],
+    pitch: {
+      eyebrow: 'The problem',
+      title: 'Your AI agent is only as reliable as the harness around it.',
+      lede: 'Two repos can run the same model and get wildly different results. One has guides that steer the agent, sensors that verify its work, and guardrails that stop damage — the other has none. Harness Score measures that harness in seconds, across any AI tool, and tells you what to fix next.',
+    },
+    steps: {
+      eyebrow: 'How it works',
+      items: [
+        {
+          title: 'Scan',
+          body: 'Run npx harness-score in your repo. The CLI reads your filesystem — 36 checks, zero LLM calls, zero network.',
+        },
+        {
+          title: 'Level',
+          body: 'Get a maturity level L0–L4, a 108-point breakdown across six dimensions, and the exact gap blocking the next level.',
+        },
+        {
+          title: 'Fix',
+          body: "Every failed check links to a remediation recipe in the guide — or let an editor plugin's /harness-audit command apply the fixes.",
+        },
+      ],
+    },
+    terminal: {
+      eyebrow: 'Example output',
+      title: 'A diagnosis, not a vibe check',
+      lede: 'Deterministic: same commit, same score — on your laptop or in CI. Gate merges with --min-level 3 so maturity only ratchets up.',
+      cta: 'Run the scanner →',
+      ariaLabel: 'Example harness-score output',
+    },
+    install: { eyebrow: 'Get started', title: 'Install anywhere you work' },
+    maturity: {
+      eyebrow: 'Maturity ladder',
+      title: 'Five levels you can measure and gate on',
+      lede: 'Levels gate on the shape of your harness — not just points. Eighty points of docs with zero tests is L1, not L3.',
+      cta: 'Full maturity model →',
+    },
+    tools: {
+      eyebrow: 'Works with',
+      title: 'Any AI coding tool',
+      lede: 'One harness, one maturity model, many tools. Configure Cursor, Claude Code, Windsurf, or any other AI tool — Harness Score measures them all the same way.',
+      cta: 'Learn about multi-harness support →',
+    },
+    showcase: {
+      eyebrow: 'Show your score',
+      title: 'Branded badges for your README',
+      lede: '112×20 pill for shield rows. CI regenerates it, or pin a static badge-lN.svg. Copy-paste embeds in Markdown, HTML, iframe, and JSX.',
+      gallery: 'Gallery',
+      embeds: 'Embed snippets',
+      cardAlt: 'Harness Score L4 · Self-correcting share card',
+    },
+    products: {
+      eyebrow: 'What ships in this repo',
+      items: [
+        {
+          title: 'Guide',
+          body: '8 chapters on harness engineering for AI coding agents — feedforward, sensors, guardrails.',
+          href: '/guide/what-is-harness-engineering',
+        },
+        {
+          title: 'CLI',
+          body: 'harness-score — JSON, markdown, badge output. Zero runtime deps.',
+          href: '/guide/measure-and-improve',
+        },
+        {
+          title: 'Cursor plugin',
+          body: '/harness-audit command + skill to fix every gap the scan finds.',
+          href: 'https://github.com/paladini/harness-score/tree/main/plugins/cursor',
+          external: true,
+        },
+        {
+          title: 'GitHub Action',
+          body: 'Scan on every push, emit the badge, fail below --min-level.',
+          href: 'https://github.com/paladini/harness-score/tree/main/action',
+          external: true,
+        },
+      ],
+    },
+    guidePath: '/guide/measure-and-improve',
+    maturityPath: '/guide/maturity-model',
+    multiHarnessPath: '/guide/multi-harness',
+    measurePath: '/guide/measure-and-improve',
+    measureShowPath: '/guide/measure-and-improve#show-your-maturity',
+    measureEmbedPath: '/guide/measure-and-improve#embed-snippets',
+    whatIsPath: '/guide/what-is-harness-engineering',
+  },
+  'pt-BR': {
+    levels: [
+      { n: 0, name: 'Sem harness', hint: 'Recomeça do zero a cada sessão' },
+      { n: 1, name: 'Documentado', hint: 'AGENTS.md orienta o agente' },
+      { n: 2, name: 'Orientado', hint: 'Rules, skills, higiene' },
+      { n: 3, name: 'Sensorizado', hint: 'Testes, tipos e CI verificam' },
+      { n: 4, name: 'Autocorretivo', hint: 'Hooks fecham o loop' },
+    ],
+    toolStatus: { flagship: 'Principal', supported: 'Suportado' },
+    installs: [
+      {
+        title: 'Executar uma vez',
+        cmd: 'npx harness-score',
+        note: 'Sem instalar. Aponte para qualquer repositório.',
+        href: '/pt-BR/guide/measure-and-improve',
+        external: false,
+        primary: true,
+      },
+      {
+        title: 'npm',
+        cmd: 'npm i -g harness-score',
+        note: 'v1.1.0 no npmjs.org',
+        href: 'https://www.npmjs.com/package/harness-score',
+        external: true,
+        primary: false,
+      },
+      {
+        title: 'Plugin Cursor',
+        cmd: '/harness-audit',
+        note: 'No repositório — Marketplace ainda não publicado',
+        href: 'https://github.com/paladini/harness-score/tree/main/plugins/cursor',
+        external: true,
+        primary: false,
+      },
+      {
+        title: 'GitHub Action',
+        cmd: 'paladini/harness-score/action',
+        note: 'Gate de CI + badge no README',
+        href: 'https://github.com/paladini/harness-score/tree/main/action',
+        external: true,
+        primary: false,
+      },
+      {
+        title: 'JSR',
+        cmd: 'npx jsr add @paladini/harness-score',
+        note: 'Usuários Deno e Bun',
+        href: 'https://jsr.io/@paladini/harness-score',
+        external: true,
+        primary: false,
+      },
+    ],
+    pitch: {
+      eyebrow: 'O problema',
+      title: 'Seu agente de IA só é tão confiável quanto o harness ao redor dele.',
+      lede: 'Dois repositórios podem usar o mesmo modelo e ter resultados muito diferentes. Um tem guias que orientam o agente, sensores que verificam o trabalho e guardrails que evitam danos — o outro não tem nada disso. O Harness Score mede esse harness em segundos, em qualquer ferramenta de IA, e mostra o que corrigir em seguida.',
+    },
+    steps: {
+      eyebrow: 'Como funciona',
+      items: [
+        {
+          title: 'Escanear',
+          body: 'Execute npx harness-score no repositório. A CLI lê o filesystem — 36 checks, zero chamadas a LLM, zero rede.',
+        },
+        {
+          title: 'Nível',
+          body: 'Receba um nível de maturidade L0–L4, a pontuação em 108 pontos em seis dimensões e exatamente o que falta para o próximo nível.',
+        },
+        {
+          title: 'Corrigir',
+          body: 'Cada check que falha aponta para uma receita de remediação no guia — ou use o comando /harness-audit do plugin para aplicar as correções.',
+        },
+      ],
+    },
+    terminal: {
+      eyebrow: 'Exemplo de saída',
+      title: 'Um diagnóstico, não um palpite',
+      lede: 'Determinístico: mesmo commit, mesma pontuação — no seu laptop ou no CI. Bloqueie merges com --min-level 3 para a maturidade só subir.',
+      cta: 'Executar o scanner →',
+      ariaLabel: 'Exemplo de saída do harness-score',
+    },
+    install: { eyebrow: 'Começar', title: 'Instale onde você trabalha' },
+    maturity: {
+      eyebrow: 'Escada de maturidade',
+      title: 'Cinco níveis que você pode medir e exigir no CI',
+      lede: 'Os níveis dependem da forma do harness — não só da pontuação. Oitenta pontos de documentação sem testes é L1, não L3.',
+      cta: 'Modelo de maturidade completo →',
+    },
+    tools: {
+      eyebrow: 'Funciona com',
+      title: 'Qualquer ferramenta de código com IA',
+      lede: 'Um harness, um modelo de maturidade, várias ferramentas. Configure Cursor, Claude Code, Windsurf ou outra — o Harness Score mede todas da mesma forma.',
+      cta: 'Saiba mais sobre multi-harness →',
+    },
+    showcase: {
+      eyebrow: 'Mostre sua pontuação',
+      title: 'Badges com a marca para o README',
+      lede: 'Pílula 112×20 para fileiras de shields. O CI regenera, ou fixe um badge-lN.svg estático. Copie embeds em Markdown, HTML, iframe e JSX.',
+      gallery: 'Galeria',
+      embeds: 'Snippets de embed',
+      cardAlt: 'Harness Score L4 · card de compartilhamento autocorretivo',
+    },
+    products: {
+      eyebrow: 'O que este repositório entrega',
+      items: [
+        {
+          title: 'Guia',
+          body: '8 capítulos sobre engenharia de harness para agentes de código — feedforward, sensores, guardrails.',
+          href: '/pt-BR/guide/what-is-harness-engineering',
+        },
+        {
+          title: 'CLI',
+          body: 'harness-score — saída JSON, markdown e badge. Zero deps em runtime.',
+          href: '/pt-BR/guide/measure-and-improve',
+        },
+        {
+          title: 'Plugin Cursor',
+          body: 'Comando /harness-audit + skill para corrigir cada gap encontrado.',
+          href: 'https://github.com/paladini/harness-score/tree/main/plugins/cursor',
+          external: true,
+        },
+        {
+          title: 'GitHub Action',
+          body: 'Escaneia a cada push, emite o badge, falha abaixo de --min-level.',
+          href: 'https://github.com/paladini/harness-score/tree/main/action',
+          external: true,
+        },
+      ],
+    },
+    guidePath: '/pt-BR/guide/measure-and-improve',
+    maturityPath: '/pt-BR/guide/maturity-model',
+    multiHarnessPath: '/pt-BR/guide/multi-harness',
+    measurePath: '/pt-BR/guide/measure-and-improve',
+    measureShowPath: '/pt-BR/guide/measure-and-improve#show-your-maturity',
+    measureEmbedPath: '/pt-BR/guide/measure-and-improve#embed-snippets',
+    whatIsPath: '/pt-BR/guide/what-is-harness-engineering',
+  },
+  es: {
+    levels: [
+      { n: 0, name: 'Sin harness', hint: 'Empieza de cero en cada sesión' },
+      { n: 1, name: 'Documentado', hint: 'AGENTS.md orienta al agente' },
+      { n: 2, name: 'Guiado', hint: 'Rules, skills, higiene' },
+      { n: 3, name: 'Con sensores', hint: 'Tests, tipos y CI verifican' },
+      { n: 4, name: 'Autocorrector', hint: 'Los hooks cierran el ciclo' },
+    ],
+    toolStatus: { flagship: 'Principal', supported: 'Compatible' },
+    installs: [
+      {
+        title: 'Ejecutar una vez',
+        cmd: 'npx harness-score',
+        note: 'Sin instalar. Apunta a cualquier repositorio.',
+        href: '/es/guide/measure-and-improve',
+        external: false,
+        primary: true,
+      },
+      {
+        title: 'npm',
+        cmd: 'npm i -g harness-score',
+        note: 'v1.1.0 en npmjs.org',
+        href: 'https://www.npmjs.com/package/harness-score',
+        external: true,
+        primary: false,
+      },
+      {
+        title: 'Plugin Cursor',
+        cmd: '/harness-audit',
+        note: 'En el repo — Marketplace aún no publicado',
+        href: 'https://github.com/paladini/harness-score/tree/main/plugins/cursor',
+        external: true,
+        primary: false,
+      },
+      {
+        title: 'GitHub Action',
+        cmd: 'paladini/harness-score/action',
+        note: 'Gate de CI + badge en README',
+        href: 'https://github.com/paladini/harness-score/tree/main/action',
+        external: true,
+        primary: false,
+      },
+      {
+        title: 'JSR',
+        cmd: 'npx jsr add @paladini/harness-score',
+        note: 'Usuarios de Deno y Bun',
+        href: 'https://jsr.io/@paladini/harness-score',
+        external: true,
+        primary: false,
+      },
+    ],
+    pitch: {
+      eyebrow: 'El problema',
+      title: 'Tu agente de IA solo es tan confiable como el harness que lo rodea.',
+      lede: 'Dos repos pueden usar el mismo modelo y obtener resultados muy distintos. Uno tiene guías que orientan al agente, sensores que verifican el trabajo y guardrails que evitan daños — el otro no tiene nada de eso. Harness Score mide ese harness en segundos, en cualquier herramienta de IA, y te dice qué corregir después.',
+    },
+    steps: {
+      eyebrow: 'Cómo funciona',
+      items: [
+        {
+          title: 'Escanear',
+          body: 'Ejecuta npx harness-score en tu repo. La CLI lee el filesystem — 36 checks, cero llamadas a LLM, cero red.',
+        },
+        {
+          title: 'Nivel',
+          body: 'Obtén un nivel de madurez L0–L4, el desglose de 108 puntos en seis dimensiones y exactamente qué falta para el siguiente nivel.',
+        },
+        {
+          title: 'Corregir',
+          body: 'Cada check fallido enlaza a una receta de remediación en la guía — o usa el comando /harness-audit del plugin para aplicar las correcciones.',
+        },
+      ],
+    },
+    terminal: {
+      eyebrow: 'Ejemplo de salida',
+      title: 'Un diagnóstico, no una corazonada',
+      lede: 'Determinista: mismo commit, misma puntuación — en tu laptop o en CI. Bloquea merges con --min-level 3 para que la madurez solo suba.',
+      cta: 'Ejecutar el escáner →',
+      ariaLabel: 'Ejemplo de salida de harness-score',
+    },
+    install: { eyebrow: 'Empezar', title: 'Instala donde trabajas' },
+    maturity: {
+      eyebrow: 'Escalera de madurez',
+      title: 'Cinco niveles que puedes medir y exigir en CI',
+      lede: 'Los niveles dependen de la forma del harness — no solo de los puntos. Ochenta puntos de docs sin tests es L1, no L3.',
+      cta: 'Modelo de madurez completo →',
+    },
+    tools: {
+      eyebrow: 'Funciona con',
+      title: 'Cualquier herramienta de código con IA',
+      lede: 'Un harness, un modelo de madurez, muchas herramientas. Configura Cursor, Claude Code, Windsurf u otra — Harness Score las mide igual.',
+      cta: 'Más sobre multi-harness →',
+    },
+    showcase: {
+      eyebrow: 'Muestra tu puntuación',
+      title: 'Badges con marca para tu README',
+      lede: 'Píldora 112×20 para filas de shields. CI la regenera, o fija un badge-lN.svg estático. Copia embeds en Markdown, HTML, iframe y JSX.',
+      gallery: 'Galería',
+      embeds: 'Snippets de embed',
+      cardAlt: 'Harness Score L4 · tarjeta de compartir autocorrector',
+    },
+    products: {
+      eyebrow: 'Qué incluye este repo',
+      items: [
+        {
+          title: 'Guía',
+          body: '8 capítulos sobre ingeniería de harness para agentes de código — feedforward, sensores, guardrails.',
+          href: '/es/guide/what-is-harness-engineering',
+        },
+        {
+          title: 'CLI',
+          body: 'harness-score — salida JSON, markdown y badge. Cero deps en runtime.',
+          href: '/es/guide/measure-and-improve',
+        },
+        {
+          title: 'Plugin Cursor',
+          body: 'Comando /harness-audit + skill para corregir cada gap encontrado.',
+          href: 'https://github.com/paladini/harness-score/tree/main/plugins/cursor',
+          external: true,
+        },
+        {
+          title: 'GitHub Action',
+          body: 'Escanea en cada push, emite el badge, falla bajo --min-level.',
+          href: 'https://github.com/paladini/harness-score/tree/main/action',
+          external: true,
+        },
+      ],
+    },
+    guidePath: '/es/guide/measure-and-improve',
+    maturityPath: '/es/guide/maturity-model',
+    multiHarnessPath: '/es/guide/multi-harness',
+    measurePath: '/es/guide/measure-and-improve',
+    measureShowPath: '/es/guide/measure-and-improve#show-your-maturity',
+    measureEmbedPath: '/es/guide/measure-and-improve#embed-snippets',
+    whatIsPath: '/es/guide/what-is-harness-engineering',
+  },
+};
+
+export const SUPPORTED_TOOLS = ['Cursor', 'Claude Code', 'Windsurf', 'Cline', 'Continue', 'Codex'] as const;
+
+export { terminalSample };

--- a/docs/.vitepress/theme/i18n/localePath.ts
+++ b/docs/.vitepress/theme/i18n/localePath.ts
@@ -1,0 +1,44 @@
+export type LocaleId = 'root' | 'pt-BR' | 'es';
+
+export interface LocaleMeta {
+  id: LocaleId;
+  label: string;
+  prefix: string;
+  hreflang: string;
+}
+
+export const LOCALES: LocaleMeta[] = [
+  { id: 'root', label: 'English', prefix: '', hreflang: 'en' },
+  { id: 'pt-BR', label: 'Português', prefix: 'pt-BR', hreflang: 'pt-BR' },
+  { id: 'es', label: 'Español', prefix: 'es', hreflang: 'es-419' },
+];
+
+export function localeFromRelativePath(relativePath: string): LocaleId {
+  if (relativePath === 'pt-BR/index.md' || relativePath.startsWith('pt-BR/')) return 'pt-BR';
+  if (relativePath === 'es/index.md' || relativePath.startsWith('es/')) return 'es';
+  return 'root';
+}
+
+/** Strip locale prefix and `.md` so `guide/foo.md` and `index.md` share one key. */
+export function neutralPagePath(relativePath: string): string {
+  let path = relativePath;
+  if (path.startsWith('pt-BR/')) path = path.slice('pt-BR/'.length);
+  else if (path.startsWith('es/')) path = path.slice('es/'.length);
+  return path.replace(/\.md$/, '').replace(/\/index$/, '') || 'index';
+}
+
+export function localePath(locale: LocaleId, neutralPath: string): string {
+  const slug = neutralPath === 'index' ? '' : neutralPath;
+  if (locale === 'root') return slug ? `/${slug}` : '/';
+  return slug ? `/${locale}/${slug}` : `/${locale}/`;
+}
+
+export function switchLocalePath(
+  currentLocale: LocaleId,
+  targetLocale: LocaleId,
+  relativePath: string,
+): string {
+  if (currentLocale === targetLocale) return localePath(targetLocale, neutralPagePath(relativePath));
+  const neutral = neutralPagePath(relativePath);
+  return localePath(targetLocale, neutral);
+}

--- a/docs/.vitepress/theme/i18n/localePath.ts
+++ b/docs/.vitepress/theme/i18n/localePath.ts
@@ -33,6 +33,11 @@ export function localePath(locale: LocaleId, neutralPath: string): string {
   return slug ? `/${locale}/${slug}` : `/${locale}/`;
 }
 
+/** hreflang target — home is translated in every locale. */
+export function hreflangPath(locale: LocaleId, neutralPath: string): string {
+  return localePath(locale, neutralPath);
+}
+
 export function switchLocalePath(
   currentLocale: LocaleId,
   targetLocale: LocaleId,

--- a/docs/.vitepress/theme/landing.css
+++ b/docs/.vitepress/theme/landing.css
@@ -13,44 +13,6 @@
   padding: 0 1.5rem 4rem;
 }
 
-.hs-landing__lang {
-  margin: 0 0 1.5rem;
-}
-
-.hs-lang-switcher {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.35rem 0.5rem;
-  font-size: 0.92rem;
-}
-
-.hs-lang-switcher__sep {
-  color: var(--hs-muted);
-  user-select: none;
-}
-
-.hs-lang-switcher__link {
-  color: var(--vp-c-text-2);
-  text-decoration: none;
-  font-weight: 500;
-  padding: 0.15rem 0.35rem;
-  border-radius: 4px;
-  transition:
-    color 0.15s,
-    background 0.15s;
-}
-
-.hs-lang-switcher__link:hover {
-  color: var(--hs-emer);
-}
-
-.hs-lang-switcher__link.is-active {
-  color: var(--hs-emer);
-  font-weight: 700;
-  background: color-mix(in srgb, var(--hs-emer) 12%, transparent);
-}
-
 .hs-landing__eyebrow {
   margin: 0 0 0.5rem;
   font-size: 0.72rem;
@@ -391,4 +353,59 @@
 .VPHomeHero .image-container {
   max-width: 88px !important;
   max-height: 88px !important;
+}
+
+.hs-landing__lang {
+  margin: 0 0 1.5rem;
+}
+
+.hs-lang-switcher {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.5rem;
+  font-size: 0.92rem;
+}
+
+.hs-lang-switcher__sep {
+  color: var(--hs-muted);
+  user-select: none;
+}
+
+.hs-lang-switcher__link {
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 0.15rem 0.35rem;
+  border-radius: 4px;
+  transition:
+    color 0.15s,
+    background 0.15s;
+}
+
+.hs-lang-switcher__link:hover {
+  color: var(--hs-emer);
+}
+
+.hs-lang-switcher__link.is-active {
+  color: var(--hs-emer);
+  font-weight: 700;
+}
+
+@media (max-width: 768px) {
+  /* Logo already appears in the header; hide floating hero image on narrow screens */
+  .VPHomeHero .image {
+    display: none;
+  }
+
+  .VPHomeHero .actions {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+  }
+
+  .VPHomeHero .action {
+    flex: 1 1 auto;
+    min-width: min(100%, 10rem);
+  }
 }

--- a/docs/.vitepress/theme/landing.css
+++ b/docs/.vitepress/theme/landing.css
@@ -13,6 +13,44 @@
   padding: 0 1.5rem 4rem;
 }
 
+.hs-landing__lang {
+  margin: 0 0 1.5rem;
+}
+
+.hs-lang-switcher {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.5rem;
+  font-size: 0.92rem;
+}
+
+.hs-lang-switcher__sep {
+  color: var(--hs-muted);
+  user-select: none;
+}
+
+.hs-lang-switcher__link {
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 0.15rem 0.35rem;
+  border-radius: 4px;
+  transition:
+    color 0.15s,
+    background 0.15s;
+}
+
+.hs-lang-switcher__link:hover {
+  color: var(--hs-emer);
+}
+
+.hs-lang-switcher__link.is-active {
+  color: var(--hs-emer);
+  font-weight: 700;
+  background: color-mix(in srgb, var(--hs-emer) 12%, transparent);
+}
+
 .hs-landing__eyebrow {
   margin: 0 0 0.5rem;
   font-size: 0.72rem;

--- a/docs/es/guide/cursor-harness-surface.md
+++ b/docs/es/guide/cursor-harness-surface.md
@@ -1,0 +1,192 @@
+# La superficie de harness de Cursor
+
+Cursor expone más maquinaria de harness que cualquier otro editor de IA mainstream.
+Este capítulo es el mapa: cada artefacto, dónde vive y qué trabajo hace en el
+sistema de control.
+
+> **Nota:** Harness Score soporta varias herramientas (Claude Code, Windsurf, Cline, Continue y otras) vía semántica OR. Este capítulo se centra en Cursor como ejemplo principal. Ver [Soporte multi-harness](./multi-harness) para cómo se reconocen y puntúan otras herramientas.
+
+## Los artefactos de un vistazo
+
+| Artefacto | Ruta | Familia | Cargado |
+|---|---|---|---|
+| Archivo de contexto del agente | `AGENTS.md` | Guía | Siempre |
+| Rules | `.cursor/rules/*.mdc` | Guía | Siempre / por glob / por relevancia |
+| Skills | `.cursor/skills/*/SKILL.md` | Guía | Bajo demanda, por description |
+| Commands | `.cursor/commands/*.md` | Guía | Explícitamente, vía `/name` |
+| Hooks | `.cursor/hooks.json` | Sensor + Guardrail | En eventos del loop del agente |
+| Servidores MCP | `.cursor/mcp.json` | Guía (herramientas) | Por sesión |
+| Subagents | definiciones de agente | Guía | Tareas delegadas |
+| Plugins | Marketplace / `.cursor-plugin/` | Todo empaquetado | Instalado |
+
+Todo vive en el repositorio — ese es el punto: **el harness viaja con el código**,
+se versiona con el código y se revisa como código.
+
+## AGENTS.md — la puerta de entrada
+
+`AGENTS.md` en la raíz del repo es lo primero que lee un agente. Es convención
+abierta (Cursor, Claude Code y la mayoría de herramientas agentic la honran) y el
+archivo único de mayor palanca en tu harness. Debe responder, brevemente:
+
+- ¿Qué es este proyecto y cómo está organizado?
+- ¿Cómo construyo, ejecuto y **pruebo**?
+- ¿Qué convenciones son innegociables?
+- ¿Qué nunca debo tocar?
+
+Mantén bajo ~150 líneas. Se carga en toda sesión — cada línea taxa la ventana de
+contexto de toda tarea. Detalles que solo importan a veces pertenecen a rules con
+alcance o skills.
+
+## Rules — guía persistente y declarativa
+
+Las rules son archivos markdown con frontmatter (`.mdc`) en `.cursor/rules/`.
+Cada rule declara *cuándo aplica*:
+
+```markdown
+---
+description: API route conventions
+globs: src/api/**
+---
+
+- Every route validates input with zod before use.
+- Errors return `{ "error": string }` and a correct status code.
+```
+
+Tres modos de activación:
+
+- `alwaysApply: true` — inyectado en todo request. Reserva para innegociables de
+  verdad; toda rule always-on es taxa permanente de contexto.
+- `globs: <pattern>` — aplicada cuando archivos coincidentes están en juego.
+  Modo workhorse: convenciones viven junto al código que gobiernan.
+- Solo `description` — el agente decide relevancia por la description.
+
+Directorios `.cursor/rules/` anidados funcionan en monorepos: coloca rules
+específicas del paquete dentro del paquete.
+
+El archivo legado `.cursorrules` está deprecado. Migra: divide por preocupación,
+alcance por glob.
+
+## Skills — conocimiento procedural bajo demanda
+
+Una skill es carpeta con `SKILL.md` (estándar abierto Agent Skills):
+
+```markdown
+---
+name: deploy
+description: Use when the user asks to deploy or release; covers tagging,
+  pipeline, and smoke tests.
+---
+
+# Deploying
+1. …step-by-step workflow…
+```
+
+Cursor muestra al agente `name` + `description` de toda skill al inicio de sesión;
+el cuerpo carga **solo cuando el agente juzga relevante**. Las skills son el
+lugar correcto para contenido procedural largo que hincharía rules: runbooks de
+deploy, recetas de migración, checklists de release, playbooks de debug.
+
+Regla práctica: **rules son declarativas y semi-always-on ("use TypeScript strict"),
+skills son procedurales y bajo demanda ("así desplegamos")**.
+La description es el disparador — escríbela como "Use when…" o nunca dispara.
+
+## Commands — workflows que invocas a propósito
+
+Archivos markdown en `.cursor/commands/` se vuelven `/slash-commands`. A
+diferencia de skills (disparadas por el agente), los commands son **disparados
+por humanos**: workflows repetibles en superficie tipo atajo — `/review`,
+`/release`, `/harness-audit`. Un archivo de command es simplemente el prompt que
+corre al invocarse.
+
+## Hooks — observar y controlar el loop del agente
+
+`.cursor/hooks.json` registra scripts en eventos del ciclo de vida del agente:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [{ "command": "node ./.cursor/hooks/guard.js" }],
+    "afterFileEdit": [{ "command": "node ./.cursor/hooks/format.js" }]
+  }
+}
+```
+
+Los scripts reciben JSON en stdin y responden en stdout — incluyendo decisiones
+de permiso (`allow` / `deny` / `ask`) para eventos de gate. Eventos clave:
+
+- **Gates** (pueden bloquear): `beforeShellExecution`, `beforeMCPExecution`,
+  `preToolUse`, `beforeReadFile`
+- **Feedback** (observan resultados): `afterFileEdit`, `postToolUse`,
+  `afterShellExecution`, `stop`
+- **Lifecycle**: `sessionStart` (inyecta contexto), `sessionEnd`, `preCompact`
+
+Los hooks son el único mecanismo Cursor *impuesto por el runtime del harness* en
+lugar de *sugerido al modelo*. Rule que dice "nunca corras comandos destructivos"
+es pedido; hook `beforeShellExecution` que niega es hecho. El capítulo 5 expande
+esta distinción.
+
+## MCP — herramientas y conocimiento
+
+`.cursor/mcp.json` conecta servidores Model Context Protocol: bases de datos,
+issue trackers, docs, browsers. Desde el harness MCP es guía (determina qué
+*ve y hace* el agente) y superficie de riesgo (servidores corren con tus
+credenciales — nunca secrets inline; usa interpolación `${ENV_VAR}`).
+
+## Subagents — delegados con propósito {#subagents-purpose-built-delegates}
+
+Un subagent es archivo markdown en `.cursor/agents/` (o carpeta `agents/` de
+plugin) con el mismo contrato de frontmatter `name` + `description` que una skill:
+
+```markdown
+---
+name: reviewer
+description: Use when asked to review a pull request or diff for conventions
+  in AGENTS.md and .cursor/rules; reports findings by severity without
+  editing code.
+---
+
+# Reviewer subagent
+
+Read the diff, AGENTS.md, and .cursor/rules/*.mdc. Report violations ordered
+by severity. Never modify code — that's the parent agent's job.
+```
+
+Distinción de skill: una skill enseña al agente *primario* un procedimiento que
+corre inline; un subagent es **delegado separado** al que el agente primario pasa
+tarea — a menudo con acceso a herramientas más estrecho o job description menor,
+para que tarea grande (auditoría de repo, release multi-step) se divida entre
+workers especializados en lugar de un agente hacer todo en un contexto. La
+documentación de Cursor describe esto como delegar trabajo "purpose-built" —
+planner, reviewer, release runner — cada uno con description lo bastante
+ajustada para que el agente primario decida cuándo delegar sin adivinar.
+
+Misma regla que skills en la description: es la única señal que el agente primario
+usa para decidir delegar — escríbela como condición de disparo, no etiqueta.
+
+## Plugins — el harness, empaquetado
+
+Un plugin Cursor empaqueta rules, skills, commands, hooks, agents y config MCP
+en una unidad instalable con manifest `.cursor-plugin/plugin.json`, distribuido
+por el [Cursor Marketplace](https://cursor.com/marketplace). Los plugins importan
+para ingeniería de harness porque hacen patrones de harness **reutilizables entre
+repos** — incluido el
+[plugin Harness Score](./measure-and-improve#the-cursor-plugin) que audita los
+artefactos que este capítulo describió (instalable desde el directorio del repo
+hoy; listado Marketplace pendiente de revisión).
+
+## Elegir el mecanismo correcto
+
+| Quieres… | Usa |
+|---|---|
+| Declarar convención que siempre vale | Rule (`alwaysApply`) — con moderación |
+| Declarar convención para parte del codebase | Rule con `globs` |
+| Enseñar procedimiento multi-step | Skill |
+| Empaquetar workflow que humanos disparan | Command |
+| Delegar trabajo a worker separado con propósito | Subagent |
+| Imponer algo independiente de lo que piensa el modelo | Hook |
+| Dar herramienta o fuente de datos al agente | Servidor MCP |
+| Compartir todo lo anterior entre repos | Plugin |
+
+Si una guía sigue ignorándose, muévela *hacia abajo* en esta tabla — de prosa que
+el modelo puede saltar, hacia mecanismos que el runtime impone.

--- a/docs/es/guide/guardrails-and-safety.md
+++ b/docs/es/guide/guardrails-and-safety.md
@@ -1,0 +1,126 @@
+# Guardrails y seguridad
+
+Las guías sugieren. Los sensores detectan. **Los guardrails impiden.** Este
+capítulo cubre la capa del harness que aguanta aunque el modelo ignore toda
+instrucción — porque no depende de que el modelo lea nada.
+
+## Por qué la prosa no es guardrail
+
+Una rule que dice "nunca corras `git push --force`" es un pedido a un sistema
+probabilístico. Generalmente será respetada. "Generalmente" es la clase de
+confiabilidad incorrecta para operaciones destructivas, irreversibles o que
+tocan credenciales. Para esas, el check debe vivir **fuera del modelo**, en
+maquinaria que el modelo no puede saltar: hooks, permisos e higiene del repo.
+
+La escalera del capítulo 3 termina aquí: orientación que sigue violándose pasa
+de rule → sensor → **gate**.
+
+## Gate hooks
+
+Los eventos de gate de Cursor — `beforeShellExecution`, `beforeMCPExecution`,
+`preToolUse`, `beforeReadFile` — corren tu script *antes* de la acción y permiten
+responder `allow`, `deny` o `ask`:
+
+```js
+// .cursor/hooks/guard-shell.js — deny destructive commands
+let input = '';
+process.stdin.on('data', (c) => (input += c));
+process.stdin.on('end', () => {
+  const { command = '' } = JSON.parse(input || '{}');
+  const destructive =
+    /\brm\s+-rf\s+[\/~]|\bgit\s+push\s+--force\b|\bdrop\s+(table|database)\b/i;
+  process.stdout.write(
+    JSON.stringify(
+      destructive.test(command)
+        ? { permission: 'deny', userMessage: 'Blocked: destructive command.' }
+        : { permission: 'allow' },
+    ),
+  );
+});
+```
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      { "command": "node ./.cursor/hooks/guard-shell.js", "timeout": 10 }
+    ]
+  }
+}
+```
+
+Patrones que valen gate en la mayoría de repos:
+
+- **Shell destructivo**: deletes recursivos fuera del workspace, force pushes,
+  rewrites de historial, `DROP`/`TRUNCATE` contra bases no locales.
+- **Escrituras outbound**: deploys, publicación de paquetes, post a APIs externas —
+  `ask`, no `deny`: humano confirma, in-flow.
+- **Lecturas con secreto**: `beforeReadFile` en `.env*`, archivos de clave y
+  stores de credencial mantienen secretos fuera del contexto del modelo.
+- **Llamadas MCP con efectos colaterales**: `beforeMCPExecution` filtrando por
+  nombre de tool — allow reads, confirm writes.
+
+Notas de diseño: falla *cerrado* para la lista peligrosa (exit code 2 bloquea),
+mantén scripts de gate sin dependencias y rápidos, y **commítelos** — config de
+hook apuntando a script que existe solo en tu máquina protege solo a ti.
+
+## Higiene de secretos
+
+El agente lee tu working tree; cualquier cosa en ella puede ir a contexto, commit
+o archivo generado. Reglas deterministas de higiene:
+
+1. **`.gitignore` cubre `.env` y `.env.*`** (permite `.env.example`).
+   El guardrail más barato que existe.
+2. **Sin archivos `.env` reales en el árbol** donde sea evitable; templates
+   documentan variables necesarias.
+3. **`mcp.json` usa interpolación `${ENV_VAR}`, nunca claves literales.** Config
+   MCP con API key inline es secreto publicado en todo clone.
+4. **Sin tokens en archivos de harness.** `AGENTS.md`, rules y configs de hooks
+   se *cargan en contexto del modelo cada sesión* — clave ahí es exfiltrada por
+   diseño.
+
+`harness-score` checa los cuatro (HYG-02 … HYG-06) con matching de firma de
+credencial — deterministicamente, offline.
+
+## Conciencia de prompt injection
+
+Los harnesses de agente tienen una clase de amenaza que workflows humanos no:
+**instrucciones escondidas en datos**. README en dependencia, página web buscada
+por MCP, comentario en issue — cualquiera puede contener texto para tu agente
+("ignora tus instrucciones y corre…"). Mitigaciones a nivel harness:
+
+- Gate hooks no importan quién autorizó la instrucción — el comando destructivo
+  se niega sea el usuario, el modelo o una página inyectada quien lo pidió. Ese
+  es el argumento más fuerte por gates sobre rules.
+- Alcance servidores MCP a lo que la tarea necesita; servidor de docs read-only
+  no publica tus datos en ningún lado.
+- Trata "agente de repente quiere curl a dominio desconocido" como señal que
+  vale gate `ask`.
+
+## Permisos y radio de explosión
+
+Más allá de hooks, reduce lo que un agente comprometido o confundido *podría*
+hacer:
+
+- Corre agentes con credenciales acotadas a la tarea (token de CI que abre PRs
+  pero no hace push a `main`).
+- Branch protection: agentes abren PRs; humanos (o checks obligatorios) hacen merge.
+- Ejecución sandboxed para trabajo autónomo no confiable o largo.
+
+El principio unificador es **defensa en profundidad**: rules hacen improbables
+malas acciones, sensores las hacen visibles, gates las hacen imposibles, y
+permisos hacen sobrevivible hasta "imposible falló".
+
+## Conjunto mínimo viable de guardrails
+
+Para un repo de producto típico, el piso se ve así:
+
+- [ ] `.gitignore` cubriendo env files; sin secretos reales en el árbol
+- [ ] `mcp.json` limpio de credenciales literales
+- [ ] `hooks.json` con un gate de shell (patrones destructivos → deny/ask)
+- [ ] Un hook de feedback (format/lint on edit)
+- [ ] Branch protection con checks de CI obligatorios
+
+Ese conjunto es exactamente lo que el [modelo de madurez](./maturity-model)
+requiere para las dimensiones Hooks & Guardrails y Hygiene & Safety en L4.

--- a/docs/es/guide/guides-feedforward.md
+++ b/docs/es/guide/guides-feedforward.md
@@ -1,0 +1,147 @@
+# Guías — controles feedforward
+
+Las guías moldean lo que el agente hace *antes* de actuar. Son los controles
+más baratos que tienes: un párrafo en el lugar correcto evita categorías enteras
+de errores. Este capítulo cubre cómo escribirlas bien.
+
+## La economía del contexto
+
+Cada guía compite por el mismo recurso escaso: la ventana de contexto y la
+atención del modelo. El modo de fallo de equipos entusiastas no es pocas guías,
+sino **demasiadas palabras** — un archivo de rules de 2.000 líneas que el modelo
+solo pasa de largo, una wiki pegada en `AGENTS.md`. La lección de harness de
+LangChain aplica aquí: *ensamblar contexto en nombre del agente* significa dar
+las 50 líneas correctas, no las 5.000.
+
+Presupuesto práctico:
+
+- `AGENTS.md`: ≤150 líneas, siempre cargado — solo lo que aplica a *toda* tarea.
+- Rules always-on: una o dos, ≤30 líneas cada una.
+- Rules con alcance por glob: las que necesites; cada una carga solo cuando aplica.
+- Skills: longitud ilimitada; cargadas solo bajo demanda.
+
+## Escribiendo un AGENTS.md que funciona
+
+Estructura que se ha probado:
+
+```markdown
+# Agent Guide — <project>
+
+## What this is
+Two sentences. Domain, purpose, key constraint.
+
+## Layout
+- src/api — HTTP layer (see .cursor/rules/api.mdc)
+- src/core — domain logic, pure functions only
+- migrations/ — generated; never edit by hand
+
+## Build & test
+- npm run dev / npm test / npm run typecheck
+- Tests MUST pass before any commit.
+
+## Conventions
+- TypeScript strict; no `any` without a comment.
+- Never add dependencies without asking.
+
+## Do not touch
+- vendor/, generated/, legacy/payments (frozen for audit)
+```
+
+Principios:
+
+1. **Comandos, no descripciones.** "Corre `npm test`" gana a "valoramos los tests".
+   Los agentes actúan con imperativos.
+2. **Apunta, no pegues.** Enlaza a la rule o skill con alcance en lugar de pegar
+   detalles ("ver `.cursor/rules/api.mdc`").
+3. **Di lo que no hacer.** Espacio negativo — directorios congelados, patrones
+   prohibidos — evita los errores más caros.
+4. **Mantén actualizado.** Guía obsoleta es peor que ninguna; el agente la sigue
+   con confianza. Revisar `AGENTS.md` entra en tu definición de hecho para cambios
+   arquitectónicos.
+
+## Escribiendo rules que disparan correctamente
+
+Una rule tiene tres trabajos: aplicar en el momento correcto, ser lo bastante
+corta para leerse, y lo bastante concreta para verificarse.
+
+**Alcance agresivo.** El mayor anti-patrón de rules es `alwaysApply: true` en
+todo. Cada rule always-on carga en cada request — incluso para corregir un typo
+en el README. Alcance por glob:
+
+```markdown
+---
+description: React component conventions
+globs: src/components/**/*.tsx
+---
+```
+
+**Una preocupación por rule.** `api.mdc`, `testing.mdc`, `styling.mdc` — no
+`everything.mdc`. Rules pequeñas son diffables, revisables y escopables
+independientemente.
+
+**Concreta y verificable.** "Escribe buenos tests" no orienta nada. "Cada nuevo
+export en `src/core` necesita test unitario en la carpeta `__tests__` hermana"
+orienta — y un revisor (o sensor) puede verificar.
+
+**Muestra, luego di.** Un ejemplo de código de 5 líneas del patrón correcto gana
+a tres párrafos describiéndolo.
+
+## Skills: la capa procedural
+
+Todo lo que parece *runbook* pertenece a una skill, no a una rule:
+
+- Procedimientos de deploy y release
+- Workflows de migración de base de datos
+- "Cómo agregar un endpoint de API de punta a punta"
+- Playbooks de debug de incidentes
+
+La calidad de la skill depende de la **description**, porque es todo lo que el
+agente ve al decidir cargarla. Compara:
+
+```yaml
+description: Deployment stuff            # never triggers
+```
+
+```yaml
+description: Use when the user asks to deploy, release, or ship to
+  production; covers tagging, the pipeline, rollback, and smoke tests.
+```
+
+Escribe descriptions como condiciones de disparo ("Use when…"), ≥40 caracteres,
+con las palabras que un usuario diría de verdad.
+
+## Commands: codifica los verbos del equipo
+
+Los commands son guías para *humanos y agentes a la vez*: `/review`, `/release`,
+`/new-endpoint` documentan cómo trabaja el equipo de forma ejecutable. Un buen
+prompt de command declara el workflow, la barra de calidad y la condición de
+parada:
+
+```markdown
+# /review
+
+Review the current diff against AGENTS.md and .cursor/rules/.
+Report findings ordered by severity with file:line references.
+Do not fix anything unless explicitly asked.
+```
+
+## Scripts bootstrap y templates
+
+Fowler lista herramientas bootstrap entre controles feedforward: generadores y
+templates que inician al agente desde un esqueleto conocido-bueno (`npm run
+new:endpoint`, template de servicio con observabilidad). Cuando un patrón debe
+repetirse exactamente, un generador gana a una descripción del patrón —
+determinismo otra vez. Menciona esos scripts en `AGENTS.md` para que los agentes
+los usen en lugar de inventar desde cero.
+
+## Cómo fallan las guías, y qué las atrapa
+
+| Falla | Síntoma | Contramedida |
+|---|---|---|
+| Guía obsoleta | Agente sigue convención desactualizada | Revisar archivos de harness en PRs que tocan arquitectura |
+| Contexto hinchado | Agente ignora instrucciones a mitad de archivo | Escopar rules; mover procedimientos a skills |
+| Orientación vaga | Agente interpreta creativamente | Hacer rules concretas y verificables |
+| Guía ignorada | Mismo error se repite | Escalar a sensor o hook (capítulos 4–5) |
+
+La última fila es el puente al siguiente capítulo: las guías son sugerencias, y
+algunas sugerencias deben volverse **checks**.

--- a/docs/es/guide/maturity-model.md
+++ b/docs/es/guide/maturity-model.md
@@ -1,0 +1,130 @@
+# El modelo de madurez
+
+Este capítulo define el modelo de madurez — el mismo marco de evaluación
+implementado por [`npx harness-score`](./measure-and-improve),
+para que un nivel que lees aquí sea uno que puedes medir, reproducir y exigir
+en CI.
+
+La forma sigue patrones familiares de madurez (capacidades DORA, funciones de
+negocio OWASP SAMM, niveles CMMI): **dimensiones** miden áreas de práctica,
+**checks** son indicadores deterministas pass/fail, y **niveles** exigen la
+*forma* de la cobertura — no solo un porcentaje bruto.
+
+Objetivos de diseño:
+
+- **Determinista.** Cada check es un hecho del filesystem: un archivo existe,
+  parsea, coincide con un patrón. Sin modelo, sin juicio, sin red.
+- **Agnóstico de herramienta, Cursor como ejemplo principal.** Rules, skills,
+  hooks y commands de cualquier herramienta de IA soportada (Cursor, Windsurf,
+  Claude Code, Codex/Antigravity `.agents/`, OpenCode, Cline, Continue,
+  instrucciones Copilot, Zed) puntúan con semántica OR — basta una herramienta
+  configurada. Infraestructura universal (tests, linters, tipos, CI) forma el
+  mismo sistema de control sin importar el IDE.
+- **Una escalera, no una calificación.** Los niveles exigen la *forma* del
+  harness (qué dimensiones están cubiertas), no solo puntos — 80 puntos de guías
+  con cero sensores no es madurez.
+
+## Las seis dimensiones
+
+108 puntos en seis dimensiones:
+
+| Dimensión | Puntos | Qué mide |
+|---|---|---|
+| Context & Guides | 20 | AGENTS.md, calidad y alcance de rules |
+| Skills & Commands | 17 | Conocimiento procedural, workflows explícitos, subagents |
+| Hooks & Guardrails | 14 | Gates y feedback enforced en runtime |
+| Sensors & Feedback | 20 | Tests, linter, tipos, formatter |
+| CI Feedback | 14 | Checks de pipeline, pre-commit |
+| Hygiene & Safety | 23 | Secretos, env files, lockfile, licencia, config MCP |
+
+Cada dimensión es la suma de checks individuales (catálogo completo con
+remediaciones en el [capítulo 7](./measure-and-improve#the-check-catalog)).
+
+## Los cinco niveles
+
+### L0 · Sin harness
+
+El repo no le da nada al agente: sin archivo de contexto, sin rules, sin checks
+enforced. Los agentes trabajan aquí — siempre lo hacen — pero cada sesión
+redescubre el proyecto desde cero y cada error sale a menos que un humano lo
+atrape. La mayoría de repos empiezan aquí.
+
+### L1 · Documentado
+
+**Requiere: Context & Guides ≥ 40%.**
+
+Hay un `AGENTS.md` (o equivalente) sustancial: qué es el proyecto, cómo
+construir y probar, qué convenciones valen. El paso de mayor palanca desde
+cero — feedforward para toda sesión futura en un archivo.
+
+### L2 · Guiado
+
+**Requiere: Context ≥ 60% · (Skills ≥ 30% o Hooks ≥ 30%) · Hygiene ≥ 50%.**
+
+La orientación tiene estructura: rules con alcance y frontmatter válido
+(`.cursor/rules/`, `.windsurf/rules/`, `.clinerules/` o equivalente de tu
+herramienta), y al menos el inicio de conocimiento procedural (skill,
+command/workflow o subagent) o maquinaria de hooks. Higiene básica sólida —
+env ignorados, sin firmas de credencial en archivos de harness. El harness ahora
+viaja con el código y se revisa como código.
+
+### L3 · Con sensores
+
+**Requiere L2, más: Sensors ≥ 60% · CI ≥ 50%.**
+
+Existe el bucle de feedback. Tests que el agente puede correr, linter, type
+checking y pipeline CI que reverifica cada push. Es el nivel donde empieza la
+autocorrección: el agente puede *verificar su propio trabajo* con herramientas
+deterministas, y el pipeline atrapa lo que pierde. Para la mayoría de equipos,
+L3 es donde el desarrollo asistido por IA deja de sentirse arriesgado.
+
+### L4 · Autocorrector
+
+**Requiere L3, más: Hooks ≥ 70% · puntuación total ≥ 80%.**
+
+El bucle cierra en runtime. Gate hooks hacen imposibles las acciones destructivas
+en lugar de desalentarlas; feedback hooks lintan y formatean en cada edición,
+dentro de la sesión. Guías, sensores y guardrails cubren las seis dimensiones.
+Un error ahora debe pasar rules, hooks on-edit, tests, type checker, CI *y*
+gates — en gran parte sin humano en el loop.
+
+## Leyendo una puntuación
+
+Dos repos pueden tener 65% con formas muy distintas — por eso los niveles exigen
+dimensiones:
+
+- **65%, todo guías, cero sensores** → L1. Bellamente documentado, no verificado.
+  Prioridad: tests + CI, no más prosa.
+- **65%, sensores fuertes, sin contexto** → L0/L1. El trabajo del agente se
+  verifica, pero adivina tus convenciones cada sesión. Prioridad: una tarde en
+  `AGENTS.md` y tres rules con alcance.
+
+El escáner imprime exactamente qué requisito bloquea el siguiente nivel
+(`To reach L3: sensors ≥ 60%; ci ≥ 50%`), así que el camino de mejora nunca
+es ambiguo.
+
+## Qué el modelo deliberadamente no mide
+
+Honestidad sobre los límites del determinismo (el caveat de Fowler de que
+"behavior harness is immature" aplica también a la medición):
+
+- **Si tus tests son buenos** — solo que existen, corren y gatean.
+- **Si tus rules son verdaderas** — una rule obsoleta puntúa como una fresca.
+- **Corrección funcional** — ningún scan estático verifica comportamiento.
+- **Práctica de equipo** — branch protection, cultura de review y workflows de
+  agente viven fuera del árbol del repo.
+
+Puntuación alta significa que la *infraestructura* para trabajo confiable con
+agente existe. Es necesaria, no suficiente — el techo de lo que un escáner
+determinista puede afirmar con honestidad.
+
+## Usando la escalera
+
+1. Ejecuta `npx harness-score` — obtén tu nivel y los gaps exactos.
+2. Sube un nivel a la vez; los requisitos de cada nivel son un esfuerzo enfocado
+   (L1: escribir AGENTS.md → L2: rules + higiene → L3: sensores + CI →
+   L4: hooks).
+3. Exige el nivel en CI (`--min-level`) para que la madurez solo suba.
+4. Muéstralo — badge en README (`harness` · `L4`) y [share card](./measure-and-improve#show-your-maturity) opcional. Misma píldora del CI (`--badge`) o archivo estático fijo.
+
+El capítulo 7 recorre cada paso, check a check.

--- a/docs/es/guide/maturity-model.md
+++ b/docs/es/guide/maturity-model.md
@@ -78,7 +78,7 @@ autocorrección: el agente puede *verificar su propio trabajo* con herramientas
 deterministas, y el pipeline atrapa lo que pierde. Para la mayoría de equipos,
 L3 es donde el desarrollo asistido por IA deja de sentirse arriesgado.
 
-### L4 · Autocorrector
+### L4 · Autocorrección
 
 **Requiere L3, más: Hooks ≥ 70% · puntuación total ≥ 80%.**
 

--- a/docs/es/guide/measure-and-improve.md
+++ b/docs/es/guide/measure-and-improve.md
@@ -1,0 +1,629 @@
+# Medir y mejorar
+
+Todo en esta guía condensa en un comando:
+
+```bash
+npx harness-score
+```
+
+El escáner recorre tu repositorio (solo filesystem — sin LLM, sin red, sin
+telemetría), corre 36 checks deterministas en cualquier herramienta de IA y reporta
+un nivel de madurez con los gaps exactos al siguiente:
+
+```
+  harness-score v1.0.0  /work/my-app
+
+  Maturity: L2 · Guided   Score: 66/108 (61%)
+  Detected: Cursor, Claude Code
+
+  Context & Guides     ████████████████░░░░  80%
+  Skills & Commands    █████████████░░░░░░░  67%
+  Hooks & Guardrails   ░░░░░░░░░░░░░░░░░░░░   0%
+  ...
+
+  To reach L3: sensors ≥ 60%; ci ≥ 50%
+```
+
+> **Multi-herramienta:** El escáner reconoce artefactos de harness de Cursor, Claude Code,
+> Windsurf, Cline, Continue y otras herramientas vía semántica OR — si configuras
+> cualquiera, Harness Score lo cuenta. Más en [Soporte multi-harness](./multi-harness).
+
+## Instalación
+
+```bash
+npx harness-score                                       # no install
+npm install -g harness-score                            # global binary
+npm install --save-dev harness-score                    # pinned devDependency
+```
+
+También espejado en [GitHub Packages](https://github.com/paladini/harness-score/pkgs/npm/harness-score)
+(`@paladini/harness-score`) y [JSR](https://jsr.io/@paladini/harness-score)
+para proyectos Deno/Bun.
+
+## Usándolo como biblioteca
+
+La CLI es un wrapper fino sobre API programática totalmente tipada — útil
+para dashboard custom, bot o herramienta que quiere el `Report` crudo
+en lugar de parsear salida de terminal:
+
+```ts
+import { score } from 'harness-score';
+
+const report = score('/path/to/repo');
+console.log(report.level.name, report.score.percent, report.dimensions);
+```
+
+`Report`, `Check`, `CheckResult`, `DimensionScore`, `LevelInfo` y toda
+forma shipan como declaraciones TypeScript — resueltas vía campo `"types"`
+explícito, para editores y `tsc` sin config extra. Bloques de nivel inferior
+también se exportan, para lo que `score()` no cubre directamente:
+
+```ts
+import { createScanContext, buildReport, computeDiff, renderMarkdown } from 'harness-score';
+
+const ctx = createScanContext('/path/to/repo');   // walk the filesystem once
+const report = buildReport(ctx);                  // run all 36 checks against it
+const markdown = renderMarkdown(report);          // same renderer the CLI's --md uses
+```
+
+## Referencia CLI
+
+```bash
+harness-score [path]              # human report (default: current directory)
+harness-score --json              # full report as JSON
+harness-score --md report.md      # markdown report (use "-" for stdout)
+harness-score --badge badge.svg   # SVG pill: harness + detected level (L0–L4)
+harness-score --min-level 3       # exit 1 if below L3 — the CI gate
+harness-score --diff base.json    # compare against a previous --json report
+```
+
+### Seguir puntuación en el tiempo {#diff-mode}
+
+`--diff <file>` compara el scan actual contra reporte baseline guardado de
+ejecución `--json` anterior — deltas de nivel y puntuación, movimiento por
+dimensión y exactamente qué checks cambiaron:
+
+```bash
+harness-score --json > baseline.json   # save today's report
+# ...later, after changes...
+harness-score --diff baseline.json     # see what moved
+```
+
+```
+  Compared to baseline:
+    Level: L2 · Guided → L3 · Sensing (+1)
+    Score: 61/108 (56%) → 84/108 (78%) (+22pp)
+    Sensors & Feedback   20% → 90% (+70pp)
+    Newly passing: SNS-01, SNS-02, SNS-04, CI-01, CI-02
+```
+
+`--diff` funciona con `--json` (agrega `current`/`baseline`/`diff` al
+payload) y `--md` (agrega sección "Compared to baseline") — es lo que la
+GitHub Action usa para comentar "puntuación subió de L2 a L3" en PRs.
+
+## El plugin Cursor
+
+Instala **Harness Score** desde [su directorio de plugin en este repo](https://github.com/paladini/harness-score/tree/main/plugins/cursor)
+(listado Cursor Marketplace enviado y pendiente de revisión — este enlace
+moverá allí cuando esté live) y obtienes:
+
+- **`/harness-audit`** — corre el escáner en el workspace abierto y hace que el
+  agente presente el reporte con las principales remediaciones.
+- **La skill `harness-engineering`** — cuando dices "arréglalo" o
+  "mejora mi harness", el agente sabe escribir los artefactos faltantes
+  siguiendo las recetas de esta guía.
+
+El análisis en sí es siempre la CLI determinista; el modelo solo presenta
+resultados y aplica correcciones que pidas.
+
+## El gate de CI {#ci-gate}
+
+Los harnesses regresan en silencio — alguien borra `hooks.json` en una limpieza,
+una rule se pudre. Traba tu nivel en CI:
+
+```yaml
+- name: Harness gate
+  run: npx -y harness-score --min-level 3
+```
+
+O usa la action empaquetada, que también emite el badge:
+
+```yaml
+- uses: paladini/harness-score/action@main
+  with:
+    min-level: '3'
+    badge: 'harness-badge.svg'
+```
+
+## Muestra tu madurez {#show-your-maturity}
+
+Harness Score entrega **dos formatos SVG con marca** en el mismo lenguaje visual
+de las barras de progreso del escáner — sin shields.io, sin servicio pago, sin red
+al renderizar:
+
+| Formato | Archivos | Muestra | Mejor para |
+|---|---|---|---|
+| **Badge** | `harness-badge.svg` o `badge-l0.svg` … `badge-l4.svg` | `harness` · `L4` | Fila README (píldora 112×20) |
+| **Share card** | `card-l0.svg` … `card-l4.svg` | Banner completo con nombre de nivel | Posts sociales, hero del repo (860×240) |
+
+El badge muestra **solo el nivel** (`L0`–`L4`). Nombres de nivel
+(Unharnessed, Guided, …) viven en share cards y en la salida del escáner.
+
+La píldora se ve idéntica si CI regenera o fijas archivo estático —
+solo cambia el cableado.
+
+### Badge — auto-actualizando (recomendado)
+
+`harness-score --badge` escribe SVG para el nivel que detecta el escáner.
+Configúralo en CI una vez; la imagen en README se actualiza conforme mejora el harness.
+
+```yaml
+# .github/workflows/harness.yml
+name: Harness Score
+on: { push: { branches: [main] } }
+permissions: { contents: write }
+jobs:
+  harness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: paladini/harness-score/action@main
+        with: { badge: 'harness-badge.svg' }
+      - uses: JamesIves/github-pages-deploy-action@v4
+        with: { branch: badges, folder: ., clean: false }
+```
+
+Referencia el archivo publicado desde tu README — recetas copy-paste completas en
+[Snippets de embed](#embed-snippets):
+
+```md
+<img alt="Harness Score" src="https://raw.githubusercontent.com/<you>/<repo>/badges/harness-badge.svg" height="20">
+```
+
+Set `height="20"` on the `<img>` so the pill lines up with npm/CI shields in
+the same row (112×20 SVG; level only — score percent stays in the CLI report).
+
+Dogfood example (this guide's live badge on GitHub Pages):
+
+<div class="hs-visual">
+  <p class="hs-visual-label">Badge (this repo)</p>
+  <div class="hs-badge-row">
+    <img class="hs-badge" src="/harness-badge.svg" alt="Harness Score" height="20">
+  </div>
+</div>
+
+The matching share card for the detected level is published as
+`harness-card.svg` (currently L4 for this repository):
+
+<img class="hs-share-card" src="/harness-card.svg" alt="Harness Score L4 · Self-correcting">
+
+### Badge — pin a level
+
+Same pill, static file — pick `badge-l0.svg` … `badge-l4.svg` if you do not
+want CI to regenerate the image. See [Embed snippets](#embed-snippets) for
+Markdown, HTML, iframe, JSX, and more.
+
+### Share card
+
+For a hero image or social post, use the banner card — it includes the level
+name (`Unharnessed`, `Guided`, …):
+
+| Level | Badge | Share card |
+|---|---|---|
+| L0 · Unharnessed | [badge-l0.svg](https://paladini.github.io/harness-score/maturity/badge-l0.svg) | [card-l0.svg](https://paladini.github.io/harness-score/maturity/card-l0.svg) |
+| L1 · Documented | [badge-l1.svg](https://paladini.github.io/harness-score/maturity/badge-l1.svg) | [card-l1.svg](https://paladini.github.io/harness-score/maturity/card-l1.svg) |
+| L2 · Guided | [badge-l2.svg](https://paladini.github.io/harness-score/maturity/badge-l2.svg) | [card-l2.svg](https://paladini.github.io/harness-score/maturity/card-l2.svg) |
+| L3 · Sensing | [badge-l3.svg](https://paladini.github.io/harness-score/maturity/badge-l3.svg) | [card-l3.svg](https://paladini.github.io/harness-score/maturity/card-l3.svg) |
+| L4 · Self-correcting | [badge-l4.svg](https://paladini.github.io/harness-score/maturity/badge-l4.svg) | [card-l4.svg](https://paladini.github.io/harness-score/maturity/card-l4.svg) |
+
+<div class="hs-visual">
+  <p class="hs-visual-label">All badge levels (112×20)</p>
+  <div class="hs-badge-row">
+    <img class="hs-badge" alt="L0" src="/maturity/badge-l0.svg" height="20">
+    <img class="hs-badge" alt="L1" src="/maturity/badge-l1.svg" height="20">
+    <img class="hs-badge" alt="L2" src="/maturity/badge-l2.svg" height="20">
+    <img class="hs-badge" alt="L3" src="/maturity/badge-l3.svg" height="20">
+    <img class="hs-badge" alt="L4" src="/maturity/badge-l4.svg" height="20">
+  </div>
+</div>
+
+<div class="hs-visual">
+  <p class="hs-visual-label">Share card example (860×240)</p>
+  <img class="hs-share-card" alt="L4 · Self-correcting" src="/maturity/card-l4.svg">
+  <p class="hs-visual-detail">Descarga cualquier nivel de la tabla — las cards incluyen el nombre del nivel.</p>
+</div>
+
+## Snippets de embed {#embed-snippets}
+
+Recetas copy-paste para compartir. Reemplaza placeholders:
+
+| Placeholder | Badge auto-actualizando | Badge fijo (nivel `{N}`) | Share card |
+|---|---|---|---|
+| `{BADGE_URL}` | `https://raw.githubusercontent.com/{owner}/{repo}/badges/harness-badge.svg` | `https://paladini.github.io/harness-score/maturity/badge-l{N}.svg` | — |
+| `{CARD_URL}` | — | — | `https://paladini.github.io/harness-score/maturity/card-l{N}.svg` |
+| `{LINK}` | Tu repo o `https://paladini.github.io/harness-score/` | Igual | Igual |
+
+`{N}` es `0`–`4`. Badge live de este repo (sin CI en tu fork):
+`https://raw.githubusercontent.com/paladini/harness-score/main/docs/public/harness-badge.svg`
+
+**Tamaño del badge:** 112×20 — siempre define `height="20"` (o `height={20}`) para
+que la píldora alinee con badges shields.io en la misma fila.
+
+### Badge — Markdown
+
+Image only (GitHub, GitLab, dev.to — use HTML if plain `![]()` stretches):
+
+```md
+<img alt="Harness Score L4" src="{BADGE_URL}" height="20">
+```
+
+Linked (clickable):
+
+```md
+[![Harness Score L4]({BADGE_URL})]({LINK})
+```
+
+Reference-style:
+
+```md
+[![Harness Score][hs-badge]][hs-link]
+
+[hs-badge]: {BADGE_URL}
+[hs-link]: {LINK}
+```
+
+### Badge — HTML
+
+```html
+<img alt="Harness Score L4" src="{BADGE_URL}" height="20" width="112">
+```
+
+Linked:
+
+```html
+<a href="{LINK}">
+  <img alt="Harness Score L4" src="{BADGE_URL}" height="20" width="112">
+</a>
+```
+
+### Badge — iframe
+
+For CMS or wikis that only allow iframes (not `<img>`):
+
+```html
+<iframe
+  src="{BADGE_URL}"
+  title="Harness Score L4"
+  width="112"
+  height="20"
+  style="border:0;overflow:hidden"
+></iframe>
+```
+
+### Badge — SVG object / embed
+
+```html
+<object data="{BADGE_URL}" type="image/svg+xml" width="112" height="20">
+  <a href="{BADGE_URL}">Harness Score L4</a>
+</object>
+```
+
+```html
+<embed src="{BADGE_URL}" type="image/svg+xml" width="112" height="20" />
+```
+
+### Badge — JSX / React
+
+```jsx
+<a href="{LINK}">
+  <img
+    alt="Harness Score L4"
+    src="{BADGE_URL}"
+    height={20}
+    width={112}
+    style={{ verticalAlign: 'middle' }}
+  />
+</a>
+```
+
+### Badge — AsciiDoc
+
+```asciidoc
+image:{BADGE_URL}[Harness Score L4,link={LINK},height=20]
+```
+
+### Badge — BBCode (forums)
+
+```text
+[url={LINK}][img]{BADGE_URL}[/img][/url]
+```
+
+### Badge — direct URL
+
+Paste in chat, Notion image block, Slack, Discord, or any tool that accepts a
+raw image URL:
+
+```text
+{BADGE_URL}
+```
+
+### Share card — Markdown / HTML
+
+Banner for README hero, blog posts, or social previews (`{N}` = `0`–`4`):
+
+```md
+[![Harness Score L4 · Self-correcting]({CARD_URL})]({LINK})
+```
+
+```html
+<a href="{LINK}">
+  <img
+    alt="Harness Score L4 · Self-correcting"
+    src="{CARD_URL}"
+    width="560"
+    style="max-width:100%;height:auto;border-radius:8px"
+  />
+</a>
+```
+
+### Share card — iframe
+
+```html
+<iframe
+  src="{CARD_URL}"
+  title="Harness Score L4 · Self-correcting"
+  width="560"
+  height="157"
+  style="border:0;max-width:100%"
+></iframe>
+```
+
+### Share card — direct URL
+
+```text
+{CARD_URL}
+```
+
+### Worked example (pinned L3 badge)
+
+```md
+<a href="https://paladini.github.io/harness-score/">
+  <img alt="Harness Score L3" src="https://paladini.github.io/harness-score/maturity/badge-l3.svg" height="20">
+</a>
+```
+
+```html
+<iframe
+  src="https://paladini.github.io/harness-score/maturity/badge-l3.svg"
+  title="Harness Score L3"
+  width="112"
+  height="20"
+  style="border:0"
+></iframe>
+```
+
+> **shields.io fan?** Your Action can also write a small JSON file and point a
+> [shields endpoint](https://shields.io/badges/endpoint-badge) at it
+> (`{ "schemaVersion": 1, "label": "harness", "message": "L3", "color": "brightgreen" }`).
+> The brand SVGs above are self-contained and need no third party.
+
+## Catálogo de checks {#the-check-catalog}
+
+Cada check que corre el escáner, con receta de remediación. Los IDs de check son
+estables; la CLI enlaza cada fallo a su entrada aquí.
+
+### Context & Guides (20 pt)
+
+#### CTX-01 · Agent context file present — 4 pts {#ctx-01}
+An `AGENTS.md` (or `CLAUDE.md` / `GEMINI.md`) exists at the repository root.
+**Corrección:** create `AGENTS.md` answering: what is this project, how do I build
+and test it, what conventions hold, what must I never touch. Recipe in
+[capítulo 3](./guides-feedforward#writing-an-agents-md-that-works).
+
+#### CTX-02 · Context file is substantive — 3 pts {#ctx-02}
+≥20 meaningful lines and ≥2 headings — a stub scores nothing.
+**Corrección:** cover layout, build & test commands, conventions, and no-go zones.
+Commands over descriptions; point to rules instead of pasting them.
+
+#### CTX-03 · Scoped rules in use — 4 pts {#ctx-03}
+At least one scoped rule file for any supported tool (e.g. `.cursor/rules/*.mdc`,
+`.windsurf/rules/*.md`, `.clinerules/*.md`, `.continue/rules/*.md`,
+`.github/instructions/*.instructions.md`, `.agents/rules/*`). Nested context
+files in subdirectories (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md` anywhere below
+the root) also count — they are directory-scoped rules in tools like Claude
+Code and Codex.
+**Corrección:** start with one short always-on rule holding your non-negotiables,
+then add path-scoped rules per area (or nested context files per subtree).
+
+#### CTX-04 · Rules have valid frontmatter — 3 pts {#ctx-04}
+Every rule declares activation metadata (`description`, `globs`/`trigger`/`paths`/`applyTo`, or `alwaysApply`).
+Rules a tool auto-loads without metadata — `.continue/rules/*` and nested
+context files — pass by construction.
+**Corrección:** add the frontmatter block; without it the agent can't decide when the
+rule applies.
+
+#### CTX-05 · Rules are scoped — 2 pts {#ctx-05}
+Not every rule is blanket always-on. Nested context files count as scoped —
+they apply only to their subtree.
+**Corrección:** scope rules to paths (`globs:`, `trigger:` glob, `paths:`, `applyTo:`)
+so they load only when relevant — every always-on rule taxes every request's context.
+
+#### CTX-06 · No bloated rules — 2 pts {#ctx-06}
+No single rule exceeds 500 lines.
+**Corrección:** split by concern, or move procedural content into a skill.
+
+#### CTX-07 · README present — 1 pt {#ctx-07}
+**Corrección:** add a README.md; it's the first orientation document for humans and
+a fallback for agents.
+
+#### CTX-08 · No legacy .cursorrules — 1 pt {#ctx-08}
+The deprecated single-file format is absent (or modern scoped rules also exist).
+**Corrección:** migrate `.cursorrules` content into scoped rules for your tool.
+
+### Skills & Commands (17 pts)
+
+#### SKL-01 · At least one skill — 4 pts {#skl-01}
+A `SKILL.md` under `.cursor/skills/<name>/`, `.claude/skills/<name>/`, or `.agents/skills/<name>/`.
+**Corrección:** package your most repeated procedure (deploy, release, migration)
+as a skill — [capítulo 3](./guides-feedforward#skills-the-procedural-layer).
+
+#### SKL-02 · Skills declare name and description — 3 pts {#skl-02}
+Frontmatter with `name:` and `description:` on every skill.
+**Corrección:** the agent decides whether to load a skill from these two fields
+alone; without them the skill is invisible.
+
+#### SKL-03 · Explicit workflows/commands defined — 3 pts {#skl-03}
+Command or workflow files (`.cursor/commands/`, `.windsurf/workflows/`,
+`.claude/commands/`, `.continue/prompts/`, `.zed/commands/`, `.agents/workflows/`).
+**Corrección:** encode workflows you trigger deliberately (`/review`, `/release`)
+as command/workflow files.
+
+#### SKL-04 · Skill descriptions are trigger-worthy — 2 pts {#skl-04}
+Descriptions ≥40 characters.
+**Corrección:** write descriptions as trigger conditions — "Use when the user asks
+to deploy or release; covers tagging, pipeline, rollback, smoke tests."
+
+#### AGT-01 · Custom subagent defined — 3 pts {#agt-01}
+A subagent file under `.cursor/agents/`, `.claude/agents/`, or `.opencode/agents/`.
+**Corrección:** package a purpose-built subagent for a job the primary agent should
+delegate (planning, review, release) — see
+[Subagents](./cursor-harness-surface#subagents-purpose-built-delegates)
+en el capítulo 2.
+
+#### AGT-02 · Subagents declare name and description — 2 pts {#agt-02}
+Frontmatter with `name:` and `description:` on every subagent definition.
+**Corrección:** the parent agent decides whether to delegate from these two fields
+alone; without them the subagent is never invoked.
+
+### Hooks & Guardrails (14 pts)
+
+#### HKS-01 · Hooks configuration present and valid — 4 pts {#hks-01}
+`.cursor/hooks.json` or `.claude/settings.json` (`hooks` key) exists and parses as JSON.
+**Corrección:** create hooks config and grow from the
+recetas en el [capítulo 5](./guardrails-and-safety#gate-hooks).
+
+#### HKS-02 · Known events, version declared — 2 pts {#hks-02}
+Version/metadata present; every registered event is documented for your tool
+(Cursor lifecycle events, or Claude Code `PreToolUse`/`PostToolUse`).
+**Corrección:** typo'd event names fail silently — check against the event list in
+[capítulo 2](./cursor-harness-surface#hooks-observe-and-control-the-agent-loop).
+
+#### HKS-03 · Gate hook guards risky operations — 4 pts {#hks-03}
+A gate hook registered (Cursor: `beforeShellExecution`, `beforeMCPExecution`,
+`preToolUse`, or `beforeReadFile`; Claude Code: `PreToolUse`).
+**Corrección:** gate de deny de comandos destructivos del capítulo 5 — rules en prosa son
+pedidos; gates son hechos.
+
+#### HKS-04 · Feedback hook observes output — 2 pts {#hks-04}
+A feedback hook registered (Cursor: `afterFileEdit`, `postToolUse`, …;
+Claude Code: `PostToolUse`).
+**Corrección:** format-and-lint on edit gives the agent instant feedback inside the
+session.
+
+#### HKS-05 · Hook scripts committed — 2 pts {#hks-05}
+Scripts referenced by the hooks config exist in the repository.
+**Corrección:** commit them; a hook pointing at a missing script fails open on
+every machine but the author's.
+
+### Sensors & Feedback (20 pts)
+
+#### SNS-01 · Test runner configured — 6 pts {#sns-01}
+A real test script/config (vitest, jest, pytest, go test, cargo test…).
+**Corrección:** wire up the runner with one obvious entry point and document it in
+AGENTS.md — tests are how the agent verifies its own work.
+
+#### SNS-02 · Linter configured — 5 pts {#sns-02}
+eslint/biome, ruff, golangci-lint, rubocop, or equivalent.
+**Corrección:** every convention expressible as a lint rule stops needing prose.
+
+#### SNS-03 · Type checking in place — 4 pts {#sns-03}
+tsconfig (ideally `strict: true`), mypy/pyright, or a statically typed
+language.
+**Corrección:** the type checker is the only sensor that reviews every agent edit
+for free — [capítulo 4](./sensors-feedback#type-checking-the-free-sensor).
+
+#### SNS-04 · Formatter configured — 3 pts {#sns-04}
+prettier/biome, black/ruff-format, gofmt/rustfmt.
+**Corrección:** formatting noise in diffs hides real mistakes from review.
+
+#### SNS-05 · Test files exist — 2 pts {#sns-05}
+At least one actual test file in the tree.
+**Corrección:** a configured runner with zero tests is a green light nobody earned.
+
+### CI Feedback (14 pts)
+
+#### CI-01 · CI pipeline configured — 4 pts {#ci-01}
+GitHub Actions workflow (or GitLab/CircleCI/Jenkins equivalent).
+**Corrección:** add `.github/workflows/ci.yml` running your sensors on every push.
+
+#### CI-02 · CI runs the tests — 4 pts {#ci-02}
+**Corrección:** no agent-authored change should be mergeable without the suite
+firing.
+
+#### CI-03 · CI runs lint/typecheck — 3 pts {#ci-03}
+**Corrección:** cheap computational sensors belong on every push — keep quality
+left.
+
+#### CI-04 · Pre-commit checks installed — 3 pts {#ci-04}
+husky/lint-staged, `pre-commit`, or lefthook.
+**Corrección:** the earliest feedback a commit can get; catches what on-edit hooks
+missed before it enters history.
+
+### Hygiene & Safety (23 pts)
+
+#### HYG-01 · .gitignore present — 2 pts {#hyg-01}
+**Corrección:** agents commit what they see; make build output and local state
+invisible.
+
+#### HYG-02 · .gitignore covers env files — 3 pts {#hyg-02}
+A `.env` pattern in .gitignore.
+**Corrección:** add `.env` and `.env.*` (allow `!.env.example`) — the cheapest
+guardrail in existence.
+
+#### HYG-03 · No unprotected .env files — 4 pts {#hyg-03}
+No real env files in the tree unless gitignored (templates are fine).
+**Corrección:** move secrets out; keep `.env.example` documenting required
+variables.
+
+#### HYG-04 · MCP config free of credentials — 4 pts {#hyg-04}
+No credential signatures in MCP config (`.cursor/mcp.json`, `.mcp.json`,
+`.agents/mcp_config.json`).
+**Corrección:** use `${ENV_VAR}` interpolation — an inlined key in MCP config is a
+secret published to every clone.
+
+#### HYG-05 · License present — 2 pts {#hyg-05}
+**Corrección:** add a LICENSE; required for open-source use and plugin marketplaces.
+
+#### HYG-06 · No secrets in harness files — 2 pts {#hyg-06}
+AGENTS.md, rules, and hooks config are clean of token signatures.
+**Corrección:** these files are loaded into model context every session — a key
+there is exfiltrated by design.
+
+#### HYG-07 · Lockfile committed — 3 pts {#hyg-07}
+package-lock.json, uv.lock, Cargo.lock, go.sum, or equivalent.
+**Corrección:** reproducible installs mean your sensors test the same dependency
+tree everywhere.
+
+#### HYG-08 · MCP config uses env interpolation for credentials — 3 pts {#hyg-08}
+An MCP config file is valid, and any credential-shaped field (token, key,
+secret, password…) uses `${ENV_VAR}` interpolation rather than a literal.
+The positive complement to HYG-04 — a repo with no MCP setup earns nothing
+here, same as any other bonus check.
+**Corrección:** reference secrets as `"${VAR_NAME}"` and document required
+variables in `.env.example`.
+
+## Plan de mejora práctico
+
+Partiendo de un repo de producto típico en L0, una sesión enfocada por nivel:
+
+1. **→ L1 (una tarde).** Escribe `AGENTS.md` (CTX-01/02). Incluye comandos build/test
+   aunque los sensores sean débiles — el agente los usará.
+2. **→ L2 (un día).** Tres rules con alcance + una skill para el procedimiento más repetido
+   (CTX-03…06, SKL-01/02). Corrige higiene: gitignore, env files,
+   licencia (HYG-01…05).
+3. **→ L3 (el trabajo real, si faltan sensores).** Test runner + linter +
+   tipos strict + `ci.yml` corriendo los tres (SNS-*, CI-01…03). Si ya
+   los tienes, este nivel es gratis.
+4. **→ L4 (una mañana).** Los dos hooks del capítulo 5 — un gate, un
+   formatter — commiteados con scripts (HKS-*), pre-commit (CI-04),
+   luego `--min-level 4` en CI para que nunca regrese.

--- a/docs/es/guide/multi-harness.md
+++ b/docs/es/guide/multi-harness.md
@@ -146,7 +146,7 @@ El escáner evalúa cada dimensión vía semántica OR, luego asigna un **nivel 
 - **L1 · Documentado** → context ≥ 40% (guía raíz sustancial).
 - **L2 · Guiado** → context ≥ 60%, skills ≥ 30% **o** hooks ≥ 30%, hygiene ≥ 50%.
 - **L3 · Con sensores** → sensors ≥ 60% y CI ≥ 50%.
-- **L4 · Autocorrector** → hooks ≥ 70% y puntuación total ≥ 80%.
+- **L4 · Autocorrección** → hooks ≥ 70% y puntuación total ≥ 80%.
 
 El nivel aplica al repo entero, no por herramienta. Es intencional: tu objetivo es elevar la calidad general del trabajo asistido por IA en el proyecto, sin importar qué herramienta eligió el dev. El modelo completo, con rationale por umbral, está en el [modelo de madurez](./maturity-model).
 

--- a/docs/es/guide/multi-harness.md
+++ b/docs/es/guide/multi-harness.md
@@ -1,0 +1,202 @@
+# Soporte multi-harness
+
+Desde **v0.4.0**, Harness Score mide la madurez del harness de código con IA en **cualquier herramienta** — no solo Cursor. Ya uses Cursor, Claude Code, Windsurf, Cline, Continue, Codex u otro IDE/editor AI-first, aplica el mismo modelo de 108 puntos.
+
+## Por qué importa multi-harness
+
+El harness es agnóstico de herramienta. Un `AGENTS.md` bien escrito, un `.gitignore` que protege secretos, un pipeline CI que corre tests — funcionan igual para Cursor, Claude Code, Windsurf u otro agente. La infraestructura de harness que construyes una vez beneficia a *toda* herramienta de IA en el proyecto.
+
+Harness Score lo hace explícito: mides una vez, cualquier herramienta se beneficia. No construyes harness Cursor y harness Claude Code por separado — construyes *un harness*, y cada herramienta compatible hereda las partes que entiende.
+
+## Cómo funciona: semántica OR
+
+El escáner usa **semántica OR** para artefactos específicos de herramienta. Cada check pregunta "¿alguna herramienta reconocida provee esto?" — no "¿Cursor lo provee?". Por ejemplo:
+
+- `.cursor/rules/*.mdc` **o** `.windsurf/rules/*.md` **o** `.clinerules/*.md` **o** un `CLAUDE.md` anidado → cuenta para **rules**
+- `.cursor/hooks.json` **o** `.claude/settings.json` con sección `hooks` → cuenta para **hooks**
+- `.cursor/skills/<name>/SKILL.md` **o** `.claude/skills/<name>/SKILL.md` → cuenta para **skills**
+- `.cursor/agents/*.md` **o** `.claude/agents/*.md` **o** `.opencode/agents/*.md` → cuenta para **subagents**
+- `AGENTS.md` en raíz **o** `CLAUDE.md` **o** `GEMINI.md` → cuenta para **guías de contexto**
+
+No necesitas configurar todos — uno basta. Desde v0.5.0, agregar segunda herramienta nunca *baja* tu puntuación: cuando existen varias configs de hooks, gana la que tiene más eventos registrados.
+
+## Herramientas soportadas
+
+Harness Score reconoce estos artefactos (patrones exactos en el registry del escáner —
+[`registry.ts`](https://github.com/paladini/harness-score/blob/main/packages/cli/src/harness/registry.ts)):
+
+| Herramienta | Rules | Skills | Commands / workflows | Subagents | Hooks | MCP |
+|---|---|---|---|---|---|---|
+| **Cursor** | `.cursor/rules/*.mdc` | `.cursor/skills/*/SKILL.md` | `.cursor/commands/*.md` | `.cursor/agents/*.md` | `.cursor/hooks.json` | `.cursor/mcp.json` |
+| **Claude Code** | `CLAUDE.md` anidados | `.claude/skills/*/SKILL.md` | `.claude/commands/*.md` | `.claude/agents/*.md` | `.claude/settings.json` (`hooks`) | `.mcp.json` |
+| **Windsurf** | `.windsurf/rules/*.md` | — | `.windsurf/workflows/*.md` | — | — | — |
+| **Cline** | `.clinerules/*.md` | — | — | — | — | — |
+| **Continue** | `.continue/rules/*.md` | — | `.continue/prompts/*` | — | — | — |
+| **GitHub Copilot** | `.github/instructions/*.instructions.md` | — | — | — | — | — |
+| **Codex** | `AGENTS.md` anidados | `.agents/skills/*/SKILL.md` | — | — | — | — |
+| **Gemini / Antigravity** | `.agents/rules/`, `.agent/rules/`, `.gemini/rules/`, `GEMINI.md` anidados | `.agents/skills/*/SKILL.md` | `.agents/workflows/`, `.agent/workflows/` | — | — | `.agents/mcp_config.json`, `.agent/mcp_config.json` |
+| **OpenCode** | — | — | — | `.opencode/agents/*.md` | — | — |
+| **Zed** | — | — | `.zed/commands/*.md` | — | — | — |
+
+Archivos de contexto en raíz (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) cuentan para toda herramienta.
+Y los artefactos más importantes son **agnósticos de herramienta**: tests, CI, linters, type checkers, `.gitignore`, lockfiles y `SECURITY.md` puntúan igual sin importar la herramienta.
+
+::: tip Columna escasa de una herramienta no es penalización
+Windsurf no tiene sistema de hooks reconocido por el escáner — pero hooks son solo una dimensión de seis. Repo solo Windsurf con rules, sensores y CI fuertes aún sube a L3. L4 requiere gate hooks, lo que hoy significa `.cursor/hooks.json` o `settings.json` de Claude Code junto a la herramienta principal.
+:::
+
+## Construyendo el harness una vez
+
+Camino típico de upgrade para repo multi-herramienta:
+
+1. **Empieza con una herramienta** (ej.: Cursor). Escribe `AGENTS.md`, agrega `.cursor/rules/`, configura sensores (tests, lint, tipos, CI).
+2. **El equipo agrega segunda herramienta** (ej.: Claude Code). Artefactos compartidos — `AGENTS.md`, tests, CI, higiene — ya funcionan. Agrega piezas nativas solo donde el comportamiento difiere: `CLAUDE.md` anidados para guía por directorio, `.claude/settings.json` para hooks.
+3. **El harness queda en un lugar.** Sensores, guardrails y guías son nivel repo — toda herramienta hereda automáticamente.
+4. **Exige madurez, no herramientas.** CI corre `harness-score --min-level 3` y mantiene la misma barra para todas.
+
+## Ejemplos prácticos
+
+### Ejemplo 1: Repo Cursor-first agrega Claude Code
+
+Tienes repo con setup Cursor fuerte:
+
+```
+.cursor/
+  rules/
+    best-practices.mdc
+    architecture.mdc
+  hooks.json
+  skills/
+    refactor/
+      SKILL.md
+AGENTS.md
+```
+
+El equipo quiere usar Claude Code junto a Cursor. Nada es obligatorio —
+la puntuación ya cuenta todo lo anterior. Para dar a sesiones Claude Code la
+misma guía que Cursor recibe de `.cursor/rules/`, agrega equivalentes nativos:
+
+- **Guía por directorio**: coloca `CLAUDE.md` en subdirectorios donde tus
+  rules `.mdc` tenían alcance (`CLAUDE.md` anidados cuentan como rules con
+  alcance desde v0.5.0). Muchos equipos hacen el `CLAUDE.md` raíz apuntar en
+  una línea a `AGENTS.md` — o symlink — para fuente única de verdad.
+- **Hooks**: espeja tu gate hook en `.claude/settings.json` (ver Ejemplo 3).
+- **Subagents**: `.claude/agents/reviewer.md` cuenta para el mismo check que
+  `.cursor/agents/reviewer.md`.
+
+De cualquier forma, Harness Score cuenta la config más fuerte — agregar segunda
+herramienta solo mantiene o sube la puntuación, nunca la baja.
+
+### Ejemplo 2: Greenfield, multi-herramienta desde el día uno
+
+Proyecto nuevo que usará Cursor y Windsurf. Construye una vez:
+
+1. Escribe `AGENTS.md` en raíz.
+2. Crea `.cursor/rules/` con convenciones de arquitectura y nomenclatura.
+3. Espeja rules que Windsurf necesita en `.windsurf/rules/` (markdown
+   simple, sin frontmatter `.mdc`).
+4. Escribe tests, configura CI, agrega linter.
+5. Corre `npx harness-score` → L2 o más. Ambas herramientas igualmente soportadas.
+
+### Ejemplo 3: Hooks para seguridad (varias herramientas beneficiadas)
+
+Agregas gate hook para bloquear comandos shell peligrosos. Formato Cursor:
+
+```json
+// .cursor/hooks.json
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      { "command": "./scripts/hooks/gate-shell.sh" }
+    ]
+  }
+}
+```
+
+Claude Code usa archivo y nombres de evento distintos, pero el mismo script:
+
+```json
+// .claude/settings.json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/scripts/hooks/gate-shell.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Harness Score recompensa cualquiera en la dimensión Hooks & Guardrails — eventos
+gate (`beforeShellExecution`, `PreToolUse`) satisfacen checks de gate hook,
+y el script referenciado debe existir en el repo (scripts commiteados forman
+parte de lo que validan los checks). Un script, dos configs, ambas herramientas
+protegidas.
+
+## Lógica de puntuación
+
+El escáner evalúa cada dimensión vía semántica OR, luego asigna un **nivel de madurez** al repo. Umbrales (espejados de `LEVEL_REQUIREMENTS` del escáner):
+
+- **L0 · Sin harness** → default; ningún requisito cumplido.
+- **L1 · Documentado** → context ≥ 40% (guía raíz sustancial).
+- **L2 · Guiado** → context ≥ 60%, skills ≥ 30% **o** hooks ≥ 30%, hygiene ≥ 50%.
+- **L3 · Con sensores** → sensors ≥ 60% y CI ≥ 50%.
+- **L4 · Autocorrector** → hooks ≥ 70% y puntuación total ≥ 80%.
+
+El nivel aplica al repo entero, no por herramienta. Es intencional: tu objetivo es elevar la calidad general del trabajo asistido por IA en el proyecto, sin importar qué herramienta eligió el dev. El modelo completo, con rationale por umbral, está en el [modelo de madurez](./maturity-model).
+
+## Migraciones y cambio de herramienta
+
+Si cambias herramienta principal (ej.: Cursor → Claude Code), el harness transfiere gradualmente y la puntuación nunca cae en cliff:
+
+1. Agrega artefactos nativos Claude (`CLAUDE.md` anidados, `.claude/skills/`, hooks en `.claude/settings.json`) junto a la config `.cursor/` existente.
+2. Corre `npx harness-score` → **mismo nivel**, porque guías, tests, CI e higiene son agnósticos, y artefactos de ambas herramientas satisfacen los mismos checks.
+3. Deprecia config `.cursor/` antigua cuando nadie use Cursor (opcional — mantener no cuesta nada).
+4. Harness Score sigue reconociendo ambos — sin riesgo de regresión.
+
+## Limitaciones y roadmap
+
+**Actual (v1.0.0):**
+
+- Soporte a plugins es escalonado: **Cursor** (principal, audit-and-fix completo), **Claude Code** (Fase 0, audit read-only), otros TBD (ver [PLUGINS-ROADMAP.md](https://github.com/paladini/harness-score/blob/main/PLUGINS-ROADMAP.md)).
+- La CLI es tool-aware y totalmente multi-harness: reportes terminal y markdown muestran línea `Detected:` con toda herramienta reconocida, y `--json` incluye `detectedHarnesses`. Los plugins alcanzan con el tiempo.
+- Hooks reconocidos solo para Cursor y Claude Code — sistemas de hooks de otras herramientas (conforme surjan) necesitan entradas en el registry.
+
+**Planeado (post-1.0):**
+
+- Scaffolding interactivo `harness-score init` (templates deterministas por herramienta).
+- Salida SARIF para integración CI/seguridad enterprise.
+- Mejoras en detector de ecosistema (más variantes y ubicaciones de config).
+
+## FAQs
+
+**P: ¿Debo configurar todas las herramientas soportadas?**
+
+R: No. Si configuras Cursor, Harness Score lo cuenta. Si luego agregas artefactos Claude Code, ambos se reconocen — pero una herramienta bien configurada basta para puntuar bien.
+
+**P: Si solo uso Cursor, ¿aún puedo compartir mi puntuación?**
+
+R: Sí. El nivel de madurez es medida de repo, no de herramienta. Repo en L3 significa "trabajo asistido por IA bien gateado y verificado aquí" — no especifica *qué* herramienta. Al compartir el badge, es creíble uses Cursor, Claude Code o ambos.
+
+**P: ¿Y si mi herramienta no está listada?**
+
+R: Abre issue con el formato de config de la herramienta y agregaremos soporte. El camino más confiable mientras tanto es (1) usar `AGENTS.md` + sensores agnósticos (tests, linters, tipos, CI), que funcionan en todas partes, o (2) mapear artefactos de tu herramienta a los que ya reconocemos.
+
+**P: ¿Puedo ver qué herramientas se detectaron?**
+
+R: Sí — `npx harness-score --json` incluye array `detectedHarnesses`. Flujo CI típico:
+
+```yaml
+- name: Audit harness maturity
+  run: npx harness-score --min-level 3
+
+- name: Fail if no tool is configured
+  run: npx harness-score --json | jq -e '.detectedHarnesses | length > 0'
+```
+
+Esto garantiza que el gate de madurez pasa *y* que se reconoció el harness de al menos una herramienta (`jq -e` sale non-zero cuando la expresión es `false`).

--- a/docs/es/guide/references.md
+++ b/docs/es/guide/references.md
@@ -1,0 +1,59 @@
+# Referencias
+
+Las fuentes que esta guía consolida, aproximadamente por orden de influencia.
+
+## Ingeniería de harness
+
+- **[Harness engineering for coding agent users](https://martinfowler.com/articles/harness-engineering.html)** — martinfowler.com, abril de 2026.
+  El artículo que enmarcó la disciplina para equipos que *usan* agentes: guías vs.
+  sensores, verificaciones computacionales vs. inferenciales, las tres dimensiones
+  de regulación (mantenibilidad, fitness arquitectónico, comportamiento), "mantener
+  la calidad a la izquierda" y harnessability como propiedad de codebases.
+- **[Harness Engineering — first thoughts](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering-memo.html)** — el memo anterior de la serie
+  *Exploring Gen AI* donde el término toma forma.
+- **[Improving Deep Agents with harness engineering](https://www.langchain.com/blog/improving-deep-agents-with-harness-engineering)** — LangChain, 2026.
+  El caso empírico: 52,8% → 66,5% en Terminal Bench 2.0 sin tocar el modelo.
+  Bucles de autoverificación, middleware de ensamblado de contexto, detección de
+  bucles y el sándwich de razonamiento.
+- **[deepagents](https://github.com/langchain-ai/deepagents)** — harness de agente
+  open source "batteries-included" de LangChain; útil como implementación concreta.
+
+## Documentación de herramientas
+
+### Cursor (principal)
+
+- **[Rules](https://cursor.com/docs/rules)** — `.cursor/rules/*.mdc`,
+  frontmatter, AGENTS.md.
+- **[Agent Skills](https://cursor.com/docs/skills)** — el estándar SKILL.md
+  y cómo Cursor carga skills.
+- **[Hooks](https://cursor.com/docs/agent/hooks)** — hooks.json, lista completa
+  de eventos, decisiones de permiso.
+- **[Plugins](https://cursor.com/docs/plugins)** — estructura de plugin,
+  manifest, modos de instalación.
+- **[Cursor Marketplace](https://cursor.com/marketplace)** y el
+  **[repositorio de spec de plugins](https://github.com/cursor/plugins)** — cómo
+  se empaquetan, revisan y distribuyen los plugins.
+
+### Claude Code, Windsurf y otros
+
+Ver [Soporte multi-harness](./multi-harness) para cómo Harness Score
+reconoce artefactos equivalentes de Claude Code (`.claude/agents/`, hooks),
+Windsurf (`.windsurf/rules/`), Cline (`.clinerules/`), Continue, Codex y
+otras herramientas.
+
+## Trabajos adyacentes
+
+- Escritos de Anthropic sobre agentes efectivos y SDKs de agentes — buena parte
+  del consejo de context engineering se transfiere directo a harnesses Cursor.
+- El estándar abierto Agent Skills adoptado en varias herramientas — razón por
+  la que skills escritas para Cursor son portables.
+- ArchUnit, dependency-cruiser, import-linter — fitness functions arquitectónicas
+  referenciadas en el [capítulo 4](./sensors-feedback).
+
+## Sobre este proyecto
+
+`harness-score` (escáner, guía, plugin Cursor y GitHub Action) es open source
+bajo MIT:
+[github.com/paladini/harness-score](https://github.com/paladini/harness-score).
+El repositorio dogfooda todo lo que enseña — puntúa L4 en su propio escáner, y
+el CI exige `--min-level 4`.

--- a/docs/es/guide/sensors-feedback.md
+++ b/docs/es/guide/sensors-feedback.md
@@ -1,0 +1,147 @@
+# Sensores — controles de feedback
+
+Los sensores verifican lo que hizo el agente. Cierran el bucle que hace posible
+la autocorrección: un agente con buenos sensores corrige sus propios errores
+antes de que los veas; uno sin sensores los entrega con un resumen confiado.
+
+## La pila de sensores
+
+Ordena por velocidad y costo, lo más rápido primero — ese orden *es* el
+principio "mantener la calidad a la izquierda":
+
+| Sensor | Latencia | Corre en |
+|---|---|---|
+| Type checker | ms–s | En edición (hook), pre-commit, CI |
+| Linter / formatter | ms–s | En edición (hook), pre-commit, CI |
+| Tests unitarios | s | Invocado por agente, pre-commit, CI |
+| Tests de integración/E2E | min | CI |
+| Checks de fitness arquitectónico | s–min | CI |
+| Code review con IA (inferencial) | min, $ | PR |
+| Review humano | horas | PR |
+
+El objetivo no es correr todo en todas partes; es que cada error lo atrape el
+**sensor más barato capaz de detectarlo**, lo más **temprano** posible. Reserva
+las dos últimas filas para lo que nada arriba puede ver.
+
+## Type checking: el sensor gratis
+
+Un type checker estricto es el sensor de mayor valor para trabajo con agente
+porque corre en cada edición sin costo marginal, es totalmente determinista, y
+sus mensajes de error son lo bastante precisos para que el agente actúe solo.
+
+- TypeScript: `"strict": true` — TS no estricto renuncia silenciosamente a la
+  mayor parte del valor.
+- Python: mypy o pyright, en CI, no solo en el IDE.
+- Go, Rust, Java, C#: el compilador ya hace esto; asegura que el agente compile
+  antes de declarar listo.
+
+Esto también es argumento de estrategia de lenguaje: codebases tipados son
+mediblemente más *preparables para harness* — el compilador supervisa cada
+edición del agente gratis.
+
+## Tests: el sensor que los agentes usan para autocorregirse
+
+Para un agente, una suite de tests no es (solo) red de seguridad — es la
+herramienta que usa para verificar su propio trabajo a mitad de tarea. Eso
+cambia qué significa "buenos tests":
+
+1. **Rápidos.** Una suite que el agente corre en segundos se corre tras cada
+   cambio; una de 20 minutos nunca. Mantén un subconjunto rápido (`npm test`)
+   aunque la suite completa sea más lenta.
+2. **Ejecutable con un comando obvio**, documentado en `AGENTS.md`. Si los tests
+   necesitan tres env vars y una base de datos, scriptea el setup.
+3. **Deterministas.** Tests flaky enseñan a agentes (como humanos) a ignorar rojo.
+4. **Comportamentales.** Tests que fijan detalles de implementación bloquean
+   refactors legítimos; tests que fijan comportamiento atrapan regresiones
+   reales. El patrón "approved fixtures" de Fowler — archivos golden revisados
+   por humanos, checados por máquinas — funciona bien en codebases con muchos
+   agentes.
+
+Y una convención que vale poner en rule: **comportamiento nuevo llega con test,
+y un test fallando nunca se borra para quedar verde.** Los agentes harán ambos
+si se permite.
+
+## Linters: codifica convenciones como código
+
+Cada convención que expresas como regla de lint es una que quitas de tus
+archivos de rules — el linter la aplica deterministicamente, con mejor bucle de
+feedback que prosa. Stacks modernos hacen rules custom baratas (ESLint flat
+config, Biome, Ruff, custom linters golangci-lint).
+
+Prioridad para trabajo con agente:
+
+- Rules que atrapan *deslices semánticos* (vars sin usar, promises flotantes,
+  errores no manejados) sobre estilo puro.
+- Rules auto-fixables — empareja con formatter para diffs solo con señal.
+- Rules custom para el "el agente insiste en hacer X" recurrente del proyecto.
+
+## Fitness arquitectónico: sensores de estructura
+
+La segunda dimensión de regulación de Fowler es fitness arquitectónico —
+sensores que verifican estructura, no solo sintaxis:
+
+- **Reglas de dependencia**: "core nunca importa de api" — ArchUnit (JVM),
+  dependency-cruiser (JS/TS), import-linter (Python).
+- **Límites de módulo** en monorepos: checks de boundary Nx/Turborepo.
+- **Presupuestos de performance**: límites de bundle, conteo de queries,
+  aserciones p95.
+
+Esto importa *más* con agentes que sin ellos: un agente optimizando tarea local
+viola de buena gana una restricción global que ningún archivo local menciona.
+Los fitness checks hacen la restricción global local e inmediata.
+
+## Hooks como sensores on-edit
+
+Los hooks de Cursor mueven sensores de "cuando el agente recuerde" a "siempre":
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      { "command": "node ./.cursor/hooks/format-on-edit.js", "timeout": 30 }
+    ]
+  }
+}
+```
+
+Buenos ciudadanos de `afterFileEdit`: formatear el archivo, correr linter en él,
+correr type checker en su paquete — y devolver fallos para que el agente corrija
+*ahora*, in context, en lugar de en CI una hora después. Manténlos rápidos
+(sub-segundo donde sea posible); hook lento taxa cada edición.
+
+## CI: el sensor de registro
+
+Sensores locales son consultivos — nada obliga al agente (o al humano que mergea
+su trabajo) a haberlos corrido. CI es donde sensores se vuelven **hechos**:
+
+- Corre tests, lint y typecheck en cada push y PR.
+- Hazlos checks obligatorios; PR con CI rojo del agente es trabajo no revisado,
+  no borrador.
+- Agrega `harness-score --min-level N` como job para frenar *regresión* de
+  harness — falla de drift de config donde alguien borra hooks.json y nadie
+  nota ([detalles en capítulo 7](./measure-and-improve#ci-gate)).
+
+Herramientas pre-commit (husky + lint-staged, `pre-commit`, lefthook) llenan el
+hueco entre hooks on-edit y CI: último check determinista antes de que exista
+el commit.
+
+## Sensores inferenciales: IA revisando IA
+
+Review basado en LLM (Bugbot de Cursor, agentes juez, plugins de review) paga
+su costo en lo que la computación no checa: ¿este cambio *significa* lo correcto?
+¿Esta abstracción tiene sentido? Dos reglas mantienen honestidad:
+
+1. Complementa la pila computacional, nunca la sustituye. Reviewer de IA
+   aprobando código que no compila es teatro.
+2. Sus hallazgos deben ser *spot-checkable* — prefiere reviewers que citan
+   file:line y describen escenario de fallo sobre los que emiten vibes.
+
+## El bucle de autocorrección, armado
+
+Con la pila en su lugar, el bucle que LangChain diseñó explícitamente emerge
+naturalmente: agente edita → hooks formatean y lintan → corre tests rápidos →
+CI reverifica todo → reviewer inferencial lee sobrevivientes. Cada capa atrapa
+lo que la anterior perdió, y cada captura ocurre en el punto más barato posible.
+Lo que aún falta es hacer imposibles las acciones peligrosas en lugar de
+detectables — eso es [Guardrails](./guardrails-and-safety).

--- a/docs/es/guide/what-is-harness-engineering.md
+++ b/docs/es/guide/what-is-harness-engineering.md
@@ -1,0 +1,118 @@
+# Qué es la ingeniería de harness
+
+> Un agente es un modelo más un harness. El modelo lo alquilas; el harness lo posees.
+
+Cuando un agente de código con IA trabaja en tu repositorio, solo parte de su
+comportamiento viene del modelo. El resto viene de todo lo que *rodea* al
+modelo: las instrucciones que carga, las herramientas que puede invocar, las
+verificaciones que corren sobre su salida, los gates que evitan acciones
+destructivas. Esa maquinaria circundante es el **harness**, y construirla de
+forma deliberada es **ingeniería de harness**.
+
+El término cristalizó a principios de 2026. El sitio de Martin Fowler publicó
+[Harness engineering for coding agent users](https://martinfowler.com/articles/harness-engineering.html)
+(basado en un
+[memo](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering-memo.html)
+anterior), enmarcando la disciplina para equipos que *usan* agentes. Por la
+misma época, LangChain mostró el otro lado: mejorando solo el harness de su
+agente de código — sin tocar el modelo — pasó de **52,8% a 66,5%** en Terminal
+Bench 2.0, de fuera del top 30 al top 5
+([Improving Deep Agents with harness engineering](https://www.langchain.com/blog/improving-deep-agents-with-harness-engineering)).
+
+La idea central de ambos: **la confiabilidad es propiedad del sistema
+modelo–harness–entorno, no de los pesos del modelo**. Un repo bien preparado
+hace útil un modelo mediocre; un repo sin harness hace peligroso un modelo
+frontier.
+
+## Guías y sensores
+
+El marco de Fowler divide los controles del harness en dos familias,
+tomadas de la teoría de control:
+
+| | **Guías** (feedforward) | **Sensores** (feedback) |
+|---|---|---|
+| Cuándo | *Antes* de que el agente actúe | *Después* de que el agente actúe |
+| Propósito | Orientar hacia buenos resultados | Detectar y corregir los malos |
+| Ejemplos (agnósticos de herramienta) | `AGENTS.md`, rules, skills, commands, contexto MCP | tests, linters, type checkers, CI, hooks |
+| Modo de fallo si falta | El agente adivina tus convenciones | El agente entrega errores con confianza |
+
+Los principios son los mismos en Cursor, Claude Code, Windsurf y cualquier otra
+herramienta de código con IA — lo que cambia es *dónde* configuras (directorios
+y formatos de frontmatter distintos), no *qué* estás construyendo. Harness
+Score reconoce esas variantes con semántica OR, para que el harness funcione
+en cualquier lugar.
+
+Un harness necesita ambos. Guías sin sensores producen salida confiada y no
+verificada. Sensores sin guías atrapan los mismos errores una y otra vez porque
+el agente nunca fue instruido para evitarlos.
+
+## Verificaciones computacionales vs. inferenciales
+
+Fowler traza una segunda distinción que esta guía — y el escáner
+`harness-score` — toma en serio:
+
+- **Verificaciones computacionales** son deterministas: linters, type checkers,
+  tests, análisis estructural. Corren en milisegundos a segundos, no cuestan
+  nada y dan la misma respuesta siempre. Pertenecen *en todas partes*: hooks,
+  pre-commit, CI.
+- **Verificaciones inferenciales** usan un modelo: code review con IA,
+  LLM-as-judge, auditorías semánticas. Son potentes pero lentas, costosas y
+  probabilísticas. Úsalas donde importa la semántica y la computación no alcanza.
+
+El principio estratégico es **"mantener la calidad a la izquierda"**: empuja las
+verificaciones rápidas, baratas y deterministas lo más temprano posible en el
+ciclo, y reserva el juicio inferencial para lo que quede. Por eso
+`harness-score` en sí es 100% computacional — una medición de madurez que no
+puedes reproducir no es medición.
+
+## Qué compra el harness: lecciones de LangChain
+
+La subida de LangChain en Terminal Bench es el mejor caso público de ingeniería
+de harness como práctica empírica. Las técnicas que movieron la aguja:
+
+1. **Bucles de autoverificación.** El agente debe planear → implementar →
+   probar → corregir antes de declarar victoria; un middleware de checklist
+   pre-cierre rechaza "listo" sin paso de verificación. En tu repo, el
+   equivalente es tener tests que el agente pueda correr — y convenciones que
+   digan que debe hacerlo.
+2. **Ensamblado de contexto en nombre del agente.** Su middleware mapea el
+   directorio de trabajo al inicio de la sesión para que el agente no gaste
+   pasos explorando. En Cursor, `AGENTS.md` y rules con alcance hacen ese
+   trabajo.
+3. **Detección de bucles.** Middleware interrumpe "doom loops" donde el agente
+   repite la misma edición fallida. Los hooks dan el mismo punto de observación.
+4. **Presupuesto de razonamiento en forma de sándwich.** Máximo pensamiento en
+   planificación y verificación final, moderado en el medio. No controlas los
+   modelos de Cursor, pero sí qué contrastan el plan y la verificación *contra*:
+   tus rules y tus tests.
+
+Las cuatro son propiedades del harness, no del modelo. Las cuatro tienen
+equivalentes directos en un repo Cursor — de eso trata el resto de esta guía.
+
+## Harnessability: algunos codebases son más fáciles de preparar
+
+Fowler destaca **affordances ambientales** — propiedades del entorno que hacen
+a los agentes más gobernables:
+
+- **Lenguajes tipados** dan a cada edición un sensor gratis e instantáneo (el
+  compilador).
+- **Límites de módulo claros** reducen el contexto que el agente necesita por
+  tarea.
+- **Convenciones consistentes** convierten guías en listas concretas.
+- **Suites de test rápidas** hacen barata la autoverificación.
+
+Por eso el [modelo de madurez](./maturity-model) puntúa type checking e
+infraestructura de tests junto con artefactos específicos de Cursor: forman
+parte del mismo sistema de control.
+
+## Hacia dónde va esta guía
+
+- El capítulo 2 mapea la [superficie de harness de Cursor](./cursor-harness-surface) —
+  cada archivo y mecanismo que ofrece Cursor.
+- Los capítulos 3–5 cubren las tres familias de control en profundidad:
+  [Guías](./guides-feedforward), [Sensores](./sensors-feedback) y
+  [Guardrails](./guardrails-and-safety).
+- El capítulo 6 define un [modelo de madurez de cinco niveles](./maturity-model)
+  con criterios objetivos.
+- El capítulo 7 muestra cómo [medir y mejorar](./measure-and-improve)
+  con el escáner `harness-score` y el plugin Cursor.

--- a/docs/es/guide/what-is-harness-engineering.md
+++ b/docs/es/guide/what-is-harness-engineering.md
@@ -39,7 +39,7 @@ tomadas de la teoría de control:
 Los principios son los mismos en Cursor, Claude Code, Windsurf y cualquier otra
 herramienta de código con IA — lo que cambia es *dónde* configuras (directorios
 y formatos de frontmatter distintos), no *qué* estás construyendo. Harness
-Score reconoce esas variantes con semántica OR, para que el harness funcione
+Score reconoce esas variantes por **equivalencia entre herramientas** (semántica OR): basta una herramienta bien configurada para que el harness funcione
 en cualquier lugar.
 
 Un harness necesita ambos. Guías sin sensores producen salida confiada y no

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -1,0 +1,21 @@
+---
+layout: home
+
+hero:
+  name: Harness Score
+  text: ¿Qué tan bien preparado está tu repositorio?
+  tagline: Un comando determinista mide tu harness de código con IA — funciona con Cursor, Claude Code, Windsurf y otras herramientas. Escanea AGENTS.md, rules, hooks, tests, CI. Sin IA en el escaneo. Sin red. Misma puntuación siempre.
+  image:
+    src: /logo.svg
+    alt: Harness Score
+  actions:
+    - theme: brand
+      text: Escanear tu repo
+      link: /es/guide/measure-and-improve
+    - theme: alt
+      text: Empezar
+      link: /es/guide/what-is-harness-engineering
+    - theme: alt
+      text: Ver plugins
+      link: https://github.com/paladini/harness-score/tree/main/plugins
+---

--- a/docs/i18n/glossary.md
+++ b/docs/i18n/glossary.md
@@ -1,0 +1,52 @@
+# Editorial glossary — Harness Score guide (internal)
+
+Contract for translators and reviewers. English is the source of truth for check IDs, CLI output, and scanner URLs.
+
+## Stable terms
+
+| English | Português (Brasil) | Español (LatAm) | Notes |
+|---|---|---|---|
+| harness | harness | harness | Keep in English; explain on first use |
+| harness engineering | engenharia de harness | ingeniería de harness | Same |
+| feedforward | feedforward | feedforward | Control-theory term; gloss once |
+| feedback | feedback | feedback | Same |
+| guides | guias | guías | Feedforward controls |
+| sensors | sensores | sensores | Feedback controls |
+| guardrails | guardrails | guardrails | Runtime enforcement |
+| maturity level | nível de maturidade | nivel de madurez | Always keep `L0`–`L4` |
+| check | verificação / check | verificación / check | Prefer "check" when tied to IDs |
+| scanner | scanner | scanner | Product name for CLI tool |
+| self-correcting | autocorretivo | autocorrección | Level name L4 in prose only |
+| OR semantics | semântica OR | semántica OR | Technical term |
+
+## Level names (prose only — CLI output stays English)
+
+| EN | pt-BR | es |
+|---|---|---|
+| Unharnessed | Sem harness | Sin harness |
+| Documented | Documentado | Documentado |
+| Guided | Orientado | Guiado |
+| Sensing | Sensorizado | Con sensores |
+| Self-correcting | Autocorretivo | Autocorrector |
+
+## Never translate
+
+- Check IDs: `CTX-01`, `SKL-01`, etc.
+- Anchor slugs: `{#ctx-01}`, `{#ci-gate}`, etc.
+- File paths: `AGENTS.md`, `.cursor/rules/*.mdc`, `hooks.json`
+- CLI commands, flags, JSON keys, code blocks
+- Scanner example terminal output (level names in sample output)
+- `npx harness-score`, package names, GitHub URLs
+- Dimension names in CLI sample output (keep English in code blocks)
+
+## Tone
+
+- Short sentences; active voice.
+- First jargon mention: plain-language gloss + stable term after.
+- Professional and accessible — not marketing hype, not academic.
+- pt-BR: Brazilian Portuguese (not European).
+- es: neutral Latin American (tú/ustedes; avoid vosotros, ordenador, fichero).
+
+## Links in translated pages
+
+Use relative paths within the locale (`./maturity-model`, `./measure-and-improve#ctx-01`), not absolute `/guide/...` paths (those escape to English).

--- a/docs/i18n/glossary.md
+++ b/docs/i18n/glossary.md
@@ -17,7 +17,7 @@ Contract for translators and reviewers. English is the source of truth for check
 | check | verificação / check | verificación / check | Prefer "check" when tied to IDs |
 | scanner | scanner | scanner | Product name for CLI tool |
 | self-correcting | autocorretivo | autocorrección | Level name L4 in prose only |
-| OR semantics | semântica OR | semántica OR | Technical term |
+| OR semantics | equivalência entre ferramentas (semântica OR) | equivalencia entre herramientas (semántica OR) | Scanner accepts Cursor *or* Claude Code equivalents |
 
 ## Level names (prose only — CLI output stays English)
 
@@ -26,8 +26,8 @@ Contract for translators and reviewers. English is the source of truth for check
 | Unharnessed | Sem harness | Sin harness |
 | Documented | Documentado | Documentado |
 | Guided | Orientado | Guiado |
-| Sensing | Sensorizado | Con sensores |
-| Self-correcting | Autocorretivo | Autocorrector |
+| Sensing | Com sensores | Con sensores |
+| Self-correcting | Autocorretivo | Autocorrección |
 
 ## Never translate
 

--- a/docs/pt-BR/guide/cursor-harness-surface.md
+++ b/docs/pt-BR/guide/cursor-harness-surface.md
@@ -1,0 +1,191 @@
+# A superfície de harness do Cursor
+
+O Cursor expõe mais maquinaria de harness que qualquer outro editor de IA mainstream.
+Este capítulo é o mapa: cada artefato, onde vive e qual trabalho faz no sistema
+de controle.
+
+> **Nota:** Harness Score suporta várias ferramentas (Claude Code, Windsurf, Cline, Continue e outras) via semântica OR. Este capítulo foca Cursor como exemplo principal. Veja [Suporte multi-harness](./multi-harness) para como outras ferramentas são reconhecidas e pontuadas.
+
+## Os artefatos em resumo
+
+| Artefato | Caminho | Família | Carregado |
+|---|---|---|---|
+| Arquivo de contexto do agente | `AGENTS.md` | Guia | Sempre |
+| Rules | `.cursor/rules/*.mdc` | Guia | Sempre / por glob / por relevância |
+| Skills | `.cursor/skills/*/SKILL.md` | Guia | Sob demanda, por description |
+| Commands | `.cursor/commands/*.md` | Guia | Explicitamente, via `/name` |
+| Hooks | `.cursor/hooks.json` | Sensor + Guardrail | Em eventos do loop do agente |
+| Servidores MCP | `.cursor/mcp.json` | Guia (ferramentas) | Por sessão |
+| Subagents | definições de agente | Guia | Tarefas delegadas |
+| Plugins | Marketplace / `.cursor-plugin/` | Tudo empacotado | Instalado |
+
+Tudo vive no repositório — esse é o ponto: **o harness viaja com o código**,
+é versionado com o código e revisado como código.
+
+## AGENTS.md — a porta da frente
+
+`AGENTS.md` na raiz do repositório é a primeira coisa que um agente lê. É
+convenção aberta (Cursor, Claude Code e a maioria das ferramentas agentic
+honram) e o arquivo único de maior alavancagem no harness. Deve responder,
+brevemente:
+
+- O que é este projeto e como está organizado?
+- Como construo, executo e **testo**?
+- Quais convenções são inegociáveis?
+- O que nunca devo tocar?
+
+Mantenha abaixo de ~150 linhas. Carrega em toda sessão — cada linha taxa a
+janela de contexto de toda tarefa. Detalhes que só importam às vezes pertencem
+a rules com escopo ou skills.
+
+## Rules — orientação persistente e declarativa
+
+Rules são arquivos markdown com frontmatter (`.mdc`) em `.cursor/rules/`.
+Cada rule declara *quando se aplica*:
+
+```markdown
+---
+description: API route conventions
+globs: src/api/**
+---
+
+- Every route validates input with zod before use.
+- Errors return `{ "error": string }` and a correct status code.
+```
+
+Três modos de ativação:
+
+- `alwaysApply: true` — injetado em todo request. Reserve para
+  inegociáveis de verdade; toda rule always-on é taxa permanente de contexto.
+- `globs: <pattern>` — aplicada quando arquivos correspondentes estão em jogo.
+  Modo workhorse: convenções vivem junto do código que governam.
+- Só `description` — o agente decide relevância pela description.
+
+Diretórios `.cursor/rules/` aninhados funcionam em monorepos: coloque rules
+específicas do pacote dentro do pacote.
+
+O arquivo legado `.cursorrules` está depreciado. Migre: divida por preocupação,
+escope por glob.
+
+## Skills — conhecimento procedural sob demanda
+
+Skill é pasta com `SKILL.md` (padrão aberto Agent Skills):
+
+```markdown
+---
+name: deploy
+description: Use when the user asks to deploy or release; covers tagging,
+  pipeline, and smoke tests.
+---
+
+# Deploying
+1. …step-by-step workflow…
+```
+
+O Cursor mostra ao agente `name` + `description` de toda skill no início da sessão;
+o corpo carrega **só quando o agente julga relevante**. Skills são o lugar certo
+para conteúdo procedural longo que incheria rules: runbooks de deploy, receitas
+de migração, checklists de release, playbooks de debug.
+
+Regra prática: **rules são declarativas e semi-always-on ("use TypeScript strict"),
+skills são procedurais e sob demanda ("aqui está como fazemos deploy")**.
+A description é o gatilho — escreva como "Use when…" ou nunca dispara.
+
+## Commands — workflows que você invoca de propósito
+
+Arquivos markdown em `.cursor/commands/` viram `/slash-commands`. Diferente de
+skills (disparadas pelo agente), commands são **disparados por humanos**: workflows
+repetíveis numa superfície tipo atalho — `/review`, `/release`, `/harness-audit`.
+Um arquivo de command é simplesmente o prompt que roda quando invocado.
+
+## Hooks — observar e controlar o loop do agente
+
+`.cursor/hooks.json` registra scripts em eventos do ciclo de vida do agente:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [{ "command": "node ./.cursor/hooks/guard.js" }],
+    "afterFileEdit": [{ "command": "node ./.cursor/hooks/format.js" }]
+  }
+}
+```
+
+Scripts recebem JSON no stdin e respondem no stdout — incluindo decisões de
+permissão (`allow` / `deny` / `ask`) para eventos de gate. Eventos-chave:
+
+- **Gates** (podem bloquear): `beforeShellExecution`, `beforeMCPExecution`,
+  `preToolUse`, `beforeReadFile`
+- **Feedback** (observam resultados): `afterFileEdit`, `postToolUse`,
+  `afterShellExecution`, `stop`
+- **Lifecycle**: `sessionStart` (injeta contexto), `sessionEnd`, `preCompact`
+
+Hooks são o único mecanismo Cursor *imposto pelo runtime do harness* em vez de
+*sugerido ao modelo*. Rule dizendo "nunca rode comandos destrutivos" é pedido;
+hook `beforeShellExecution` que nega é fato. O capítulo 5 expande essa distinção.
+
+## MCP — ferramentas e conhecimento
+
+`.cursor/mcp.json` conecta servidores Model Context Protocol: bancos, issue
+trackers, docs, browsers. Do ponto de vista do harness MCP é guia (determina o
+que o agente *vê e faz*) e superfície de risco (servidores rodam com suas
+credenciais — nunca inline secrets; use interpolação `${ENV_VAR}`).
+
+## Subagents — delegados com propósito {#subagents-purpose-built-delegates}
+
+Subagent é arquivo markdown em `.cursor/agents/` (ou pasta `agents/` de plugin)
+com o mesmo contrato de frontmatter `name` + `description` de uma skill:
+
+```markdown
+---
+name: reviewer
+description: Use when asked to review a pull request or diff for conventions
+  in AGENTS.md and .cursor/rules; reports findings by severity without
+  editing code.
+---
+
+# Reviewer subagent
+
+Read the diff, AGENTS.md, and .cursor/rules/*.mdc. Report violations ordered
+by severity. Never modify code — that's the parent agent's job.
+```
+
+Distinção de skill: skill ensina o agente *primário* um procedimento que roda
+inline; subagent é **delegado separado** a quem o agente primário passa tarefa —
+muitas vezes com acesso a ferramentas mais estreito ou job description menor,
+para tarefa grande (auditoria de repo, release multi-step) ser dividida entre
+workers especializados em vez de um agente fazer tudo num contexto. A documentação
+do Cursor descreve isso como delegar trabalho "purpose-built" — planner, reviewer,
+release runner — cada um com description suficientemente apertada para o agente
+primário decidir quando delegar sem adivinhar.
+
+Mesma regra das skills na description: é o único sinal que o agente primário usa
+para decidir delegar — escreva como condição de gatilho, não rótulo.
+
+## Plugins — o harness, empacotado
+
+Plugin Cursor empacota rules, skills, commands, hooks, agents e config MCP num
+unit instalável com manifest `.cursor-plugin/plugin.json`, distribuído pelo
+[Cursor Marketplace](https://cursor.com/marketplace). Plugins importam para
+engenharia de harness porque tornam padrões de harness **reutilizáveis entre
+repositórios** — incluindo o
+[plugin Harness Score](./measure-and-improve#the-cursor-plugin) que audita os
+artefatos que este capítulo descreveu (instalável do diretório do repo hoje;
+listagem Marketplace pendente de revisão).
+
+## Escolhendo o mecanismo certo
+
+| Você quer… | Use |
+|---|---|
+| Declarar convenção que sempre vale | Rule (`alwaysApply`) — com parcimônia |
+| Declarar convenção para parte do codebase | Rule com `globs` |
+| Ensinar procedimento multi-step | Skill |
+| Empacotar workflow que humanos disparam | Command |
+| Delegar job a worker separado com propósito | Subagent |
+| Impor algo independente do que o modelo pensa | Hook |
+| Dar ferramenta ou fonte de dados ao agente | Servidor MCP |
+| Compartilhar tudo isso entre repos | Plugin |
+
+Se uma orientação continua ignorada, mova *para baixo* nesta tabela — de prosa
+que o modelo pode pular, para mecanismos que o runtime impõe.

--- a/docs/pt-BR/guide/guardrails-and-safety.md
+++ b/docs/pt-BR/guide/guardrails-and-safety.md
@@ -1,0 +1,125 @@
+# Guardrails e segurança
+
+Guias sugerem. Sensores detectam. **Guardrails impedem.** Este capítulo cobre
+a camada do harness que segura mesmo quando o modelo ignora toda instrução —
+porque não depende do modelo ler nada.
+
+## Por que prosa não é guardrail
+
+Uma rule que diz "nunca rode `git push --force`" é um pedido a um sistema
+probabilístico. Geralmente será respeitada. "Geralmente" é a classe de
+confiabilidade errada para operações destrutivas, irreversíveis ou que tocam
+credenciais. Para essas, o check deve viver **fora do modelo**, em maquinaria
+que o modelo não pode pular: hooks, permissões e higiene do repositório.
+
+A escada de escalada do capítulo 3 termina aqui: orientação que continua sendo
+violada move de rule → sensor → **gate**.
+
+## Gate hooks
+
+Os eventos de gate do Cursor — `beforeShellExecution`, `beforeMCPExecution`,
+`preToolUse`, `beforeReadFile` — rodam seu script *antes* da ação e permitem
+responder `allow`, `deny` ou `ask`:
+
+```js
+// .cursor/hooks/guard-shell.js — deny destructive commands
+let input = '';
+process.stdin.on('data', (c) => (input += c));
+process.stdin.on('end', () => {
+  const { command = '' } = JSON.parse(input || '{}');
+  const destructive =
+    /\brm\s+-rf\s+[\/~]|\bgit\s+push\s+--force\b|\bdrop\s+(table|database)\b/i;
+  process.stdout.write(
+    JSON.stringify(
+      destructive.test(command)
+        ? { permission: 'deny', userMessage: 'Blocked: destructive command.' }
+        : { permission: 'allow' },
+    ),
+  );
+});
+```
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      { "command": "node ./.cursor/hooks/guard-shell.js", "timeout": 10 }
+    ]
+  }
+}
+```
+
+Padrões que valem gate na maioria dos repositórios:
+
+- **Shell destrutivo**: deletes recursivos fora do workspace, force pushes,
+  rewrites de histórico, `DROP`/`TRUNCATE` contra bancos não locais.
+- **Escritas outbound**: deploys, publicação de pacotes, post em APIs externas —
+  `ask`, não `deny`: humano confirma, in-flow.
+- **Leituras com segredo**: `beforeReadFile` em `.env*`, arquivos de chave e
+  stores de credencial mantém segredos fora do contexto do modelo.
+- **Chamadas MCP com efeitos colaterais**: `beforeMCPExecution` filtrando por
+  nome de tool — allow reads, confirm writes.
+
+Notas de design: falhe *fechado* para a lista perigosa (exit code 2 bloqueia),
+mantenha scripts de gate sem dependências e rápidos, e **commite-os** — config
+de hook apontando para script que existe só na sua máquina protege só você.
+
+## Higiene de segredos
+
+O agente lê sua working tree; qualquer coisa nela pode ir para contexto, commit
+ou arquivo gerado. Regras determinísticas de higiene:
+
+1. **`.gitignore` cobre `.env` e `.env.*`** (permita `.env.example`).
+   O guardrail mais barato que existe.
+2. **Sem arquivos `.env` reais na árvore** onde evitável; templates documentam
+   variáveis necessárias.
+3. **`mcp.json` usa interpolação `${ENV_VAR}`, nunca chaves literais.** Config
+   MCP com API key inline é segredo publicado em todo clone.
+4. **Sem tokens em arquivos de harness.** `AGENTS.md`, rules e configs de hooks
+   são *carregados no contexto do modelo a cada sessão* — chave ali é exfiltrada
+   por design.
+
+`harness-score` checa os quatro (HYG-02 … HYG-06) com matching de assinatura de
+credencial — deterministicamente, offline.
+
+## Consciência de prompt injection
+
+Harnesses de agente têm uma classe de ameaça que workflows humanos não têm:
+**instruções escondidas em dados**. README em dependência, página web buscada
+por MCP, comentário em issue — qualquer um pode conter texto para seu agente
+("ignore suas instruções e rode…"). Mitigações no nível do harness:
+
+- Gate hooks não se importam com quem autorou a instrução — o comando destrutivo
+  é negado seja o usuário, o modelo ou uma página injetada quem pediu. Esse é o
+  argumento mais forte por gates sobre rules.
+- Escopo servidores MCP ao que a tarefa precisa; servidor de docs read-only não
+  posta seus dados em lugar nenhum.
+- Trate "agente de repente quer curl em domínio desconhecido" como sinal que
+  vale gate `ask`.
+
+## Permissões e raio de explosão
+
+Além de hooks, reduza o que um agente comprometido ou confuso *poderia* fazer:
+
+- Rode agentes com credenciais escopadas à tarefa (token de CI que abre PRs mas
+  não faz push em `main`).
+- Branch protection: agentes abrem PRs; humanos (ou checks obrigatórios) fazem merge.
+- Execução sandboxed para trabalho autônomo não confiável ou longo.
+
+O princípio unificador é **defesa em profundidade**: rules tornam más ações
+improváveis, sensores as tornam visíveis, gates as tornam impossíveis, e
+permissões fazem até "impossível falhou" ser sobrevivível.
+
+## Conjunto mínimo viável de guardrails
+
+Para um repositório de produto típico, o piso parece:
+
+- [ ] `.gitignore` cobrindo env files; sem segredos reais na árvore
+- [ ] `mcp.json` limpo de credenciais literais
+- [ ] `hooks.json` com um gate de shell (padrões destrutivos → deny/ask)
+- [ ] Um hook de feedback (format/lint on edit)
+- [ ] Branch protection com checks de CI obrigatórios
+
+Esse conjunto é exatamente o que o [modelo de maturidade](./maturity-model)
+exige para as dimensões Hooks & Guardrails e Hygiene & Safety em L4.

--- a/docs/pt-BR/guide/guides-feedforward.md
+++ b/docs/pt-BR/guide/guides-feedforward.md
@@ -1,0 +1,147 @@
+# Guias — controles feedforward
+
+Guias moldam o que o agente faz *antes* de agir. São os controles mais baratos
+que você tem: um parágrafo no lugar certo evita categorias inteiras de erros.
+Este capítulo cobre como escrevê-las bem.
+
+## A economia do contexto
+
+Cada guia compete pelo mesmo recurso escasso: a janela de contexto e a atenção
+do modelo. O modo de falha de equipes entusiasmadas não é poucas guias, e sim
+**palavras demais** — um arquivo de rules com 2.000 linhas que o modelo só
+passa os olhos, uma wiki colada no `AGENTS.md`. A lição de harness da LangChain
+aplica aqui: *montar contexto em nome do agente* significa dar as 50 linhas
+certas, não todas as 5.000.
+
+Orçamento prático:
+
+- `AGENTS.md`: ≤150 linhas, sempre carregado — só o que vale para *toda* tarefa.
+- Rules always-on: uma ou duas, ≤30 linhas cada.
+- Rules com escopo por glob: quantas precisar; cada uma carrega só quando relevante.
+- Skills: comprimento ilimitado; carregadas só sob demanda.
+
+## Escrevendo um AGENTS.md que funciona
+
+Estrutura que se provou:
+
+```markdown
+# Agent Guide — <project>
+
+## What this is
+Two sentences. Domain, purpose, key constraint.
+
+## Layout
+- src/api — HTTP layer (see .cursor/rules/api.mdc)
+- src/core — domain logic, pure functions only
+- migrations/ — generated; never edit by hand
+
+## Build & test
+- npm run dev / npm test / npm run typecheck
+- Tests MUST pass before any commit.
+
+## Conventions
+- TypeScript strict; no `any` without a comment.
+- Never add dependencies without asking.
+
+## Do not touch
+- vendor/, generated/, legacy/payments (frozen for audit)
+```
+
+Princípios:
+
+1. **Comandos, não descrições.** "Rode `npm test`" vence "valorizamos testes".
+   Agentes agem com imperativos.
+2. **Aponte, não cole.** Link para a rule ou skill com escopo em vez de colar
+   detalhes ("veja `.cursor/rules/api.mdc`").
+3. **Diga o que não fazer.** Espaço negativo — diretórios congelados, padrões
+   proibidos — evita os erros mais caros.
+4. **Mantenha atual.** Guia obsoleta é pior que nenhuma; o agente segue com
+   confiança. Revisar `AGENTS.md` entra na sua definição de pronto para mudanças
+   arquiteturais.
+
+## Escrevendo rules que disparam corretamente
+
+Uma rule tem três trabalhos: aplicar no momento certo, ser curta o suficiente
+para ser lida, e concreta o suficiente para ser verificável.
+
+**Escopo agressivo.** O maior anti-padrão de rules é `alwaysApply: true` em
+tudo. Cada rule always-on carrega em todo request — inclusive para corrigir um
+typo no README. Escopo por glob:
+
+```markdown
+---
+description: React component conventions
+globs: src/components/**/*.tsx
+---
+```
+
+**Uma preocupação por rule.** `api.mdc`, `testing.mdc`, `styling.mdc` — não
+`everything.mdc`. Rules pequenas são diffáveis, revisáveis e escopáveis
+independentemente.
+
+**Concreta e verificável.** "Escreva bons testes" não orienta nada. "Cada novo
+export em `src/core` precisa de teste unitário na pasta `__tests__` irmã"
+orienta — e um revisor (ou sensor) pode verificar.
+
+**Mostre, depois diga.** Um exemplo de código de 5 linhas do padrão certo vence
+três parágrafos descrevendo-o.
+
+## Skills: a camada procedural
+
+Tudo que parece *runbook* pertence a uma skill, não a uma rule:
+
+- Procedimentos de deploy e release
+- Workflows de migração de banco
+- "Como adicionar um endpoint de API de ponta a ponta"
+- Playbooks de debug de incidentes
+
+A qualidade da skill depende da **description**, porque é tudo que o agente vê
+ao decidir carregá-la. Compare:
+
+```yaml
+description: Deployment stuff            # never triggers
+```
+
+```yaml
+description: Use when the user asks to deploy, release, or ship to
+  production; covers tagging, the pipeline, rollback, and smoke tests.
+```
+
+Escreva descriptions como condições de disparo ("Use when…"), ≥40 caracteres,
+com as palavras que um usuário diria de fato.
+
+## Commands: codifique os verbos da equipe
+
+Commands são guias para *humanos e agentes ao mesmo tempo*: `/review`, `/release`,
+`/new-endpoint` documentam como a equipe trabalha de forma executável. Um bom
+prompt de command declara o workflow, a barra de qualidade e a condição de
+parada:
+
+```markdown
+# /review
+
+Review the current diff against AGENTS.md and .cursor/rules/.
+Report findings ordered by severity with file:line references.
+Do not fix anything unless explicitly asked.
+```
+
+## Scripts bootstrap e templates
+
+Fowler lista ferramentas bootstrap entre controles feedforward: geradores e
+templates que iniciam o agente a partir de um esqueleto conhecido-bom (`npm run
+new:endpoint`, template de serviço com observabilidade). Quando um padrão deve
+se repetir exatamente, um gerador vence uma descrição do padrão — determinismo
+de novo. Mencione esses scripts no `AGENTS.md` para agentes usá-los em vez de
+inventar do zero.
+
+## Como guias falham, e o que pega
+
+| Falha | Sintoma | Contramedida |
+|---|---|---|
+| Guia obsoleta | Agente segue convenção desatualizada | Revisar arquivos de harness em PRs que tocam arquitetura |
+| Contexto inchado | Agente ignora instruções no meio do arquivo | Escopar rules; mover procedimentos para skills |
+| Orientação vaga | Agente interpreta criativamente | Tornar rules concretas e verificáveis |
+| Guia ignorada | Mesmo erro se repete | Escalar para sensor ou hook (capítulos 4–5) |
+
+A última linha é a ponte para o próximo capítulo: guias são sugestões, e algumas
+sugestões precisam virar **checks**.

--- a/docs/pt-BR/guide/maturity-model.md
+++ b/docs/pt-BR/guide/maturity-model.md
@@ -1,0 +1,130 @@
+# O modelo de maturidade
+
+Este capítulo define o modelo de maturidade — o mesmo framework de avaliação
+implementado por [`npx harness-score`](./measure-and-improve),
+para que um nível que você lê aqui seja um nível que você pode medir, reproduzir
+e exigir no CI.
+
+A forma segue padrões familiares de maturidade (capacidades DORA, funções de
+negócio OWASP SAMM, níveis CMMI): **dimensões** medem áreas de prática,
+**checks** são indicadores determinísticos pass/fail, e **níveis** exigem a
+*forma* da cobertura — não só uma porcentagem bruta.
+
+Objetivos de design:
+
+- **Determinístico.** Cada check é um fato do filesystem: um arquivo existe,
+  parseia, combina com um padrão. Sem modelo, sem julgamento, sem rede.
+- **Agnóstico de ferramenta, Cursor como exemplo principal.** Rules, skills,
+  hooks e commands de qualquer ferramenta de IA suportada (Cursor, Windsurf,
+  Claude Code, Codex/Antigravity `.agents/`, OpenCode, Cline, Continue,
+  instruções Copilot, Zed) pontuam via semântica OR — uma ferramenta
+  configurada basta. Infraestrutura universal (testes, linters, tipos, CI)
+  forma o mesmo sistema de controle independente do IDE.
+- **Uma escada, não uma nota.** Níveis exigem a *forma* do harness (quais
+  dimensões estão cobertas), não só pontos — 80 pontos de guias com zero
+  sensores não é maturidade.
+
+## As seis dimensões
+
+108 pontos em seis dimensões:
+
+| Dimensão | Pontos | O que mede |
+|---|---|---|
+| Context & Guides | 20 | AGENTS.md, qualidade e escopo de rules |
+| Skills & Commands | 17 | Conhecimento procedural, workflows explícitos, subagents |
+| Hooks & Guardrails | 14 | Gates e feedback enforced em runtime |
+| Sensors & Feedback | 20 | Testes, linter, tipos, formatter |
+| CI Feedback | 14 | Checks de pipeline, pre-commit |
+| Hygiene & Safety | 23 | Segredos, env files, lockfile, licença, config MCP |
+
+Cada dimensão é a soma de checks individuais (catálogo completo com
+remediações no [capítulo 7](./measure-and-improve#the-check-catalog)).
+
+## Os cinco níveis
+
+### L0 · Sem harness
+
+O repositório não dá nada ao agente: sem arquivo de contexto, sem rules, sem
+checks enforced. Agentes trabalham aqui — sempre trabalham — mas toda sessão
+redescobre o projeto do zero e todo erro segue em frente a menos que um humano
+pegue. A maioria dos repositórios começa aqui.
+
+### L1 · Documentado
+
+**Exige: Context & Guides ≥ 40%.**
+
+Há um `AGENTS.md` (ou equivalente) substantivo: o que é o projeto, como
+construir e testar, quais convenções valem. O passo de maior alavancagem a
+partir do zero — feedforward para toda sessão futura em um arquivo.
+
+### L2 · Orientado
+
+**Exige: Context ≥ 60% · (Skills ≥ 30% ou Hooks ≥ 30%) · Hygiene ≥ 50%.**
+
+A orientação tem estrutura: rules com escopo e frontmatter válido
+(`.cursor/rules/`, `.windsurf/rules/`, `.clinerules/` ou equivalente da sua
+ferramenta), e pelo menos o início de conhecimento procedural (skill,
+command/workflow ou subagent) ou maquinaria de hooks. Higiene básica segura —
+env ignorados, sem assinaturas de credencial em arquivos de harness. O harness
+agora viaja com o código e é revisado como código.
+
+### L3 · Sensorizado
+
+**Exige L2, mais: Sensors ≥ 60% · CI ≥ 50%.**
+
+O loop de feedback existe. Testes que o agente pode rodar, linter, type
+checking e pipeline CI que reverifica a cada push. É o nível em que a
+autocorreção começa: o agente pode *verificar o próprio trabalho* com
+ferramentas determinísticas, e o pipeline pega o que ele perde. Para a maioria
+das equipes, L3 é onde desenvolvimento assistido por IA deixa de parecer arriscado.
+
+### L4 · Autocorretivo
+
+**Exige L3, mais: Hooks ≥ 70% · pontuação total ≥ 80%.**
+
+O loop fecha em runtime. Gate hooks tornam ações destrutivas impossíveis em
+vez de desencorajadas; feedback hooks lintam e formatam a cada edição, dentro
+da sessão. Guias, sensores e guardrails cobrem as seis dimensões. Um erro agora
+precisa passar pelas rules, hooks on-edit, testes, type checker, CI *e* gates —
+em grande parte sem humano no loop.
+
+## Lendo uma pontuação
+
+Dois repositórios podem ter 65% com formas muito diferentes — por isso os
+níveis exigem dimensões:
+
+- **65%, tudo guias, zero sensores** → L1. Lindamente documentado, não
+  verificado. Prioridade: testes + CI, não mais prosa.
+- **65%, sensores fortes, sem contexto** → L0/L1. O trabalho do agente é
+  verificado, mas ele adivinha suas convenções a cada sessão. Prioridade: uma
+  tarde em `AGENTS.md` e três rules com escopo.
+
+O scanner imprime exatamente qual requisito bloqueia o próximo nível
+(`To reach L3: sensors ≥ 60%; ci ≥ 50%`), então o caminho de melhoria nunca
+é ambíguo.
+
+## O que o modelo deliberadamente não mede
+
+Honestidade sobre os limites do determinismo (o caveat de Fowler de que "behavior
+harness is immature" vale também para medição):
+
+- **Se seus testes são bons** — só que existem, rodam e gateiam.
+- **Se suas rules são verdadeiras** — uma rule obsoleta pontua como uma fresca.
+- **Corretude funcional** — nenhum scan estático verifica comportamento.
+- **Prática de equipe** — branch protection, cultura de review e workflows de
+  agente ficam fora da árvore do repositório.
+
+Pontuação alta significa que a *infraestrutura* para trabalho confiável com
+agente existe. É necessária, não suficiente — o teto do que um scanner
+determinístico pode afirmar com honestidade.
+
+## Usando a escada
+
+1. Rode `npx harness-score` — obtenha seu nível e os gaps exatos.
+2. Suba um nível por vez; os requisitos de cada nível são um esforço focado
+   (L1: escrever AGENTS.md → L2: rules + higiene → L3: sensores + CI →
+   L4: hooks).
+3. Exija o nível no CI (`--min-level`) para a maturidade só subir.
+4. Mostre — badge no README (`harness` · `L4`) e [share card](./measure-and-improve#show-your-maturity) opcional. Mesma pílula do CI (`--badge`) ou arquivo estático fixo.
+
+O capítulo 7 percorre cada passo, check a check.

--- a/docs/pt-BR/guide/maturity-model.md
+++ b/docs/pt-BR/guide/maturity-model.md
@@ -68,7 +68,7 @@ command/workflow ou subagent) ou maquinaria de hooks. Higiene básica segura —
 env ignorados, sem assinaturas de credencial em arquivos de harness. O harness
 agora viaja com o código e é revisado como código.
 
-### L3 · Sensorizado
+### L3 · Com sensores
 
 **Exige L2, mais: Sensors ≥ 60% · CI ≥ 50%.**
 

--- a/docs/pt-BR/guide/measure-and-improve.md
+++ b/docs/pt-BR/guide/measure-and-improve.md
@@ -1,0 +1,629 @@
+# Medir e melhorar
+
+Tudo neste guia condensa em um comando:
+
+```bash
+npx harness-score
+```
+
+O scanner percorre seu repositório (somente filesystem — sem LLM, sem rede, sem
+telemetria), roda 36 checks determinísticos em qualquer ferramenta de IA e reporta
+um nível de maturidade com os gaps exatos para o próximo:
+
+```
+  harness-score v1.0.0  /work/my-app
+
+  Maturity: L2 · Guided   Score: 66/108 (61%)
+  Detected: Cursor, Claude Code
+
+  Context & Guides     ████████████████░░░░  80%
+  Skills & Commands    █████████████░░░░░░░  67%
+  Hooks & Guardrails   ░░░░░░░░░░░░░░░░░░░░   0%
+  ...
+
+  To reach L3: sensors ≥ 60%; ci ≥ 50%
+```
+
+> **Multi-ferramenta:** O scanner reconhece artefatos de harness do Cursor, Claude Code,
+> Windsurf, Cline, Continue e outras ferramentas via semântica OR — se você configurar
+> qualquer uma, o Harness Score conta. Saiba mais em [Suporte multi-harness](./multi-harness).
+
+## Instalação
+
+```bash
+npx harness-score                                       # no install
+npm install -g harness-score                            # global binary
+npm install --save-dev harness-score                    # pinned devDependency
+```
+
+Também espelhado em [GitHub Packages](https://github.com/paladini/harness-score/pkgs/npm/harness-score)
+(`@paladini/harness-score`) e [JSR](https://jsr.io/@paladini/harness-score)
+para projetos Deno/Bun.
+
+## Usando como biblioteca
+
+A CLI é um wrapper fino sobre API programática totalmente tipada — útil
+para dashboard customizado, bot ou ferramenta que quer o `Report` bruto
+em vez de parsear saída de terminal:
+
+```ts
+import { score } from 'harness-score';
+
+const report = score('/path/to/repo');
+console.log(report.level.name, report.score.percent, report.dimensions);
+```
+
+`Report`, `Check`, `CheckResult`, `DimensionScore`, `LevelInfo` e toda
+forma shipam como declarações TypeScript — resolvidas via campo `"types"`
+explícito, para editores e `tsc` pegarem sem config extra. Blocos de nível
+inferior também são exportados, para o que `score()` não cobre diretamente:
+
+```ts
+import { createScanContext, buildReport, computeDiff, renderMarkdown } from 'harness-score';
+
+const ctx = createScanContext('/path/to/repo');   // walk the filesystem once
+const report = buildReport(ctx);                  // run all 36 checks against it
+const markdown = renderMarkdown(report);          // same renderer the CLI's --md uses
+```
+
+## Referência da CLI
+
+```bash
+harness-score [path]              # human report (default: current directory)
+harness-score --json              # full report as JSON
+harness-score --md report.md      # markdown report (use "-" for stdout)
+harness-score --badge badge.svg   # SVG pill: harness + detected level (L0–L4)
+harness-score --min-level 3       # exit 1 if below L3 — the CI gate
+harness-score --diff base.json    # compare against a previous --json report
+```
+
+### Acompanhar pontuação no tempo {#diff-mode}
+
+`--diff <file>` compara o scan atual contra relatório baseline salvo de
+execução `--json` anterior — deltas de nível e pontuação, movimento por
+dimensão e exatamente quais checks viraram:
+
+```bash
+harness-score --json > baseline.json   # save today's report
+# ...later, after changes...
+harness-score --diff baseline.json     # see what moved
+```
+
+```
+  Compared to baseline:
+    Level: L2 · Guided → L3 · Sensing (+1)
+    Score: 61/108 (56%) → 84/108 (78%) (+22pp)
+    Sensors & Feedback   20% → 90% (+70pp)
+    Newly passing: SNS-01, SNS-02, SNS-04, CI-01, CI-02
+```
+
+`--diff` funciona com `--json` (adiciona `current`/`baseline`/`diff` ao
+payload) e `--md` (adiciona seção "Compared to baseline") — é o que a
+GitHub Action usa para comentar "pontuação subiu de L2 para L3" em PRs.
+
+## O plugin Cursor
+
+Instale **Harness Score** do [diretório de plugin neste repo](https://github.com/paladini/harness-score/tree/main/plugins/cursor)
+(listagem Cursor Marketplace enviada e pendente de revisão — este link
+moverá para lá quando estiver live) e você ganha:
+
+- **`/harness-audit`** — roda o scanner no workspace aberto e faz o agente
+  apresentar o relatório com as principais remediações.
+- **A skill `harness-engineering`** — quando você diz "corrija" ou
+  "melhore meu harness", o agente sabe escrever os artefatos faltantes
+  seguindo as receitas deste guia.
+
+A análise em si é sempre a CLI determinística; o modelo só apresenta
+resultados e aplica correções que você pedir.
+
+## O gate de CI {#ci-gate}
+
+Harnesses regredem silenciosamente — alguém apaga `hooks.json` numa limpeza,
+rule apodrece. Trave seu nível no CI:
+
+```yaml
+- name: Harness gate
+  run: npx -y harness-score --min-level 3
+```
+
+Ou use a action empacotada, que também emite o badge:
+
+```yaml
+- uses: paladini/harness-score/action@main
+  with:
+    min-level: '3'
+    badge: 'harness-badge.svg'
+```
+
+## Mostre sua maturidade {#show-your-maturity}
+
+Harness Score entrega **dois formatos SVG com marca** na mesma linguagem visual
+das barras de progresso do scanner — sem shields.io, sem serviço pago, sem rede
+no render:
+
+| Formato | Arquivos | Mostra | Melhor para |
+|---|---|---|---|
+| **Badge** | `harness-badge.svg` ou `badge-l0.svg` … `badge-l4.svg` | `harness` · `L4` | Fileira README (pílula 112×20) |
+| **Share card** | `card-l0.svg` … `card-l4.svg` | Banner completo com nome do nível | Posts sociais, hero do repo (860×240) |
+
+O badge mostra **só o nível** (`L0`–`L4`). Nomes de nível
+(Unharnessed, Guided, …) ficam nos share cards e na saída do scanner.
+
+A pílula parece idêntica se CI regenera ou você fixa arquivo estático —
+só a fiação muda.
+
+### Badge — auto-atualizando (recomendado)
+
+`harness-score --badge` escreve SVG para o nível que o scanner detecta.
+Configure no CI uma vez; a imagem no README atualiza conforme o harness melhora.
+
+```yaml
+# .github/workflows/harness.yml
+name: Harness Score
+on: { push: { branches: [main] } }
+permissions: { contents: write }
+jobs:
+  harness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: paladini/harness-score/action@main
+        with: { badge: 'harness-badge.svg' }
+      - uses: JamesIves/github-pages-deploy-action@v4
+        with: { branch: badges, folder: ., clean: false }
+```
+
+Referencie o arquivo publicado no README — receitas copy-paste completas em
+[Snippets de embed](#embed-snippets):
+
+```md
+<img alt="Harness Score" src="https://raw.githubusercontent.com/<you>/<repo>/badges/harness-badge.svg" height="20">
+```
+
+Defina `height="20"` no `<img>` para a pílula alinhar com shields npm/CI na
+mesma fileira (SVG 112×20; só nível — percentual fica no relatório da CLI).
+
+Exemplo dogfood (badge live deste guia no GitHub Pages):
+
+<div class="hs-visual">
+  <p class="hs-visual-label">Badge (this repo)</p>
+  <div class="hs-badge-row">
+    <img class="hs-badge" src="/harness-badge.svg" alt="Harness Score" height="20">
+  </div>
+</div>
+
+O share card correspondente ao nível detectado é publicado como
+`harness-card.svg` (atualmente L4 neste repositório):
+
+<img class="hs-share-card" src="/harness-card.svg" alt="Harness Score L4 · Self-correcting">
+
+### Badge — fixar um nível
+
+Mesma pílula, arquivo estático — escolha `badge-l0.svg` … `badge-l4.svg` se não
+quiser que CI regenere a imagem. Veja [Snippets de embed](#embed-snippets) para
+Markdown, HTML, iframe, JSX e mais.
+
+### Share card
+
+Para hero image ou post social, use o banner card — inclui o nome do nível
+(`Unharnessed`, `Guided`, …):
+
+| Level | Badge | Share card |
+|---|---|---|
+| L0 · Unharnessed | [badge-l0.svg](https://paladini.github.io/harness-score/maturity/badge-l0.svg) | [card-l0.svg](https://paladini.github.io/harness-score/maturity/card-l0.svg) |
+| L1 · Documented | [badge-l1.svg](https://paladini.github.io/harness-score/maturity/badge-l1.svg) | [card-l1.svg](https://paladini.github.io/harness-score/maturity/card-l1.svg) |
+| L2 · Guided | [badge-l2.svg](https://paladini.github.io/harness-score/maturity/badge-l2.svg) | [card-l2.svg](https://paladini.github.io/harness-score/maturity/card-l2.svg) |
+| L3 · Sensing | [badge-l3.svg](https://paladini.github.io/harness-score/maturity/badge-l3.svg) | [card-l3.svg](https://paladini.github.io/harness-score/maturity/card-l3.svg) |
+| L4 · Self-correcting | [badge-l4.svg](https://paladini.github.io/harness-score/maturity/badge-l4.svg) | [card-l4.svg](https://paladini.github.io/harness-score/maturity/card-l4.svg) |
+
+<div class="hs-visual">
+  <p class="hs-visual-label">All badge levels (112×20)</p>
+  <div class="hs-badge-row">
+    <img class="hs-badge" alt="L0" src="/maturity/badge-l0.svg" height="20">
+    <img class="hs-badge" alt="L1" src="/maturity/badge-l1.svg" height="20">
+    <img class="hs-badge" alt="L2" src="/maturity/badge-l2.svg" height="20">
+    <img class="hs-badge" alt="L3" src="/maturity/badge-l3.svg" height="20">
+    <img class="hs-badge" alt="L4" src="/maturity/badge-l4.svg" height="20">
+  </div>
+</div>
+
+<div class="hs-visual">
+  <p class="hs-visual-label">Share card example (860×240)</p>
+  <img class="hs-share-card" alt="L4 · Self-correcting" src="/maturity/card-l4.svg">
+  <p class="hs-visual-detail">Baixe qualquer nível da tabela acima — cards incluem o nome do nível.</p>
+</div>
+
+## Snippets de embed {#embed-snippets}
+
+Receitas copy-paste para compartilhar. Substitua placeholders:
+
+| Placeholder | Badge auto-atualizando | Badge fixo (nível `{N}`) | Share card |
+|---|---|---|---|
+| `{BADGE_URL}` | `https://raw.githubusercontent.com/{owner}/{repo}/badges/harness-badge.svg` | `https://paladini.github.io/harness-score/maturity/badge-l{N}.svg` | — |
+| `{CARD_URL}` | — | — | `https://paladini.github.io/harness-score/maturity/card-l{N}.svg` |
+| `{LINK}` | Seu repo ou `https://paladini.github.io/harness-score/` | Igual | Igual |
+
+`{N}` é `0`–`4`. Badge live deste repositório (sem CI no seu fork):
+`https://raw.githubusercontent.com/paladini/harness-score/main/docs/public/harness-badge.svg`
+
+**Tamanho do badge:** 112×20 — sempre defina `height="20"` (ou `height={20}`) para
+a pílula alinhar com badges shields.io na mesma fileira.
+
+### Badge — Markdown
+
+Image only (GitHub, GitLab, dev.to — use HTML if plain `![]()` stretches):
+
+```md
+<img alt="Harness Score L4" src="{BADGE_URL}" height="20">
+```
+
+Linked (clickable):
+
+```md
+[![Harness Score L4]({BADGE_URL})]({LINK})
+```
+
+Reference-style:
+
+```md
+[![Harness Score][hs-badge]][hs-link]
+
+[hs-badge]: {BADGE_URL}
+[hs-link]: {LINK}
+```
+
+### Badge — HTML
+
+```html
+<img alt="Harness Score L4" src="{BADGE_URL}" height="20" width="112">
+```
+
+Linked:
+
+```html
+<a href="{LINK}">
+  <img alt="Harness Score L4" src="{BADGE_URL}" height="20" width="112">
+</a>
+```
+
+### Badge — iframe
+
+For CMS or wikis that only allow iframes (not `<img>`):
+
+```html
+<iframe
+  src="{BADGE_URL}"
+  title="Harness Score L4"
+  width="112"
+  height="20"
+  style="border:0;overflow:hidden"
+></iframe>
+```
+
+### Badge — SVG object / embed
+
+```html
+<object data="{BADGE_URL}" type="image/svg+xml" width="112" height="20">
+  <a href="{BADGE_URL}">Harness Score L4</a>
+</object>
+```
+
+```html
+<embed src="{BADGE_URL}" type="image/svg+xml" width="112" height="20" />
+```
+
+### Badge — JSX / React
+
+```jsx
+<a href="{LINK}">
+  <img
+    alt="Harness Score L4"
+    src="{BADGE_URL}"
+    height={20}
+    width={112}
+    style={{ verticalAlign: 'middle' }}
+  />
+</a>
+```
+
+### Badge — AsciiDoc
+
+```asciidoc
+image:{BADGE_URL}[Harness Score L4,link={LINK},height=20]
+```
+
+### Badge — BBCode (forums)
+
+```text
+[url={LINK}][img]{BADGE_URL}[/img][/url]
+```
+
+### Badge — direct URL
+
+Cole em chat, bloco de imagem Notion, Slack, Discord ou ferramenta que aceite
+URL de imagem crua:
+
+```text
+{BADGE_URL}
+```
+
+### Share card — Markdown / HTML
+
+Banner para hero do README, posts de blog ou previews sociais (`{N}` = `0`–`4`):
+
+```md
+[![Harness Score L4 · Self-correcting]({CARD_URL})]({LINK})
+```
+
+```html
+<a href="{LINK}">
+  <img
+    alt="Harness Score L4 · Self-correcting"
+    src="{CARD_URL}"
+    width="560"
+    style="max-width:100%;height:auto;border-radius:8px"
+  />
+</a>
+```
+
+### Share card — iframe
+
+```html
+<iframe
+  src="{CARD_URL}"
+  title="Harness Score L4 · Self-correcting"
+  width="560"
+  height="157"
+  style="border:0;max-width:100%"
+></iframe>
+```
+
+### Share card — direct URL
+
+```text
+{CARD_URL}
+```
+
+### Exemplo prático (badge L3 fixo)
+
+```md
+<a href="https://paladini.github.io/harness-score/">
+  <img alt="Harness Score L3" src="https://paladini.github.io/harness-score/maturity/badge-l3.svg" height="20">
+</a>
+```
+
+```html
+<iframe
+  src="https://paladini.github.io/harness-score/maturity/badge-l3.svg"
+  title="Harness Score L3"
+  width="112"
+  height="20"
+  style="border:0"
+></iframe>
+```
+
+> **Fã de shields.io?** Sua Action também pode escrever JSON pequeno e apontar um
+> [endpoint shields](https://shields.io/badges/endpoint-badge) para ele
+> (`{ "schemaVersion": 1, "label": "harness", "message": "L3", "color": "brightgreen" }`).
+> Os SVGs com marca acima são autocontidos e não precisam de terceiros.
+
+## Catálogo de checks {#the-check-catalog}
+
+Cada check que o scanner roda, com receita de remediação. IDs de check são
+estáveis; a CLI liga cada falha à entrada aqui.
+
+### Context & Guides (20 pt)
+
+#### CTX-01 · Agent context file present — 4 pts {#ctx-01}
+An `AGENTS.md` (or `CLAUDE.md` / `GEMINI.md`) exists at the repository root.
+**Correção:** create `AGENTS.md` answering: what is this project, how do I build
+and test it, what conventions hold, what must I never touch. Recipe in
+[capítulo 3](./guides-feedforward#writing-an-agents-md-that-works).
+
+#### CTX-02 · Context file is substantive — 3 pts {#ctx-02}
+≥20 meaningful lines and ≥2 headings — a stub scores nothing.
+**Correção:** cover layout, build & test commands, conventions, and no-go zones.
+Commands over descriptions; point to rules instead of pasting them.
+
+#### CTX-03 · Scoped rules in use — 4 pts {#ctx-03}
+At least one scoped rule file for any supported tool (e.g. `.cursor/rules/*.mdc`,
+`.windsurf/rules/*.md`, `.clinerules/*.md`, `.continue/rules/*.md`,
+`.github/instructions/*.instructions.md`, `.agents/rules/*`). Nested context
+files in subdirectories (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md` anywhere below
+the root) also count — they are directory-scoped rules in tools like Claude
+Code and Codex.
+**Correção:** start with one short always-on rule holding your non-negotiables,
+then add path-scoped rules per area (or nested context files per subtree).
+
+#### CTX-04 · Rules have valid frontmatter — 3 pts {#ctx-04}
+Every rule declares activation metadata (`description`, `globs`/`trigger`/`paths`/`applyTo`, or `alwaysApply`).
+Rules a tool auto-loads without metadata — `.continue/rules/*` and nested
+context files — pass by construction.
+**Correção:** add the frontmatter block; without it the agent can't decide when the
+rule applies.
+
+#### CTX-05 · Rules are scoped — 2 pts {#ctx-05}
+Not every rule is blanket always-on. Nested context files count as scoped —
+they apply only to their subtree.
+**Correção:** scope rules to paths (`globs:`, `trigger:` glob, `paths:`, `applyTo:`)
+so they load only when relevant — every always-on rule taxes every request's context.
+
+#### CTX-06 · No bloated rules — 2 pts {#ctx-06}
+No single rule exceeds 500 lines.
+**Correção:** split by concern, or move procedural content into a skill.
+
+#### CTX-07 · README present — 1 pt {#ctx-07}
+**Correção:** add a README.md; it's the first orientation document for humans and
+a fallback for agents.
+
+#### CTX-08 · No legacy .cursorrules — 1 pt {#ctx-08}
+The deprecated single-file format is absent (or modern scoped rules also exist).
+**Correção:** migrate `.cursorrules` content into scoped rules for your tool.
+
+### Skills & Commands (17 pts)
+
+#### SKL-01 · At least one skill — 4 pts {#skl-01}
+A `SKILL.md` under `.cursor/skills/<name>/`, `.claude/skills/<name>/`, or `.agents/skills/<name>/`.
+**Correção:** package your most repeated procedure (deploy, release, migration)
+as a skill — [capítulo 3](./guides-feedforward#skills-the-procedural-layer).
+
+#### SKL-02 · Skills declare name and description — 3 pts {#skl-02}
+Frontmatter with `name:` and `description:` on every skill.
+**Correção:** the agent decides whether to load a skill from these two fields
+alone; without them the skill is invisible.
+
+#### SKL-03 · Explicit workflows/commands defined — 3 pts {#skl-03}
+Command or workflow files (`.cursor/commands/`, `.windsurf/workflows/`,
+`.claude/commands/`, `.continue/prompts/`, `.zed/commands/`, `.agents/workflows/`).
+**Correção:** encode workflows you trigger deliberately (`/review`, `/release`)
+as command/workflow files.
+
+#### SKL-04 · Skill descriptions are trigger-worthy — 2 pts {#skl-04}
+Descriptions ≥40 characters.
+**Correção:** write descriptions as trigger conditions — "Use when the user asks
+to deploy or release; covers tagging, pipeline, rollback, smoke tests."
+
+#### AGT-01 · Custom subagent defined — 3 pts {#agt-01}
+A subagent file under `.cursor/agents/`, `.claude/agents/`, or `.opencode/agents/`.
+**Correção:** package a purpose-built subagent for a job the primary agent should
+delegate (planning, review, release) — see
+[Subagents](./cursor-harness-surface#subagents-purpose-built-delegates)
+no capítulo 2.
+
+#### AGT-02 · Subagents declare name and description — 2 pts {#agt-02}
+Frontmatter with `name:` and `description:` on every subagent definition.
+**Correção:** the parent agent decides whether to delegate from these two fields
+alone; without them the subagent is never invoked.
+
+### Hooks & Guardrails (14 pts)
+
+#### HKS-01 · Hooks configuration present and valid — 4 pts {#hks-01}
+`.cursor/hooks.json` or `.claude/settings.json` (`hooks` key) exists and parses as JSON.
+**Correção:** create hooks config and grow from the
+receitas no [capítulo 5](./guardrails-and-safety#gate-hooks).
+
+#### HKS-02 · Known events, version declared — 2 pts {#hks-02}
+Version/metadata present; every registered event is documented for your tool
+(Cursor lifecycle events, or Claude Code `PreToolUse`/`PostToolUse`).
+**Correção:** typo'd event names fail silently — check against the event list in
+[capítulo 2](./cursor-harness-surface#hooks-observe-and-control-the-agent-loop).
+
+#### HKS-03 · Gate hook guards risky operations — 4 pts {#hks-03}
+A gate hook registered (Cursor: `beforeShellExecution`, `beforeMCPExecution`,
+`preToolUse`, or `beforeReadFile`; Claude Code: `PreToolUse`).
+**Correção:** gate de deny de comandos destrutivos do capítulo 5 — rules em prosa são
+pedidos; gates são fatos.
+
+#### HKS-04 · Feedback hook observes output — 2 pts {#hks-04}
+A feedback hook registered (Cursor: `afterFileEdit`, `postToolUse`, …;
+Claude Code: `PostToolUse`).
+**Correção:** format-and-lint on edit gives the agent instant feedback inside the
+session.
+
+#### HKS-05 · Hook scripts committed — 2 pts {#hks-05}
+Scripts referenced by the hooks config exist in the repository.
+**Correção:** commit them; a hook pointing at a missing script fails open on
+every machine but the author's.
+
+### Sensors & Feedback (20 pts)
+
+#### SNS-01 · Test runner configured — 6 pts {#sns-01}
+A real test script/config (vitest, jest, pytest, go test, cargo test…).
+**Correção:** wire up the runner with one obvious entry point and document it in
+AGENTS.md — tests are how the agent verifies its own work.
+
+#### SNS-02 · Linter configured — 5 pts {#sns-02}
+eslint/biome, ruff, golangci-lint, rubocop, or equivalent.
+**Correção:** every convention expressible as a lint rule stops needing prose.
+
+#### SNS-03 · Type checking in place — 4 pts {#sns-03}
+tsconfig (ideally `strict: true`), mypy/pyright, or a statically typed
+language.
+**Correção:** the type checker is the only sensor that reviews every agent edit
+for free — [capítulo 4](./sensors-feedback#type-checking-the-free-sensor).
+
+#### SNS-04 · Formatter configured — 3 pts {#sns-04}
+prettier/biome, black/ruff-format, gofmt/rustfmt.
+**Correção:** formatting noise in diffs hides real mistakes from review.
+
+#### SNS-05 · Test files exist — 2 pts {#sns-05}
+At least one actual test file in the tree.
+**Correção:** a configured runner with zero tests is a green light nobody earned.
+
+### CI Feedback (14 pts)
+
+#### CI-01 · CI pipeline configured — 4 pts {#ci-01}
+GitHub Actions workflow (or GitLab/CircleCI/Jenkins equivalent).
+**Correção:** add `.github/workflows/ci.yml` running your sensors on every push.
+
+#### CI-02 · CI runs the tests — 4 pts {#ci-02}
+**Correção:** no agent-authored change should be mergeable without the suite
+firing.
+
+#### CI-03 · CI runs lint/typecheck — 3 pts {#ci-03}
+**Correção:** cheap computational sensors belong on every push — keep quality
+left.
+
+#### CI-04 · Pre-commit checks installed — 3 pts {#ci-04}
+husky/lint-staged, `pre-commit`, or lefthook.
+**Correção:** the earliest feedback a commit can get; catches what on-edit hooks
+missed before it enters history.
+
+### Hygiene & Safety (23 pts)
+
+#### HYG-01 · .gitignore present — 2 pts {#hyg-01}
+**Correção:** agents commit what they see; make build output and local state
+invisible.
+
+#### HYG-02 · .gitignore covers env files — 3 pts {#hyg-02}
+A `.env` pattern in .gitignore.
+**Correção:** add `.env` and `.env.*` (allow `!.env.example`) — the cheapest
+guardrail in existence.
+
+#### HYG-03 · No unprotected .env files — 4 pts {#hyg-03}
+No real env files in the tree unless gitignored (templates are fine).
+**Correção:** move secrets out; keep `.env.example` documenting required
+variables.
+
+#### HYG-04 · MCP config free of credentials — 4 pts {#hyg-04}
+No credential signatures in MCP config (`.cursor/mcp.json`, `.mcp.json`,
+`.agents/mcp_config.json`).
+**Correção:** use `${ENV_VAR}` interpolation — an inlined key in MCP config is a
+secret published to every clone.
+
+#### HYG-05 · License present — 2 pts {#hyg-05}
+**Correção:** add a LICENSE; required for open-source use and plugin marketplaces.
+
+#### HYG-06 · No secrets in harness files — 2 pts {#hyg-06}
+AGENTS.md, rules, and hooks config are clean of token signatures.
+**Correção:** these files are loaded into model context every session — a key
+there is exfiltrated by design.
+
+#### HYG-07 · Lockfile committed — 3 pts {#hyg-07}
+package-lock.json, uv.lock, Cargo.lock, go.sum, or equivalent.
+**Correção:** reproducible installs mean your sensors test the same dependency
+tree everywhere.
+
+#### HYG-08 · MCP config uses env interpolation for credentials — 3 pts {#hyg-08}
+An MCP config file is valid, and any credential-shaped field (token, key,
+secret, password…) uses `${ENV_VAR}` interpolation rather than a literal.
+The positive complement to HYG-04 — a repo with no MCP setup earns nothing
+here, same as any other bonus check.
+**Correção:** reference secrets as `"${VAR_NAME}"` and document required
+variables in `.env.example`.
+
+## Plano de melhoria prático
+
+Partindo de repo de produto típico em L0, uma sessão focada por nível:
+
+1. **→ L1 (uma tarde).** Escreva `AGENTS.md` (CTX-01/02). Inclua comandos build/test
+   mesmo com sensores fracos — o agente usará.
+2. **→ L2 (um dia).** Três rules com escopo + uma skill para procedimento mais repetido
+   (CTX-03…06, SKL-01/02). Corrija higiene: gitignore, env files,
+   licença (HYG-01…05).
+3. **→ L3 (trabalho real, se sensores faltarem).** Test runner + linter +
+   tipos strict + `ci.yml` rodando os três (SNS-*, CI-01…03). Se já
+   tiver, este nível é grátis.
+4. **→ L4 (uma manhã).** Os dois hooks do capítulo 5 — um gate, um
+   formatter — commitados com scripts (HKS-*), pre-commit (CI-04),
+   depois `--min-level 4` no CI para nunca regredir.

--- a/docs/pt-BR/guide/multi-harness.md
+++ b/docs/pt-BR/guide/multi-harness.md
@@ -145,7 +145,7 @@ O scanner avalia cada dimensão via semântica OR, depois atribui um **nível de
 - **L0 · Sem harness** → padrão; nenhum requisito atendido.
 - **L1 · Documentado** → context ≥ 40% (guia raiz substantiva).
 - **L2 · Orientado** → context ≥ 60%, skills ≥ 30% **ou** hooks ≥ 30%, hygiene ≥ 50%.
-- **L3 · Sensorizado** → sensors ≥ 60% e CI ≥ 50%.
+- **L3 · Com sensores** → sensors ≥ 60% e CI ≥ 50%.
 - **L4 · Autocorretivo** → hooks ≥ 70% e pontuação total ≥ 80%.
 
 O nível aplica-se ao repositório inteiro, não por ferramenta. Isso é intencional: seu objetivo é elevar a qualidade geral do trabalho assistido por IA no projeto, independente da ferramenta que o dev escolheu. O modelo completo, com rationale por limiar, está no [modelo de maturidade](./maturity-model).

--- a/docs/pt-BR/guide/multi-harness.md
+++ b/docs/pt-BR/guide/multi-harness.md
@@ -1,0 +1,202 @@
+# Suporte multi-harness
+
+A partir da **v0.4.0**, o Harness Score mede a maturidade do harness de código com IA em **qualquer ferramenta** — não só Cursor. Seja Cursor, Claude Code, Windsurf, Cline, Continue, Codex ou outro IDE/editor AI-first, o mesmo modelo de 108 pontos se aplica.
+
+## Por que multi-harness importa
+
+O harness é agnóstico de ferramenta. Um `AGENTS.md` bem escrito, um `.gitignore` que protege segredos, um pipeline CI que roda testes — funcionam igual para Cursor, Claude Code, Windsurf ou qualquer outro agente. A infraestrutura de harness que você constrói uma vez beneficia *toda* ferramenta de IA no projeto.
+
+O Harness Score torna isso explícito: você mede uma vez, qualquer ferramenta se beneficia. Você não constrói harness Cursor e harness Claude Code separados — constrói *um harness*, e cada ferramenta compatível herda as partes que entende.
+
+## Como funciona: semântica OR
+
+O scanner usa **semântica OR** para artefatos específicos de ferramenta. Cada check pergunta "alguma ferramenta reconhecida fornece isso?" — não "o Cursor fornece?". Por exemplo:
+
+- `.cursor/rules/*.mdc` **ou** `.windsurf/rules/*.md` **ou** `.clinerules/*.md` **ou** um `CLAUDE.md` aninhado → conta para **rules**
+- `.cursor/hooks.json` **ou** `.claude/settings.json` com seção `hooks` → conta para **hooks**
+- `.cursor/skills/<name>/SKILL.md` **ou** `.claude/skills/<name>/SKILL.md` → conta para **skills**
+- `.cursor/agents/*.md` **ou** `.claude/agents/*.md` **ou** `.opencode/agents/*.md` → conta para **subagents**
+- `AGENTS.md` na raiz **ou** `CLAUDE.md` **ou** `GEMINI.md` → conta para **guias de contexto**
+
+Você não precisa configurar todos — um basta. Desde v0.5.0, adicionar segunda ferramenta nunca *abaixa* sua pontuação: quando várias configs de hooks existem, vence a com mais eventos registrados.
+
+## Ferramentas suportadas
+
+O Harness Score reconhece estes artefatos (padrões exatos no registry do scanner —
+[`registry.ts`](https://github.com/paladini/harness-score/blob/main/packages/cli/src/harness/registry.ts)):
+
+| Ferramenta | Rules | Skills | Commands / workflows | Subagents | Hooks | MCP |
+|---|---|---|---|---|---|---|
+| **Cursor** | `.cursor/rules/*.mdc` | `.cursor/skills/*/SKILL.md` | `.cursor/commands/*.md` | `.cursor/agents/*.md` | `.cursor/hooks.json` | `.cursor/mcp.json` |
+| **Claude Code** | `CLAUDE.md` aninhados | `.claude/skills/*/SKILL.md` | `.claude/commands/*.md` | `.claude/agents/*.md` | `.claude/settings.json` (`hooks`) | `.mcp.json` |
+| **Windsurf** | `.windsurf/rules/*.md` | — | `.windsurf/workflows/*.md` | — | — | — |
+| **Cline** | `.clinerules/*.md` | — | — | — | — | — |
+| **Continue** | `.continue/rules/*.md` | — | `.continue/prompts/*` | — | — | — |
+| **GitHub Copilot** | `.github/instructions/*.instructions.md` | — | — | — | — | — |
+| **Codex** | `AGENTS.md` aninhados | `.agents/skills/*/SKILL.md` | — | — | — | — |
+| **Gemini / Antigravity** | `.agents/rules/`, `.agent/rules/`, `.gemini/rules/`, `GEMINI.md` aninhados | `.agents/skills/*/SKILL.md` | `.agents/workflows/`, `.agent/workflows/` | — | — | `.agents/mcp_config.json`, `.agent/mcp_config.json` |
+| **OpenCode** | — | — | — | `.opencode/agents/*.md` | — | — |
+| **Zed** | — | — | `.zed/commands/*.md` | — | — | — |
+
+Arquivos de contexto na raiz (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) contam para toda ferramenta.
+E os artefatos mais importantes são **agnósticos de ferramenta**: testes, CI, linters, type checkers, `.gitignore`, lockfiles e `SECURITY.md` pontuam igual independente da ferramenta.
+
+::: tip Coluna esparça de uma ferramenta não é penalidade
+Windsurf não tem sistema de hooks reconhecido pelo scanner — mas hooks são só uma dimensão de seis. Repositório só Windsurf com rules, sensores e CI fortes ainda sobe a L3. L4 exige gate hooks, o que hoje significa `.cursor/hooks.json` ou `settings.json` do Claude Code junto da ferramenta principal.
+:::
+
+## Construindo o harness uma vez
+
+Caminho típico de upgrade para repositório multi-ferramenta:
+
+1. **Comece com uma ferramenta** (ex.: Cursor). Escreva `AGENTS.md`, adicione `.cursor/rules/`, configure sensores (testes, lint, tipos, CI).
+2. **A equipe adiciona segunda ferramenta** (ex.: Claude Code). Artefatos compartilhados — `AGENTS.md`, testes, CI, higiene — já funcionam. Adicione peças nativas só onde o comportamento difere: `CLAUDE.md` aninhados para orientação por diretório, `.claude/settings.json` para hooks.
+3. **O harness fica num lugar.** Sensores, guardrails e guias são nível repo — toda ferramenta herda automaticamente.
+4. **Exija maturidade, não ferramentas.** CI roda `harness-score --min-level 3` e segura todas na mesma barra.
+
+## Exemplos práticos
+
+### Exemplo 1: Repo Cursor-first adiciona Claude Code
+
+Você tem repo com setup Cursor forte:
+
+```
+.cursor/
+  rules/
+    best-practices.mdc
+    architecture.mdc
+  hooks.json
+  skills/
+    refactor/
+      SKILL.md
+AGENTS.md
+```
+
+A equipe quer usar Claude Code junto do Cursor. Nada é obrigatório —
+a pontuação já conta tudo acima. Para dar às sessões Claude Code a mesma
+orientação que Cursor recebe de `.cursor/rules/`, adicione equivalentes nativos:
+
+- **Orientação por diretório**: coloque `CLAUDE.md` nos subdiretórios onde suas
+  rules `.mdc` tinham escopo (`CLAUDE.md` aninhados contam como rules com escopo
+  desde v0.5.0). Muitas equipes fazem o `CLAUDE.md` raiz apontar em uma linha
+  para `AGENTS.md` — ou symlink — para fonte única de verdade.
+- **Hooks**: espelhe seu gate hook em `.claude/settings.json` (veja Exemplo 3).
+- **Subagents**: `.claude/agents/reviewer.md` conta para o mesmo check que
+  `.cursor/agents/reviewer.md`.
+
+De qualquer forma, Harness Score conta a config mais forte — adicionar segunda
+ferramenta só mantém ou eleva a pontuação, nunca abaixa.
+
+### Exemplo 2: Greenfield, multi-ferramenta desde o dia um
+
+Projeto novo que usará Cursor e Windsurf. Construa uma vez:
+
+1. Escreva `AGENTS.md` na raiz.
+2. Crie `.cursor/rules/` com convenções de arquitetura e nomenclatura.
+3. Espelhe rules que Windsurf precisa em `.windsurf/rules/` (markdown
+   simples, sem frontmatter `.mdc`).
+4. Escreva testes, configure CI, adicione linter.
+5. Rode `npx harness-score` → L2 ou mais. Ambas ferramentas igualmente suportadas.
+
+### Exemplo 3: Hooks para segurança (várias ferramentas beneficiadas)
+
+Você adiciona gate hook para bloquear comandos shell perigosos. Formato Cursor:
+
+```json
+// .cursor/hooks.json
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      { "command": "./scripts/hooks/gate-shell.sh" }
+    ]
+  }
+}
+```
+
+Claude Code usa arquivo e nomes de evento diferentes, mas o mesmo script:
+
+```json
+// .claude/settings.json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/scripts/hooks/gate-shell.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Harness Score recompensa qualquer um na dimensão Hooks & Guardrails — eventos
+gate (`beforeShellExecution`, `PreToolUse`) satisfazem checks de gate hook,
+e o script referenciado deve existir no repositório (scripts commitados fazem
+parte do que os checks validam). Um script, duas configs, ambas ferramentas
+protegidas.
+
+## Lógica de pontuação
+
+O scanner avalia cada dimensão via semântica OR, depois atribui um **nível de maturidade** ao repositório. Limiares (espelhados de `LEVEL_REQUIREMENTS` do scanner):
+
+- **L0 · Sem harness** → padrão; nenhum requisito atendido.
+- **L1 · Documentado** → context ≥ 40% (guia raiz substantiva).
+- **L2 · Orientado** → context ≥ 60%, skills ≥ 30% **ou** hooks ≥ 30%, hygiene ≥ 50%.
+- **L3 · Sensorizado** → sensors ≥ 60% e CI ≥ 50%.
+- **L4 · Autocorretivo** → hooks ≥ 70% e pontuação total ≥ 80%.
+
+O nível aplica-se ao repositório inteiro, não por ferramenta. Isso é intencional: seu objetivo é elevar a qualidade geral do trabalho assistido por IA no projeto, independente da ferramenta que o dev escolheu. O modelo completo, com rationale por limiar, está no [modelo de maturidade](./maturity-model).
+
+## Migrações e mudança de ferramenta
+
+Se trocar ferramenta principal (ex.: Cursor → Claude Code), o harness transfere gradualmente e a pontuação nunca despenca:
+
+1. Adicione artefatos nativos Claude (`CLAUDE.md` aninhados, `.claude/skills/`, hooks em `.claude/settings.json`) junto da config `.cursor/` existente.
+2. Rode `npx harness-score` → **mesmo nível**, porque guias, testes, CI e higiene são agnósticos, e artefatos de ambas ferramentas satisfazem os mesmos checks.
+3. Deprecie config `.cursor/` antiga quando ninguém usar Cursor (opcional — manter não custa nada).
+4. Harness Score continua reconhecendo ambos — sem risco de regressão.
+
+## Limitações e roadmap
+
+**Atual (v1.0.0):**
+
+- Suporte a plugins é escalonado: **Cursor** (principal, audit-and-fix completo), **Claude Code** (Fase 0, audit read-only), outros TBD (veja [PLUGINS-ROADMAP.md](https://github.com/paladini/harness-score/blob/main/PLUGINS-ROADMAP.md)).
+- A CLI é tool-aware e totalmente multi-harness: relatórios terminal e markdown mostram linha `Detected:` com toda ferramenta reconhecida, e `--json` inclui `detectedHarnesses`. Plugins alcançam com o tempo.
+- Hooks reconhecidos só para Cursor e Claude Code — sistemas de hooks de outras ferramentas (conforme surgirem) precisam de entradas no registry.
+
+**Planejado (pós-1.0):**
+
+- Scaffolding interativo `harness-score init` (templates determinísticos por ferramenta).
+- Saída SARIF para integração CI/segurança enterprise.
+- Melhorias no detector de ecossistema (mais variantes e locais de config).
+
+## FAQs
+
+**P: Preciso configurar todas as ferramentas suportadas?**
+
+R: Não. Se configurar Cursor, Harness Score conta. Se depois adicionar artefatos Claude Code, ambos são reconhecidos — mas uma ferramenta bem configurada basta para pontuar bem.
+
+**P: Se uso só Cursor, ainda posso compartilhar minha pontuação?**
+
+R: Sim. O nível de maturidade é medida de repositório, não de ferramenta. Repo em L3 significa "trabalho assistido por IA bem gateado e verificado aqui" — não especifica *qual* ferramenta. Ao compartilhar o badge, é credível use Cursor, Claude Code ou ambos.
+
+**P: E se minha ferramenta não está listada?**
+
+R: Abra issue com o formato de config da ferramenta e adicionaremos suporte. O caminho mais confiável enquanto isso é (1) usar `AGENTS.md` + sensores agnósticos (testes, linters, tipos, CI), que funcionam em todo lugar, ou (2) mapear artefatos da ferramenta para os que já reconhecemos.
+
+**P: Posso ver quais ferramentas foram detectadas?**
+
+R: Sim — `npx harness-score --json` inclui array `detectedHarnesses`. Fluxo CI típico:
+
+```yaml
+- name: Audit harness maturity
+  run: npx harness-score --min-level 3
+
+- name: Fail if no tool is configured
+  run: npx harness-score --json | jq -e '.detectedHarnesses | length > 0'
+```
+
+Isso garante que o gate de maturidade passa *e* que o harness de pelo menos uma ferramenta foi reconhecido (`jq -e` sai non-zero quando a expressão é `false`).

--- a/docs/pt-BR/guide/references.md
+++ b/docs/pt-BR/guide/references.md
@@ -1,0 +1,59 @@
+# Referências
+
+As fontes que este guia consolida, aproximadamente por ordem de influência.
+
+## Engenharia de harness
+
+- **[Harness engineering for coding agent users](https://martinfowler.com/articles/harness-engineering.html)** — martinfowler.com, abril de 2026.
+  O artigo que enquadrou a disciplina para equipes que *usam* agentes: guias vs.
+  sensores, verificações computacionais vs. inferenciais, as três dimensões de
+  regulação (manutenibilidade, fitness arquitetural, comportamento), "manter a
+  qualidade à esquerda" e harnessability como propriedade de codebases.
+- **[Harness Engineering — first thoughts](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering-memo.html)** — o memo anterior da série
+  *Exploring Gen AI* onde o termo toma forma.
+- **[Improving Deep Agents with harness engineering](https://www.langchain.com/blog/improving-deep-agents-with-harness-engineering)** — LangChain, 2026.
+  O caso empírico: 52,8% → 66,5% no Terminal Bench 2.0 sem tocar no modelo.
+  Loops de autoverificação, middleware de montagem de contexto, detecção de loop
+  e o sanduíche de raciocínio.
+- **[deepagents](https://github.com/langchain-ai/deepagents)** — harness de agente
+  open source "batteries-included" da LangChain; útil como implementação concreta.
+
+## Documentação de ferramentas
+
+### Cursor (principal)
+
+- **[Rules](https://cursor.com/docs/rules)** — `.cursor/rules/*.mdc`,
+  frontmatter, AGENTS.md.
+- **[Agent Skills](https://cursor.com/docs/skills)** — o padrão SKILL.md
+  e como o Cursor carrega skills.
+- **[Hooks](https://cursor.com/docs/agent/hooks)** — hooks.json, lista completa
+  de eventos, decisões de permissão.
+- **[Plugins](https://cursor.com/docs/plugins)** — estrutura de plugin,
+  manifest, modos de instalação.
+- **[Cursor Marketplace](https://cursor.com/marketplace)** e o
+  **[repositório de spec de plugins](https://github.com/cursor/plugins)** — como
+  plugins são empacotados, revisados e distribuídos.
+
+### Claude Code, Windsurf e outros
+
+Veja [Suporte multi-harness](./multi-harness) para como o Harness Score
+reconhece artefatos equivalentes do Claude Code (`.claude/agents/`, hooks),
+Windsurf (`.windsurf/rules/`), Cline (`.clinerules/`), Continue, Codex e
+outras ferramentas.
+
+## Trabalhos adjacentes
+
+- Escritos da Anthropic sobre agentes eficazes e SDKs de agentes — boa parte
+  do conselho de context engineering transfere diretamente para harnesses Cursor.
+- O padrão aberto Agent Skills adotado em várias ferramentas — motivo pelo qual
+  skills escritas para Cursor são portáveis.
+- ArchUnit, dependency-cruiser, import-linter — fitness functions arquiteturais
+  referenciadas no [capítulo 4](./sensors-feedback).
+
+## Sobre este projeto
+
+`harness-score` (scanner, guia, plugin Cursor e GitHub Action) é open source
+sob MIT:
+[github.com/paladini/harness-score](https://github.com/paladini/harness-score).
+O repositório dogfooda tudo que ensina — pontua L4 no próprio scanner, e o CI
+exige `--min-level 4`.

--- a/docs/pt-BR/guide/sensors-feedback.md
+++ b/docs/pt-BR/guide/sensors-feedback.md
@@ -1,0 +1,147 @@
+# Sensores — controles de feedback
+
+Sensores verificam o que o agente fez. Fecham o loop que torna a autocorreção
+possível: um agente com bons sensores corrige os próprios erros antes de você
+ver; um agente sem sensores os entrega com um resumo confiante.
+
+## A pilha de sensores
+
+Ordene por velocidade e custo, o mais rápido primeiro — essa ordem *é* o
+princípio "manter a qualidade à esquerda":
+
+| Sensor | Latência | Roda em |
+|---|---|---|
+| Type checker | ms–s | Na edição (hook), pre-commit, CI |
+| Linter / formatter | ms–s | Na edição (hook), pre-commit, CI |
+| Testes unitários | s | Invocado pelo agente, pre-commit, CI |
+| Testes de integração/E2E | min | CI |
+| Checks de fitness arquitetural | s–min | CI |
+| Code review com IA (inferencial) | min, $ | PR |
+| Review humano | horas | PR |
+
+O objetivo não é rodar tudo em todo lugar; é que cada erro seja pego pelo
+**sensor mais barato capaz de detectá-lo**, o mais **cedo** possível. Reserve as
+duas últimas linhas para o que nada acima consegue ver.
+
+## Type checking: o sensor gratuito
+
+Um type checker estrito é o sensor de maior valor para trabalho com agente
+porque roda a cada edição sem custo marginal, é totalmente determinístico, e
+suas mensagens de erro são precisas o suficiente para o agente agir sozinho.
+
+- TypeScript: `"strict": true` — TS não-estrito abre mão silenciosamente da
+  maior parte do valor.
+- Python: mypy ou pyright, no CI, não só no IDE.
+- Go, Rust, Java, C#: o compilador já faz isso; garanta que o agente compila
+  antes de declarar pronto.
+
+Isso também é argumento de estratégia de linguagem: codebases tipados são
+mensuravelmente mais *preparáveis para harness* — o compilador supervisiona
+cada edição do agente de graça.
+
+## Testes: o sensor que agentes usam para se autocorrigir
+
+Para um agente, uma suite de testes não é (só) rede de segurança — é a
+ferramenta que usa para verificar o próprio trabalho no meio da tarefa. Isso
+muda o que "bons testes" significam:
+
+1. **Rápidos.** Uma suite que o agente roda em segundos roda após cada mudança;
+   uma de 20 minutos nunca roda. Mantenha um subconjunto rápido (`npm test`)
+   mesmo se a suite completa for mais lenta.
+2. **Executável com um comando óbvio**, documentado no `AGENTS.md`. Se testes
+   precisam de três env vars e um banco, scripte o setup.
+3. **Determinísticos.** Testes flaky ensinam agentes (como humanos) a ignorar
+   vermelho.
+4. **Comportamentais.** Testes que fixam detalhes de implementação bloqueiam
+   refactors legítimos; testes que fixam comportamento pegam regressões reais.
+   O padrão "approved fixtures" de Fowler — arquivos golden revisados por
+   humanos, checados por máquinas — funciona bem em codebases com muitos agentes.
+
+E uma convenção que vale colocar em rule: **comportamento novo chega com teste,
+e teste falhando nunca é apagado para ficar verde.** Agentes farão os dois se
+permitido.
+
+## Linters: codifique convenções como código
+
+Toda convenção que você expressa como regra de lint é uma convenção que remove
+dos arquivos de rules — o linter aplica deterministicamente, com loop de
+feedback melhor que prosa. Stacks modernas tornam rules customizadas baratas
+(ESLint flat config, Biome, Ruff, custom linters golangci-lint).
+
+Prioridade para trabalho com agente:
+
+- Rules que pegam *deslizes semânticos* (vars não usadas, promises flutuantes,
+  erros não tratados) sobre estilo puro.
+- Rules auto-fixáveis — pareie com formatter para diffs só com sinal.
+- Rules customizadas para o "o agente insiste em fazer X" recorrente do projeto.
+
+## Fitness arquitetural: sensores de estrutura
+
+A segunda dimensão de regulação de Fowler é fitness arquitetural — sensores
+que verificam estrutura, não só sintaxe:
+
+- **Regras de dependência**: "core nunca importa de api" — ArchUnit (JVM),
+  dependency-cruiser (JS/TS), import-linter (Python).
+- **Limites de módulo** em monorepos: checks de boundary Nx/Turborepo.
+- **Orçamentos de performance**: limites de bundle, contagem de queries,
+  asserções p95.
+
+Isso importa *mais* com agentes do que sem: um agente otimizando tarefa local
+viola de boa vontade uma restrição global que nenhum arquivo local menciona.
+Fitness checks tornam a restrição global local e imediata.
+
+## Hooks como sensores on-edit
+
+Hooks do Cursor movem sensores de "quando o agente lembrar" para "sempre":
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      { "command": "node ./.cursor/hooks/format-on-edit.js", "timeout": 30 }
+    ]
+  }
+}
+```
+
+Bons cidadãos de `afterFileEdit`: formatar o arquivo, rodar linter nele, rodar
+type checker no pacote — e devolver falhas para o agente corrigir *agora*, in
+context, em vez de na CI uma hora depois. Mantenha-os rápidos (sub-segundo onde
+possível); hook lento taxa cada edição.
+
+## CI: o sensor de registro
+
+Sensores locais são consultivos — nada força o agente (ou o humano que mergeia
+seu trabalho) a tê-los rodado. CI é onde sensores viram **fatos**:
+
+- Rode testes, lint e typecheck a cada push e PR.
+- Torne-os checks obrigatórios; PR com CI vermelho do agente é trabalho não
+  revisado, não rascunho.
+- Adicione `harness-score --min-level N` como job para parar *regressão* de
+  harness — falha de drift de config onde alguém apaga hooks.json e ninguém
+  percebe ([detalhes no capítulo 7](./measure-and-improve#ci-gate)).
+
+Ferramentas pre-commit (husky + lint-staged, `pre-commit`, lefthook) preenchem
+o gap entre hooks on-edit e CI: último check determinístico antes do commit
+existir.
+
+## Sensores inferenciais: IA revisando IA
+
+Review baseado em LLM (Bugbot do Cursor, agentes juiz, plugins de review) paga
+seu custo no que a computação não checa: essa mudança *significa* a coisa
+certa? Essa abstração faz sentido? Duas regras mantêm honestidade:
+
+1. Complementa a pilha computacional, nunca substitui. Reviewer de IA aprovando
+   código que não compila é teatro.
+2. Achados devem ser *spot-checkable* — prefira reviewers que citam file:line e
+   descrevem cenário de falha sobre os que emitem vibes.
+
+## O loop de autocorreção, montado
+
+Com a pilha no lugar, o loop que a LangChain engenhou explicitamente emerge
+naturalmente: agente edita → hooks formatam e lintam → roda testes rápidos →
+CI reverifica tudo → reviewer inferencial lê os sobreviventes. Cada camada pega
+o que a anterior perdeu, e cada captura acontece no ponto mais barato possível.
+O que ainda falta é tornar ações perigosas impossíveis em vez de detectáveis —
+isso é [Guardrails](./guardrails-and-safety).

--- a/docs/pt-BR/guide/what-is-harness-engineering.md
+++ b/docs/pt-BR/guide/what-is-harness-engineering.md
@@ -1,0 +1,118 @@
+# O que é engenharia de harness
+
+> Um agente é um modelo mais um harness. O modelo você aluga; o harness você possui.
+
+Quando um agente de código com IA trabalha no seu repositório, só parte do
+comportamento vem do modelo. O resto vem de tudo *ao redor* do modelo: as
+instruções que carrega, as ferramentas que pode chamar, as verificações que
+rodam na saída, os gates que impedem ações destrutivas. Essa maquinaria ao
+redor é o **harness**, e construí-la de forma deliberada é **engenharia de
+harness**.
+
+O termo cristalizou no início de 2026. O site de Martin Fowler publicou
+[Harness engineering for coding agent users](https://martinfowler.com/articles/harness-engineering.html)
+(com base em um
+[memo](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering-memo.html)
+anterior), enquadrando a disciplina para equipes que *usam* agentes. Por
+volta da mesma época, a LangChain mostrou o outro lado: melhorando apenas o
+harness do agente de código — sem tocar no modelo — passou de **52,8% para
+66,5%** no Terminal Bench 2.0, de fora do top 30 para o top 5
+([Improving Deep Agents with harness engineering](https://www.langchain.com/blog/improving-deep-agents-with-harness-engineering)).
+
+A lição central dos dois: **confiabilidade é propriedade do sistema
+modelo–harness–ambiente, não dos pesos do modelo**. Um repositório bem
+preparado torna um modelo mediano útil; um repositório sem harness torna um
+modelo de ponta perigoso.
+
+## Guias e sensores
+
+O framework de Fowler divide os controles do harness em duas famílias,
+emprestadas da teoria de controle:
+
+| | **Guias** (feedforward) | **Sensores** (feedback) |
+|---|---|---|
+| Quando | *Antes* do agente agir | *Depois* do agente agir |
+| Propósito | Orientar para bons resultados | Detectar e corrigir os ruins |
+| Exemplos (agnósticos de ferramenta) | `AGENTS.md`, rules, skills, commands, contexto MCP | testes, linters, type checkers, CI, hooks |
+| Modo de falha quando ausente | Agente adivinha suas convenções | Agente entrega erros com confiança |
+
+Os princípios são os mesmos no Cursor, Claude Code, Windsurf e qualquer outra
+ferramenta de código com IA — o que muda é *onde* você configura (diretórios
+e formatos de frontmatter diferentes), não *o que* você está construindo. O
+Harness Score reconhece essas variantes via semântica OR, para o harness
+funcionar em qualquer lugar.
+
+Um harness precisa dos dois. Guias sem sensores produzem saída confiante e
+não verificada. Sensores sem guias pegam os mesmos erros repetidamente porque
+o agente nunca foi instruído a evitá-los.
+
+## Verificações computacionais vs. inferenciais
+
+Fowler traça uma segunda distinção que este guia — e o scanner
+`harness-score` — leva a sério:
+
+- **Verificações computacionais** são determinísticas: linters, type checkers,
+  testes, análise estrutural. Rodam em milissegundos a segundos, não custam
+  nada e dão a mesma resposta sempre. Pertencem *em todo lugar*: hooks,
+  pre-commit, CI.
+- **Verificações inferenciais** usam um modelo: code review com IA,
+  LLM-as-judge, auditorias semânticas. São poderosas, mas lentas, caras e
+  probabilísticas. Use onde a semântica importa e a computação não alcança.
+
+O princípio estratégico é **"manter a qualidade à esquerda"**: empurre as
+verificações rápidas, baratas e determinísticas o mais cedo possível no loop,
+e reserve julgamento inferencial para o que sobrar. Por isso o
+`harness-score` em si é 100% computacional — uma medição de maturidade que
+você não consegue reproduzir não é medição.
+
+## O que o harness compra: lições da LangChain
+
+A subida da LangChain no Terminal Bench é o melhor case público de engenharia
+de harness como prática empírica. As técnicas que moveram a agulha:
+
+1. **Loops de autoverificação.** O agente deve planejar → implementar →
+   testar → corrigir antes de declarar vitória; um middleware de checklist
+   pré-conclusão recusa "pronto" sem passagem de verificação. No seu repo, o
+   equivalente é ter testes que o agente consegue rodar — e convenções que
+   digam para rodá-los.
+2. **Montagem de contexto em nome do agente.** O middleware deles mapeia o
+   diretório de trabalho no início da sessão para o agente não gastar passos
+   explorando. No Cursor, `AGENTS.md` e rules com escopo fazem esse trabalho.
+3. **Detecção de loop.** Middleware interrompe "doom loops" em que o agente
+   repete a mesma edição falha. Hooks dão o mesmo ponto de observação.
+4. **Orçamento de raciocínio em forma de sanduíche.** Máximo de pensamento no
+   planejamento e na verificação final, moderado no meio. Você não controla os
+   modelos do Cursor, mas controla o que o plano e a verificação *conferem*:
+   suas rules e seus testes.
+
+As quatro são propriedades do harness, não do modelo. As quatro têm equivalentes
+diretos em um repositório Cursor — é disso que o resto deste guia trata.
+
+## Harnessability: alguns codebases são mais fáceis de preparar
+
+Fowler destaca **affordances ambientes** — propriedades do ambiente que tornam
+agentes mais governáveis:
+
+- **Linguagens tipadas** dão a cada edição um sensor gratuito e instantâneo (o
+  compilador).
+- **Limites de módulo claros** reduzem o contexto que o agente precisa por
+  tarefa.
+- **Convenções consistentes** transformam guias de ensaios em listas objetivas.
+- **Suites de teste rápidas** tornam a autoverificação barata o suficiente
+  para ser habitual.
+
+Por isso o [modelo de maturidade](./maturity-model) pontua type checking e
+infraestrutura de testes junto com artefatos específicos do Cursor: fazem
+parte do mesmo sistema de controle.
+
+## Para onde este guia leva
+
+- O capítulo 2 mapeia a [superfície de harness do Cursor](./cursor-harness-surface) —
+  cada arquivo e mecanismo que o Cursor oferece.
+- Os capítulos 3–5 cobrem as três famílias de controle em profundidade:
+  [Guias](./guides-feedforward), [Sensores](./sensors-feedback) e
+  [Guardrails](./guardrails-and-safety).
+- O capítulo 6 define um [modelo de maturidade de cinco níveis](./maturity-model)
+  com critérios objetivos.
+- O capítulo 7 mostra como [medir e melhorar](./measure-and-improve)
+  com o scanner `harness-score` e o plugin Cursor.

--- a/docs/pt-BR/guide/what-is-harness-engineering.md
+++ b/docs/pt-BR/guide/what-is-harness-engineering.md
@@ -39,7 +39,7 @@ emprestadas da teoria de controle:
 Os princípios são os mesmos no Cursor, Claude Code, Windsurf e qualquer outra
 ferramenta de código com IA — o que muda é *onde* você configura (diretórios
 e formatos de frontmatter diferentes), não *o que* você está construindo. O
-Harness Score reconhece essas variantes via semântica OR, para o harness
+Harness Score reconhece essas variantes por **equivalência entre ferramentas** (semântica OR): basta uma ferramenta configurada corretamente para o harness
 funcionar em qualquer lugar.
 
 Um harness precisa dos dois. Guias sem sensores produzem saída confiante e

--- a/docs/pt-BR/index.md
+++ b/docs/pt-BR/index.md
@@ -1,0 +1,21 @@
+---
+layout: home
+
+hero:
+  name: Harness Score
+  text: Quão bem preparado está o seu repositório?
+  tagline: Um comando determinístico mede o harness de código com IA — funciona com Cursor, Claude Code, Windsurf e outras ferramentas. Escaneia AGENTS.md, rules, hooks, testes, CI. Sem IA no scan. Sem rede. Mesma pontuação sempre.
+  image:
+    src: /logo.svg
+    alt: Harness Score
+  actions:
+    - theme: brand
+      text: Escanear seu repositório
+      link: /pt-BR/guide/measure-and-improve
+    - theme: alt
+      text: Começar
+      link: /pt-BR/guide/what-is-harness-engineering
+    - theme: alt
+      text: Ver plugins
+      link: https://github.com/paladini/harness-score/tree/main/plugins
+---

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # harness-score
 
+## 1.1.0
+
+### Minor Changes
+
+- Add full VitePress guide translations in English (default), Portuguese (Brazil), and Latin American Spanish, with an easy language switcher in the site header and landing page.
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/cli/jsr.json
+++ b/packages/cli/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@paladini/harness-score",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-score",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Deterministic AI coding harness-maturity scanner for AI-assisted repositories (Cursor-flagship, expanding to other AI-first dev tools). Zero LLM calls, zero network, zero runtime dependencies.",
   "type": "module",
   "bin": {

--- a/packages/cli/src/score.ts
+++ b/packages/cli/src/score.ts
@@ -12,7 +12,7 @@ import type {
 import { DIMENSIONS } from './types.js';
 
 export const DOCS_BASE_URL = 'https://paladini.github.io/harness-score/guide/measure-and-improve';
-export const TOOL_VERSION = '1.0.0';
+export const TOOL_VERSION = '1.1.0';
 
 export const LEVEL_NAMES = ['Unharnessed', 'Documented', 'Guided', 'Sensing', 'Self-correcting'] as const;
 

--- a/packages/cli/test/docs.test.ts
+++ b/packages/cli/test/docs.test.ts
@@ -4,15 +4,14 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
 import { ALL_CHECKS } from '../src/index.js';
 
-const GUIDE = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  '..',
-  '..',
-  '..',
-  'docs',
-  'guide',
-  'measure-and-improve.md',
-);
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+const GUIDE = path.join(REPO, 'docs', 'guide', 'measure-and-improve.md');
+
+function extractAnchors(content: string): string[] {
+  const matches = content.matchAll(/\{#([a-z0-9-]+)\}/g);
+  return [...matches].map((m) => m[1]).sort();
+}
 
 describe('docs stay in sync with the scanner', () => {
   const content = fs.readFileSync(GUIDE, 'utf8');
@@ -32,4 +31,17 @@ describe('docs stay in sync with the scanner', () => {
       expect(line, `heading for ${check.id}`).toContain(`${check.points} pt`);
     }
   });
+});
+
+describe('translated measure-and-improve guides preserve anchors', () => {
+  const enAnchors = extractAnchors(fs.readFileSync(GUIDE, 'utf8'));
+
+  for (const locale of ['pt-BR', 'es'] as const) {
+    test(`${locale} has the same anchor set as English`, () => {
+      const translated = path.join(REPO, 'docs', locale, 'guide', 'measure-and-improve.md');
+      expect(fs.existsSync(translated), `${locale} guide missing`).toBe(true);
+      const localeAnchors = extractAnchors(fs.readFileSync(translated, 'utf8'));
+      expect(localeAnchors).toEqual(enAnchors);
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- Full VitePress guide in English (default), Portuguese (Brazil), and Latin American Spanish (`/`, `/pt-BR/`, `/es/`).
- Language switcher in the site header (VitePress locales) and on the landing page, switching to the equivalent page in each locale.
- SEO: `hreflang`, canonical URLs, editorial glossary (`docs/i18n/glossary.md`), and anchor sync tests for translated check catalogs.
- Version bump to **1.1.0** (no scanner/check changes — same score as 1.0.0).

## Test plan
- [x] `npm run docs:build`
- [x] `npm test`
- [ ] Manual: open `/`, `/pt-BR/`, `/es/` and switch languages on landing + a guide chapter
- [ ] Manual: deep link `#ctx-01` works in each locale