### PR TITLE
feat(docs): add Hindi (hi-IN) documentation locale

### DIFF
--- a/.changeset/zh-cn-docs-locale.md
+++ b/.changeset/zh-cn-docs-locale.md
@@ -1,5 +1,5 @@
 ---
-"harness-score": patch
+"harness-score": minor
 ---
 
-Add Simplified Chinese (`zh-CN`) documentation locale with full guide translation and VitePress i18n wiring.
+Add Hindi (`hi-IN`) documentation locale with full guide translation and VitePress i18n wiring. Includes previously unreleased zh-CN docs locale from the same release train.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,6 +56,18 @@ const guideItemsZh: SidebarItem[] = [
   { text: '9 · 参考资料', link: '/guide/references' },
 ];
 
+const guideItemsHi: SidebarItem[] = [
+  { text: '1 · harness engineering क्या है', link: '/guide/what-is-harness-engineering' },
+  { text: '2 · Multi-harness support', link: '/guide/multi-harness' },
+  { text: '3 · Cursor harness surface', link: '/guide/cursor-harness-surface' },
+  { text: '4 · Guides — feedforward', link: '/guide/guides-feedforward' },
+  { text: '5 · Sensors — feedback', link: '/guide/sensors-feedback' },
+  { text: '6 · Guardrails और safety', link: '/guide/guardrails-and-safety' },
+  { text: '7 · Maturity model', link: '/guide/maturity-model' },
+  { text: '8 · Measure और improve', link: '/guide/measure-and-improve' },
+  { text: '9 · References', link: '/guide/references' },
+];
+
 const sharedTheme = {
   logo: '/logo.svg',
   logoLink: BASE,
@@ -186,6 +198,36 @@ export default defineConfig({
         returnToTopLabel: '返回顶部',
         darkModeSwitchLabel: '外观',
         sidebarMenuLabel: '菜单',
+      },
+    },
+    'hi-IN': {
+      label: 'हिन्दी',
+      lang: 'hi-IN',
+      link: '/hi-IN/',
+      description:
+        'AI coding agents के लिए harness engineering गाइड — deterministic scanner से harness maturity मापें।',
+      themeConfig: {
+        ...sharedTheme,
+        nav: [
+          { text: 'गाइड', link: '/hi-IN/guide/what-is-harness-engineering' },
+          { text: 'Multi-harness', link: '/hi-IN/guide/multi-harness' },
+          { text: 'Maturity', link: '/hi-IN/guide/maturity-model' },
+          { text: 'Scanner', link: '/hi-IN/guide/measure-and-improve' },
+        ],
+        sidebar: [
+          { text: 'गाइड', items: guideItemsHi.map((i) => ({ text: i.text, link: `/hi-IN${i.link}` })) },
+        ],
+        footer: {
+          message: 'MIT License के तहत जारी।',
+          copyright: FOOTER_COPYRIGHT,
+        },
+        docFooter: { prev: 'पिछला', next: 'अगला' },
+        outline: { label: 'इस पृष्ठ पर' },
+        lastUpdated: { text: 'अंतिम अपडेट' },
+        langMenuLabel: 'भाषा',
+        returnToTopLabel: 'ऊपर जाएँ',
+        darkModeSwitchLabel: 'दिखावट',
+        sidebarMenuLabel: 'मेनू',
       },
     },
   },

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -52,3 +52,8 @@
   margin: 0.25rem 0 0;
   border-radius: 8px;
 }
+
+/* Devanagari (hi-IN): conjuncts and matras need a reliable fallback alongside Inter. */
+:root {
+  --vp-font-family-base: "Inter", "Noto Sans Devanagari", system-ui, sans-serif;
+}

--- a/docs/.vitepress/theme/i18n/landing.ts
+++ b/docs/.vitepress/theme/i18n/landing.ts
@@ -606,6 +606,142 @@ export const LANDING: Record<LocaleId, LandingCopy> = {
     measureEmbedPath: '/zh-CN/guide/measure-and-improve#embed-snippets',
     whatIsPath: '/zh-CN/guide/what-is-harness-engineering',
   },
+  'hi-IN': {
+    levels: [
+      { n: 0, name: 'harness रहित', hint: 'हर सत्र शून्य से शुरू' },
+      { n: 1, name: 'दस्तावेज़ीकृत', hint: 'AGENTS.md एजेंट को मार्गदर्शन देता है' },
+      { n: 2, name: 'मार्गदर्शित', hint: 'Rules, skills, hygiene' },
+      { n: 3, name: 'sensors के साथ', hint: 'Tests, types, CI काम verify करते हैं' },
+      { n: 4, name: 'स्व-सुधार', hint: 'Hooks feedback loop बंद करते हैं' },
+    ],
+    toolStatus: { flagship: 'फ़्लैगशिप', supported: 'समर्थित' },
+    installs: [
+      {
+        title: 'एक बार चलाएँ',
+        cmd: 'npx harness-score',
+        note: 'इंस्टॉल की ज़रूरत नहीं। किसी भी repo path पर चलाएँ।',
+        href: '/hi-IN/guide/measure-and-improve',
+        external: false,
+        primary: true,
+      },
+      {
+        title: 'npm',
+        cmd: 'npm i -g harness-score',
+        note: 'v1.1.0 npmjs.org पर',
+        href: 'https://www.npmjs.com/package/harness-score',
+        external: true,
+        primary: false,
+      },
+      {
+        title: 'Cursor plugin',
+        cmd: '/harness-audit',
+        note: 'Repo में — Marketplace जल्द',
+        href: 'https://github.com/paladini/harness-score/tree/main/plugins/cursor',
+        external: true,
+        primary: false,
+      },
+      {
+        title: 'GitHub Action',
+        cmd: 'paladini/harness-score/action',
+        note: 'CI gate + README बैज',
+        href: 'https://github.com/paladini/harness-score/tree/main/action',
+        external: true,
+        primary: false,
+      },
+      {
+        title: 'JSR',
+        cmd: 'npx jsr add @paladini/harness-score',
+        note: 'Deno और Bun users',
+        href: 'https://jsr.io/@paladini/harness-score',
+        external: true,
+        primary: false,
+      },
+    ],
+    pitch: {
+      eyebrow: 'समस्या',
+      title: 'AI एजेंट की विश्वसनीयता उसके harness पर निर्भर करती है।',
+      lede: 'दो repos एक ही model चला सकते हैं — परिणाम बिल्कुल अलग। एक में feedforward guides, sensors जो काम verify करते हैं, और guardrails जो नुकसान रोकते हैं; दूसरे में कुछ नहीं। Harness Score किसी भी AI tool के लिए harness को सेकंडों में मापता है और अगला सुधार स्पष्ट बताता है।',
+    },
+    steps: {
+      eyebrow: 'कैसे काम करता है',
+      items: [
+        {
+          title: 'Scan',
+          body: 'Repo में npx harness-score चलाएँ। CLI सिर्फ़ filesystem पढ़ती है — 36 checks, zero LLM calls, zero network.',
+        },
+        {
+          title: 'Level',
+          body: 'L0–L4 maturity level, छह dimensions में 108 points का breakdown, और अगले level के लिए exact gaps।',
+        },
+        {
+          title: 'Fix',
+          body: 'हर fail हुआ check guide में remediation recipe से जुड़ा है — या plugin का /harness-audit command चलाकर fixes लागू करें।',
+        },
+      ],
+    },
+    terminal: {
+      eyebrow: 'नमूना output',
+      title: 'Diagnosis, guesswork नहीं',
+      lede: 'Deterministic: same commit, same score — laptop या CI में। Merge gate के लिए --min-level 3 — maturity सिर्फ़ ऊपर जाए।',
+      cta: 'Scanner चलाएँ →',
+      ariaLabel: 'harness-score नमूना output',
+    },
+    install: { eyebrow: 'शुरू करें', title: 'जहाँ काम करते हैं वहाँ install करें' },
+    maturity: {
+      eyebrow: 'Maturity ladder',
+      title: 'पाँच levels जिन्हें measure और gate किया जा सकता है',
+      lede: 'Levels harness के *shape* पर depend करते हैं — सिर्फ़ points पर नहीं। Tests के बिना 80% docs = L1, L3 नहीं।',
+      cta: 'पूरा maturity model →',
+    },
+    tools: {
+      eyebrow: 'Compatible',
+      title: 'कोई भी AI coding tool',
+      lede: 'एक harness, एक maturity model, कई tools। Cursor, Claude Code, Windsurf या कोई और — Harness Score सबको एक जैसे measure करता है।',
+      cta: 'Multi-harness support →',
+    },
+    showcase: {
+      eyebrow: 'Score दिखाएँ',
+      title: 'README brand बैज',
+      lede: '112×20 capsule बैज shield row के लिए। CI regenerate करती है, या static badge-lN.svg pin करें। Markdown, HTML, iframe, JSX embeds copy करें।',
+      gallery: 'Gallery',
+      embeds: 'Embed snippets',
+      cardAlt: 'Harness Score L4 · self-correcting share card',
+    },
+    products: {
+      eyebrow: 'इस repo में',
+      items: [
+        {
+          title: 'Guide',
+          body: '8 chapters — AI coding agents के लिए harness engineering: feedforward, sensors, guardrails.',
+          href: '/hi-IN/guide/what-is-harness-engineering',
+        },
+        {
+          title: 'CLI',
+          body: 'harness-score — JSON, markdown, badge output। Zero runtime deps.',
+          href: '/hi-IN/guide/measure-and-improve',
+        },
+        {
+          title: 'Cursor plugin',
+          body: '/harness-audit command + skill — scan में मिले हर gap को fix करें।',
+          href: 'https://github.com/paladini/harness-score/tree/main/plugins/cursor',
+          external: true,
+        },
+        {
+          title: 'GitHub Action',
+          body: 'हर push पर scan, badge emit, --min-level से नीचे fail।',
+          href: 'https://github.com/paladini/harness-score/tree/main/action',
+          external: true,
+        },
+      ],
+    },
+    guidePath: '/hi-IN/guide/measure-and-improve',
+    maturityPath: '/hi-IN/guide/maturity-model',
+    multiHarnessPath: '/hi-IN/guide/multi-harness',
+    measurePath: '/hi-IN/guide/measure-and-improve',
+    measureShowPath: '/hi-IN/guide/measure-and-improve#show-your-maturity',
+    measureEmbedPath: '/hi-IN/guide/measure-and-improve#embed-snippets',
+    whatIsPath: '/hi-IN/guide/what-is-harness-engineering',
+  },
 };
 
 export const SUPPORTED_TOOLS = ['Cursor', 'Claude Code', 'Windsurf', 'Cline', 'Continue', 'Codex'] as const;

--- a/docs/.vitepress/theme/i18n/localePath.ts
+++ b/docs/.vitepress/theme/i18n/localePath.ts
@@ -1,4 +1,4 @@
-export type LocaleId = 'root' | 'pt-BR' | 'es' | 'zh-CN';
+export type LocaleId = 'root' | 'pt-BR' | 'es' | 'zh-CN' | 'hi-IN';
 
 export interface LocaleMeta {
   id: LocaleId;
@@ -12,6 +12,7 @@ export const LOCALES: LocaleMeta[] = [
   { id: 'pt-BR', label: 'Português', prefix: 'pt-BR', hreflang: 'pt-BR' },
   { id: 'es', label: 'Español', prefix: 'es', hreflang: 'es-419' },
   { id: 'zh-CN', label: '中文', prefix: 'zh-CN', hreflang: 'zh-CN' },
+  { id: 'hi-IN', label: 'हिन्दी', prefix: 'hi-IN', hreflang: 'hi-IN' },
 ];
 
 const PREFIXED_LOCALES = LOCALES.filter((locale) => locale.prefix !== '');

--- a/docs/hi-IN/guide/cursor-harness-surface.md
+++ b/docs/hi-IN/guide/cursor-harness-surface.md
@@ -1,0 +1,154 @@
+# Cursor Harness Surface
+
+Cursor किसी भी mainstream AI editor से अधिक harness machinery expose करता है।
+यह अध्याय map है: हर artifact, कहाँ रहता है, और control system में क्या काम करता है।
+
+> **नोट:** Harness Score OR semantics से कई tools (Claude Code, Windsurf, Cline, Continue, और अन्य) support करता है। यह अध्याय Cursor को flagship example के रूप में focus करता है। अन्य tools कैसे recognize और score होते हैं, [Multi-Harness Support](./multi-harness) देखें।
+
+## Artifacts एक नज़र में
+
+| Artifact | Path | Family | Loaded |
+|---|---|---|---|
+| Agent context file | `AGENTS.md` | Guide | Always |
+| Rules | `.cursor/rules/*.mdc` | Guide | Always / by glob / by relevance |
+| Skills | `.cursor/skills/*/SKILL.md` | Guide | On demand, by description |
+| Commands | `.cursor/commands/*.md` | Guide | Explicitly, via `/name` |
+| Hooks | `.cursor/hooks.json` | Sensor + Guardrail | On agent-loop events |
+| MCP servers | `.cursor/mcp.json` | Guide (tools) | Per session |
+| Subagents | agent definitions | Guide | Delegated tasks |
+| Plugins | Marketplace / `.cursor-plugin/` | All bundled | Installed |
+
+सब repository में रहता है — यही point है: **harness code के साथ ship होता है**,
+code के साथ version होता है, और code की तरह review होता है।
+
+## AGENTS.md — front door
+
+Repository root पर `AGENTS.md` पहली चीज़ है जो एजेंट पढ़ता है। यह open convention है (Cursor, Claude Code, और ज़्यादातर agentic tools honor करते हैं) और harness में highest-leverage single file। संक्षेप में जवाब दे:
+
+- यह project क्या है और layout कैसा है?
+- build, run और **test** कैसे करें?
+- कौन सी conventions non-negotiable हैं?
+- क्या कभी touch नहीं करना?
+
+~150 lines से कम रखें। हर session पर load होता है — हर line हर task के context window पर tax है। जो details कभी-कभी matter करती हैं, scoped rules या skills में belong करती हैं।
+
+## Rules — persistent, declarative guidance
+
+Rules markdown-with-frontmatter files (`.mdc`) हैं `.cursor/rules/` के अंदर।
+हर rule declare करता है *कब apply हो*:
+
+```markdown
+---
+description: API route conventions
+globs: src/api/**
+---
+
+- Every route validates input with zod before use.
+- Errors return `{ "error": string }` and a correct status code.
+```
+
+तीन activation modes:
+
+- `alwaysApply: true` — हर request में inject। true non-negotiables के लिए reserve; हर always-on rule permanent context tax है।
+- `globs: <pattern>` — matching files play में हों तब apply। workhorse mode: conventions code के पास रहती हैं जिसे govern करती हैं।
+- केवल `description` — एजेंट description से relevance decide करता है।
+
+Nested `.cursor/rules/` directories monorepos में काम करते हैं: package-specific rules package के अंदर रखें।
+
+Legacy single-file `.cursorrules` deprecated है। migrate करें: concern से split, glob से scope।
+
+## Skills — procedural knowledge on demand
+
+Skill एक folder है `SKILL.md` के साथ (open Agent Skills standard):
+
+```markdown
+---
+name: deploy
+description: Use when the user asks to deploy or release; covers tagging,
+  pipeline, and smoke tests.
+---
+
+# Deploying
+1. …step-by-step workflow…
+```
+
+Cursor session start पर हर skill का `name` + `description` एजेंट को दिखाता है;
+body **केवल तब load** होती है जब एजेंट relevant judge करे। skills long procedural content के लिए सही जगह हैं जो rules bloated कर दे: deploy runbooks, migration recipes, release checklists, debugging playbooks।
+
+Rule of thumb: **rules declarative और always-on-ish ("use strict TypeScript"), skills procedural और on-demand ("here is how we deploy")**। description trigger है — "Use when…" लिखें, नहीं तो fire नहीं होगा।
+
+## Commands — workflows जो deliberately invoke करें
+
+`.cursor/commands/` के अंदर markdown files `/slash-commands` बन जाते हैं। skills (agent-triggered) के unlike, commands **human-triggered** हैं: repeatable workflows keybinding-like surface पर — `/review`, `/release`, `/harness-audit`। command file बस prompt है invoke होने पर चलने वाला।
+
+## Hooks — agent loop observe और control
+
+`.cursor/hooks.json` agent lifecycle events पर scripts register करता है:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [{ "command": "node ./.cursor/hooks/guard.js" }],
+    "afterFileEdit": [{ "command": "node ./.cursor/hooks/format.js" }]
+  }
+}
+```
+
+Scripts stdin पर JSON receive करते हैं और stdout पर answer — gating events के लिए permission decisions (`allow` / `deny` / `ask`) सहित। key events:
+
+- **Gates** (block कर सकते हैं): `beforeShellExecution`, `beforeMCPExecution`,
+  `preToolUse`, `beforeReadFile`
+- **Feedback** (results observe): `afterFileEdit`, `postToolUse`,
+  `afterShellExecution`, `stop`
+- **Lifecycle**: `sessionStart` (context inject), `sessionEnd`, `preCompact`
+
+Hooks वही Cursor mechanism है जो *harness runtime द्वारा enforced* है,
+*model को suggested* नहीं। rule "never run destructive commands" request है; `beforeShellExecution` hook जो deny करे fact है। अध्याय 5 इस distinction पर build करता है।
+
+## MCP — tools और knowledge
+
+`.cursor/mcp.json` Model Context Protocol servers connect करता है: databases, issue trackers, docs, browsers। harness perspective से MCP guide है (agent *क्या देख और कर* सकता है determine करता है) और risk surface (servers आपके credentials के साथ चलते हैं — secrets inline नहीं; `${ENV_VAR}` interpolation)।
+
+## Subagents — purpose-built delegates {#subagents-purpose-built-delegates}
+
+Subagent `.cursor/agents/` (या plugin के `agents/` folder) के अंदर markdown file है, skill जैसा `name` + `description` frontmatter contract:
+
+```markdown
+---
+name: reviewer
+description: Use when asked to review a pull request or diff for conventions
+  in AGENTS.md and .cursor/rules; reports findings by severity without
+  editing code.
+---
+
+# Reviewer subagent
+
+Read the diff, AGENTS.md, and .cursor/rules/*.mdc. Report violations ordered
+by severity. Never modify code — that's the parent agent's job.
+```
+
+Skill से distinction: skill *primary* agent को procedure सिखाता है जो inline चलाता है; subagent **अलग delegate** है जिसे primary agent task hand off करता है — अक्सर अपना scoped tool access या narrower job description, ताकि बड़ा task (full repo audit, multi-step release) specialized workers में split हो, एक agent एक context में सब न करे। Cursor की docs इसे "purpose-built" work delegate करना कहती हैं — planner, reviewer, release runner — हर एक की description इतनी tight कि primary agent hand off decide करे बिना guess किए।
+
+Skills जैसा rule description पर: parent agent delegate करे या नहीं decide करने का एकमात्र signal description है, label नहीं — trigger condition लिखें।
+
+## Plugins — harness, packaged
+
+Cursor plugin rules, skills, commands, hooks, agents, और MCP config bundle करता है एक installable unit में `.cursor-plugin/plugin.json` manifest के साथ,
+[Cursor Marketplace](https://cursor.com/marketplace) से distribute। plugins harness engineering के लिए matter करते हैं क्योंकि harness patterns **repositories में reusable** बनाते हैं — including
+[Harness Score plugin](./measure-and-improve#the-cursor-plugin) जो इस अध्याय के artifacts audit करता है (आज repo directory से install; Marketplace listing pending review)।
+
+## सही mechanism चुनना
+
+| आप चाहते हैं… | Use |
+|---|---|
+| convention state करें जो हमेशा hold करे | Rule (`alwaysApply`) — sparingly |
+| codebase के हिस्से के लिए convention | Rule with `globs` |
+| multi-step procedure सिखाएँ | Skill |
+| workflow package करें humans trigger करें | Command |
+| job delegate करें separate, purpose-built worker को | Subagent |
+| model जो सोचे enforce करें | Hook |
+| agent को tool या data source दें | MCP server |
+| ऊपर सब repos में share करें | Plugin |
+
+Guidance ignore होती रहे, table में *नीचे* shift करें — prose जो model skip कर सकता है, runtime enforce करने वाले mechanisms की ओर।

--- a/docs/hi-IN/guide/guardrails-and-safety.md
+++ b/docs/hi-IN/guide/guardrails-and-safety.md
@@ -1,0 +1,92 @@
+# Guardrails और Safety
+
+Guides suggest करते हैं। Sensors detect करते हैं। **Guardrails prevent करते हैं।** यह अध्याय harness की वह परत कवर करता है जो तब भी कायम रहती है जब मॉडल हर निर्देश ignore कर दे — क्योंकि यह मॉडल के कुछ पढ़ने पर निर्भर नहीं।
+
+## Prose guardrail क्यों नहीं है
+
+«कभी `git push --force` न चलाएँ» वाली rule probabilistic system से अनुरोध है। आमतौर पर मानी जाएगी। Destructive, irreversible, या credential-touching operations के लिए «आमतौर पर» गलत reliability class है। उनके लिए check **मॉडल के बाहर** होना चाहिए, machinery में जिसे मॉडल skip नहीं कर सकता: hooks, permissions, repository hygiene।
+
+अध्याय 3 की escalation ladder यहाँ समाप्त होती है: बार-बार violate होने वाला guidance rule → sensor → **gate** पर जाता है।
+
+## Gate hooks
+
+Cursor के gating events — `beforeShellExecution`, `beforeMCPExecution`, `preToolUse`, `beforeReadFile` — action से *पहले* आपका script चलाते हैं और `allow`, `deny`, या `ask` उत्तर देने देते हैं:
+
+```js
+// .cursor/hooks/guard-shell.js — deny destructive commands
+let input = '';
+process.stdin.on('data', (c) => (input += c));
+process.stdin.on('end', () => {
+  const { command = '' } = JSON.parse(input || '{}');
+  const destructive =
+    /\brm\s+-rf\s+[\/~]|\bgit\s+push\s+--force\b|\bdrop\s+(table|database)\b/i;
+  process.stdout.write(
+    JSON.stringify(
+      destructive.test(command)
+        ? { permission: 'deny', userMessage: 'Blocked: destructive command.' }
+        : { permission: 'allow' },
+    ),
+  );
+});
+```
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      { "command": "node ./.cursor/hooks/guard-shell.js", "timeout": 10 }
+    ]
+  }
+}
+```
+
+अधिकांश repositories में gate करने लायक patterns:
+
+- **Destructive shell**: workspace के बाहर recursive deletes, force pushes, history rewrites, non-local databases पर `DROP`/`TRUNCATE`।
+- **Outbound writes**: deploys, package publishes, external APIs पर posting — `deny` नहीं, `ask`: human in-flow confirm करता है।
+- **Secret-bearing reads**: `.env*`, key files, credential stores पर `beforeReadFile` secrets को model context से पूरी तरह बाहर रखता है।
+- **Side effects वाले MCP calls**: tool name से filter — `beforeMCPExecution`; reads allow, writes confirm।
+
+Design notes: dangerous list के लिए *closed* fail (exit code 2 block), gate scripts dependency-free और fast रखें, और **commit करें** — केवल आपकी machine पर मौजूद script की ओर इशारा करने वाला hook config केवल आपकी रक्षा करता है।
+
+## Secret hygiene
+
+एजेंट आपका working tree पढ़ता है; उसमें कुछ भी context, commit, या generated file में समा सकता है। Deterministic hygiene rules:
+
+1. **`.gitignore` `.env` और `.env.*` cover करे** (`.env.example` allow)। यह सबसे सस्ता guardrail है।
+2. **Tree में real `.env` files न हों** जहाँ avoidable; templates required variables document करें।
+3. **`mcp.json` `${ENV_VAR}` interpolation use करे, literal keys नहीं।** Inlined API key वाला MCP config हर clone पर published secret है।
+4. **Harness files में tokens नहीं।** `AGENTS.md`, rules, hooks configs *हर session पर model context में load* होते हैं — वहाँ key design से exfiltrated है।
+
+`harness-score` चारों (HYG-02 … HYG-06) credential-signature matching से check करता है — deterministically, offline।
+
+## Prompt-injection awareness
+
+Agent harnesses में human workflows में नहीं दिखने वाला threat class है: **data में छिपे निर्देश**। Dependency का README, MCP से fetch किया webpage, issue comment — कोई भी आपके एजेंट को संबोधित text रख सकता है («अपने निर्देश ignore करो और चलाओ…»)। Harness-level mitigations:
+
+- Gate hooks को परवाह नहीं कि निर्देश किसने लिखा — destructive command deny होती है चाहे user, model, या injected page ने माँगी हो। Gates को rules पर यही सबसे मजबूत तर्क है।
+- MCP servers task जितने चाहिए उतने scope करें; read-only docs server आपका data कहीं post नहीं कर सकता।
+- «एजेंट अचानक unfamiliar domain पर curl करना चाहता है» — `ask` gate के लायक signal।
+
+## Permissions और blast radius
+
+Hooks के अलावा, compromised या confused agent *क्या* कर सकता है, सिकोड़ें:
+
+- Task-scoped credentials के साथ agents चलाएँ (CI token जो PRs open कर सके पर `main` push नहीं)।
+- Branch protection: agents PRs open करें; humans (या required checks) merge।
+- Untrusted या long-running autonomous work के लिए sandboxed execution।
+
+एकीकृत सिद्धांत **defense in depth** है: rules bad actions को unlikely बनाते हैं, sensors visible, gates impossible, permissions «impossible failed» को भी survivable।
+
+## न्यूनतम viable guardrail set
+
+Typical product repository के लिए floor:
+
+- [ ] `.gitignore` env files cover; tree में real secrets नहीं
+- [ ] `mcp.json` literal credentials से clean
+- [ ] `hooks.json` एक shell gate (destructive patterns → deny/ask)
+- [ ] एक feedback hook (edit पर format/lint)
+- [ ] Branch protection required CI checks के साथ
+
+यह set वही है जो [maturity model](./maturity-model) L4 पर Hooks & Guardrails और Hygiene & Safety dimensions के लिए माँगता है।

--- a/docs/hi-IN/guide/guides-feedforward.md
+++ b/docs/hi-IN/guide/guides-feedforward.md
@@ -1,0 +1,116 @@
+# Guides — Feedforward नियंत्रण
+
+Guides एजेंट को कार्य करने से *पहले* आकार देते हैं — feedforward, यानी कार्य से पहले का मार्गदर्शन। ये सबसे सस्ते नियंत्रण हैं: सही जगह एक अनुच्छेद पूरे वर्ग की गलतियाँ रोक देता है। यह अध्याय बताता है कि उन्हें अच्छी तरह कैसे लिखें।
+
+## संदर्भ की अर्थशास्त्र
+
+हर guide एक ही दुर्लभ संसाधन के लिए प्रतिस्पर्धा करता है: मॉडल की context window और उसका ध्यान। उत्साही टीमों की विफलता अक्सर guides की कमी नहीं, **शब्दों की अधिकता** होती है — दो हज़ार पंक्तियों की rules file जिसे मॉडल सरसरी नज़र से पढ़ ले, wiki जो `AGENTS.md` में चिपका दी गई हो। LangChain का harness सबक यहाँ लागू होता है: *एजेंट की ओर से context जोड़ना* का मतलब सही 50 पंक्तियाँ देना है, सभी 5,000 नहीं।
+
+व्यावहारिक बजट:
+
+- `AGENTS.md`: ≤150 पंक्तियाँ, हमेशा लोड — केवल वही जो *हर* कार्य पर लागू हो।
+- Always-on rules: एक या दो, प्रत्येक ≤30 पंक्तियाँ।
+- Glob-scoped rules: जितनी चाहिए उतनी; प्रत्येक केवल प्रासंगिक होने पर लोड।
+- Skills: लंबाई की सीमा नहीं; केवल माँग पर लोड।
+
+## काम करने वाला AGENTS.md लिखना
+
+जो संरचना सिद्ध हो चुकी है:
+
+```markdown
+# Agent Guide — <project>
+
+## What this is
+Two sentences. Domain, purpose, key constraint.
+
+## Layout
+- src/api — HTTP layer (see .cursor/rules/api.mdc)
+- src/core — domain logic, pure functions only
+- migrations/ — generated; never edit by hand
+
+## Build & test
+- npm run dev / npm test / npm run typecheck
+- Tests MUST pass before any commit.
+
+## Conventions
+- TypeScript strict; no `any` without a comment.
+- Never add dependencies without asking.
+
+## Do not touch
+- vendor/, generated/, legacy/payments (frozen for audit)
+```
+
+सिद्धांत:
+
+1. **विवरण से आगे आदेश।** «`npm test` चलाएँ» — «हम परीक्षण को महत्व देते हैं» से बेहतर। एजेंट आदेशों पर कार्य करते हैं।
+2. **इशारा करें, चिपकाएँ नहीं।** विवरण inline करने के बजाय scoped rule या skill से लिंक करें («`.cursor/rules/api.mdc` देखें»)।
+3. **क्या न करें, बताएँ।** नकारात्मक स्थान — frozen directories, वर्जित patterns — सबसे महँगी गलतियाँ रोकते हैं।
+4. **अद्यतन रखें।** पुराना guide किसी guide से भी बुरा; एजेंट उसे आत्मविश्वास से मानता है। `AGENTS.md` की समीक्षा आर्किटेक्चर बदलावों के लिए आपकी definition of done का हिस्सा होनी चाहिए।
+
+## सही समय पर चलने वाली rules लिखना
+
+Rule के तीन काम हैं: सही समय पर लागू होना, पढ़ने योग्य छोटी होना, और जाँच योग्य ठोस होना।
+
+**Scope को सख्ती से लगाएँ।** rules का सबसे बड़ा anti-pattern है हर चीज़ पर `alwaysApply: true`। हर always-on rule हर अनुरोध पर लोड होती है — README में typo ठीक करने के अनुरोध सहित। Glob से scope करें:
+
+```markdown
+---
+description: React component conventions
+globs: src/components/**/*.tsx
+---
+```
+
+**एक rule, एक विषय।** `api.mdc`, `testing.mdc`, `styling.mdc` — `everything.mdc` नहीं। छोटी rules diff करने, review करने और स्वतंत्र scope करने योग्य होती हैं।
+
+**ठोस और जाँच योग्य।** «अच्छे tests लिखें» कुछ नहीं बताता। «`src/core` में हर नए export के लिए sibling `__tests__` folder में unit test चाहिए» — बताता है, और reviewer (या sensor) इसे verify कर सकता है।
+
+**पहले दिखाएँ, फिर बताएँ।** सही pattern का 5-पंक्ति code example तीन अनुच्छेदों से बेहतर काम करता है।
+
+## Skills: प्रक्रियात्मक परत
+
+जो कुछ *runbook* जैसा लगे, वह rule में नहीं, skill में हो:
+
+- Deploy और release प्रक्रियाएँ
+- Database migration workflows
+- «नया API endpoint end-to-end कैसे जोड़ें»
+- Incident debugging playbooks
+
+Skill की गुणवत्ता **description** पर निर्भर करती है — load करने का निर्णय लेते समय एजेंट केवल यही देखता है। तुलना करें:
+
+```yaml
+description: Deployment stuff            # never triggers
+```
+
+```yaml
+description: Use when the user asks to deploy, release, or ship to
+  production; covers tagging, the pipeline, rollback, and smoke tests.
+```
+
+Descriptions को trigger conditions के रूप में लिखें («Use when…»), ≥40 characters, वे शब्द बताते हुए जो user वास्तव में कहेगा।
+
+## Commands: अपनी टीम की क्रियाएँ encode करें
+
+Commands *मनुष्य और एजेंट दोनों* के लिए guides हैं: `/review`, `/release`, `/new-endpoint` — executable रूप में आपकी टीम कैसे काम करती है, यह दर्शाते हैं। अच्छा command prompt workflow, quality bar और stopping condition बताता है:
+
+```markdown
+# /review
+
+Review the current diff against AGENTS.md and .cursor/rules/.
+Report findings ordered by severity with file:line references.
+Do not fix anything unless explicitly asked.
+```
+
+## Bootstrap scripts और templates
+
+Fowler bootstrap tooling को feedforward नियंत्रणों में गिनता है: generators और templates जो एजेंट को ज्ञात-अच्छे skeleton से शुरू करते हैं (`npm run new:endpoint`, observability wired-in service template)। जब pattern बिल्कुल वैसा ही दोहराना हो, generator pattern के description से बेहतर — फिर से determinism। ऐसे scripts `AGENTS.md` में उल्लेख करें ताकि एजेंट hand-rolling के बजाय उन्हें इस्तेमाल करें।
+
+## Guides कैसे विफल होते हैं, और क्या पकड़ता है
+
+| विफलता | लक्षण | प्रतिकार |
+|---|---|---|
+| Stale guide | एजेंट पुरानी convention follow करता है | architecture छूने वाले PR में harness files review करें |
+| Bloated context | एजेंट file के बीच के निर्देश ignore करता है | rules scope करें; procedures skills में ले जाएँ |
+| Vague guidance | एजेंट creatively interpret करता है | rules को ठोस और जाँच योग्य बनाएँ |
+| Guide ignored | वही गलती बार-बार | sensor या hook पर escalate करें (अध्याय 4–5) |
+
+अंतिम पंक्ति अगले अध्याय का पुल है: guides सुझाव हैं, और कुछ सुझाव **checks** बनने चाहिए।

--- a/docs/hi-IN/guide/maturity-model.md
+++ b/docs/hi-IN/guide/maturity-model.md
@@ -1,0 +1,85 @@
+# परिपक्वता मॉडल
+
+यह अध्याय maturity model परिभाषित करता है — वही assessment framework जो [`npx harness-score`](./measure-and-improve) implement करता है, इसलिए यहाँ पढ़ा गया level वही है जिसे आप measure, reproduce, और gate पर लगा सकते हैं।
+
+आकार परिचित capability-maturity patterns (DORA *capabilities*, OWASP SAMM *business functions*, CMMI *levels*) का अनुसरण करता है: **dimensions** अभ्यास के क्षेत्र measure करते हैं, **checks** deterministic pass/fail indicators हैं, और **levels** coverage shape पर gate करते हैं — केवल raw percentage नहीं।
+
+डिज़ाइन लक्ष्य:
+
+- **Deterministic।** हर check filesystem fact है: file मौजूद है, parse होती है, pattern match। कोई model नहीं, judgment calls नहीं, network नहीं।
+- **Harness-agnostic, Cursor flagship example।** किसी supported AI-first tool (Cursor, Windsurf, Claude Code, Codex/Antigravity `.agents/`, OpenCode, Cline, Continue, Copilot instructions, Zed) के rules, skills, hooks, commands OR semantics से score — एक configured tool काफी। Universal harness infrastructure (tests, linters, types, CI) IDE से स्वतंत्र same control system बनाती है।
+- **Grade नहीं, सीढ़ी।** Levels harness के *shape* (कौन-से dimensions covered) पर gate — केवल raw percentage नहीं — guides के 80 points, sensors शून्य, maturity नहीं।
+
+## छह dimensions
+
+108 points, छह dimensions में:
+
+| Dimension | Points | क्या measure होता है |
+|---|---|---|
+| Context & Guides | 20 | AGENTS.md, rules quality और scoping |
+| Skills & Commands | 17 | Procedural knowledge, explicit workflows, subagents |
+| Hooks & Guardrails | 14 | Runtime-enforced gates और feedback |
+| Sensors & Feedback | 20 | Tests, linter, types, formatter |
+| CI Feedback | 14 | Pipeline checks, pre-commit |
+| Hygiene & Safety | 23 | Secrets, env files, lockfile, license, MCP config |
+
+हर dimension individual checks का योग है (remediations सहित पूरा catalog [अध्याय 7](./measure-and-improve#the-check-catalog) में)।
+
+## पाँच levels
+
+### L0 · Unharnessed (harness रहित)
+
+Repository एजेंट को कुछ नहीं देती: context file नहीं, rules नहीं, enforced checks नहीं। एजेंट यहाँ काम करते हैं — हमेशा करते हैं — पर हर session project scratch से rediscover करता है और हर गलती ship हो जाती है जब तक human न पकड़े। अधिकांश repositories यहीं से शुरू।
+
+### L1 · Documented (दस्तावेज़ीकृत)
+
+**आवश्यक: Context & Guides ≥ 40%.**
+
+ठोस `AGENTS.md` (या equivalent): project क्या है, build और test कैसे, conventions क्या। शून्य से सबसे अधिक leverage — एक file में हर future session के लिए feedforward।
+
+### L2 · Guided (मार्गदर्शित)
+
+**आवश्यक: Context ≥ 60% · (Skills ≥ 30% या Hooks ≥ 30%) · Hygiene ≥ 50%.**
+
+Guidance संरचित: valid frontmatter वाली scoped rules (`.cursor/rules/`, `.windsurf/rules/`, `.clinerules/`, या आपके tool का equivalent), और procedural knowledge की शुरुआत (skill, command/workflow, या subagent) या hook machinery। Basic hygiene — env files ignored, harness files में credential signatures नहीं। Harness code के साथ ship होता है और code की तरह review।
+
+### L3 · Sensing (sensors के साथ)
+
+**L2 आवश्यक, और: Sensors ≥ 60% · CI ≥ 50%.**
+
+Feedback loop मौजूद। Tests एजेंट चला सके, linter, type checking, CI pipeline हर push re-verify। यह वह level जहाँ स्व-सुधार शुरू: एजेंट deterministic tools से *अपना काम check* कर सकता है, pipeline जो छूटे पकड़ता है। अधिकांश teams के लिए L3 वह बिंदु जहाँ AI-assisted development risky नहीं लगता।
+
+### L4 · Self-correcting (स्व-सुधार)
+
+**L3 आवश्यक, और: Hooks ≥ 70% · total score ≥ 80%.**
+
+Loop runtime पर बंद। Gate hooks destructive actions impossible बनाते हैं, discouraged नहीं; feedback hooks हर edit पर lint और format, session के अंदर। Guides, sensors, guardrails सभी छह dimensions cover। गलती अब rules, on-edit hooks, tests, type checker, CI, *और* gates — ज़्यादातर बिना human — पार करनी होगी।
+
+## Score पढ़ना
+
+दो repositories 65% score कर सकते हैं, shape बिल्कुल अलग — इसलिए levels dimensions पर gate:
+
+- **65%, सब guides, sensors नहीं** → L1। दस्तावेज़ अच्छे, पर verify नहीं। प्राथमिकता: tests + CI, और prose नहीं।
+- **65%, strong sensors, context नहीं** → L0/L1। एजेंट का काम check होता है पर हर session conventions अनुमान। प्राथमिकता: एक दोपहर `AGENTS.md` और तीन scoped rules।
+
+Scanner सटीक print करता है कौन-सी requirement अगला level block (`To reach L3: sensors ≥ 60%; ci ≥ 50%`), सुधार का रास्ता ambiguous नहीं।
+
+## Model जानबूझकर क्या measure नहीं करता
+
+Determinism की सीमाओं पर ईमानदारी (Fowler का «behavior harness immature» caveat measurement पर भी):
+
+- **आपके tests अच्छे हैं या नहीं** — केवल exist, run, gate।
+- **आपकी rules सच हैं या नहीं** — stale rule fresh जैसा score।
+- **Functional correctness** — static scan behavior verify नहीं कर सकता।
+- **Team practice** — branch protection, review culture, agent workflows repository tree के बाहर।
+
+High score का मतलब reliable agent work के लिए *infrastructure* मौजूद। आवश्यक, पर्याप्त नहीं — deterministic scanner ईमानदारी से claim कर सकता है, उसकी ceiling।
+
+## सीढ़ी का उपयोग
+
+1. `npx harness-score` चलाएँ — level और exact gaps।
+2. एक level एक बार; हर level की requirements एक focused effort (L1: AGENTS.md → L2: rules + hygiene → L3: sensors + CI → L4: hooks)।
+3. CI में level gate (`--min-level`) ताकि maturity केवल ऊपर की ओर बढ़े।
+4. दिखाएँ — README बैज (`harness` · `L4`) और optional [share card](./measure-and-improve#show-your-maturity)। वही pill CI (`--badge`) या pinned static file से।
+
+अध्याय 7 हर step check-by-check चलता है।

--- a/docs/hi-IN/guide/measure-and-improve.md
+++ b/docs/hi-IN/guide/measure-and-improve.md
@@ -1,0 +1,600 @@
+# मापन और सुधार
+
+इस गाइड का सार एक कमांड में समेटा गया है:
+
+```bash
+npx harness-score
+```
+
+स्कैनर आपके रिपॉज़िटरी को पार करता है (केवल फ़ाइलसिस्टम — बिना LLM, बिना नेटवर्क, बिना टेलीमेट्री), किसी भी AI टूल पर 36 निश्चित checks चलाता है, और अगले स्तर तक की सटीक कमियों के साथ परिपक्वता स्तर रिपोर्ट करता है:
+
+```
+  harness-score v1.0.0  /work/my-app
+
+  Maturity: L2 · Guided   Score: 66/108 (61%)
+  Detected: Cursor, Claude Code
+
+  Context & Guides     ████████████████░░░░  80%
+  Skills & Commands    █████████████░░░░░░░  67%
+  Hooks & Guardrails   ░░░░░░░░░░░░░░░░░░░░   0%
+  ...
+
+  To reach L3: sensors ≥ 60%; ci ≥ 50%
+```
+
+> **मल्टी-टूल:** स्कैनर Cursor, Claude Code, Windsurf, Cline, Continue और अन्य टूल के harness artifacts को OR semantics से पहचानता है — यदि आप कोई एक टूल कॉन्फ़िगर करते हैं, तो Harness Score उसे गिनता है। अधिक जानकारी: [मल्टी-harness सपोर्ट](./multi-harness)।
+
+## इंस्टॉल करना
+
+```bash
+npx harness-score                                       # no install
+npm install -g harness-score                            # global binary
+npm install --save-dev harness-score                    # pinned devDependency
+```
+
+[GitHub Packages](https://github.com/paladini/harness-score/pkgs/npm/harness-score)
+(`@paladini/harness-score`) और [JSR](https://jsr.io/@paladini/harness-score) पर भी
+Deno/Bun प्रोजेक्ट के लिए उपलब्ध है।
+
+## लाइब्रेरी के रूप में उपयोग
+
+CLI पूर्ण-टाइप्ड प्रोग्रामेटिक API के चारों ओर एक पतला wrapper है — कस्टम डैशबोर्ड, बॉट, या किसी भी टूल के लिए उपयोगी जो टर्मिनल आउटपुट पार्स करने के बजाय कच्चा `Report` चाहता है:
+
+```ts
+import { score } from 'harness-score';
+
+const report = score('/path/to/repo');
+console.log(report.level.name, report.score.percent, report.dimensions);
+```
+
+`Report`, `Check`, `CheckResult`, `DimensionScore`, `LevelInfo` और हर अन्य shape TypeScript declarations के रूप में शिप होते हैं — स्पष्ट `"types"` फ़ील्ड के ज़रिए resolve होते हैं, इसलिए एडिटर और `tsc` बिना अतिरिक्त कॉन्फ़िगरेशन के उन्हें पहचान लेते हैं। निचले-स्तर के building blocks भी export हैं, जो `score()` सीधे कवर नहीं करता:
+
+```ts
+import { createScanContext, buildReport, computeDiff, renderMarkdown } from 'harness-score';
+
+const ctx = createScanContext('/path/to/repo');   // walk the filesystem once
+const report = buildReport(ctx);                  // run all 36 checks against it
+const markdown = renderMarkdown(report);          // same renderer the CLI's --md uses
+```
+
+## CLI संदर्भ
+
+```bash
+harness-score [path]              # human report (default: current directory)
+harness-score --json              # full report as JSON
+harness-score --md report.md      # markdown report (use "-" for stdout)
+harness-score --badge badge.svg   # SVG pill: harness + detected level (L0–L4)
+harness-score --min-level 3       # exit 1 if below L3 — the CI gate
+harness-score --diff base.json    # compare against a previous --json report
+```
+
+### समय के साथ स्कोर ट्रैक करना {#diff-mode}
+
+`--diff <file>` वर्तमान स्कैन की तुलना पहले `--json` रन से सहेजी गई baseline रिपोर्ट से करता है — स्तर और स्कोर के deltas, प्रति-आयाम गति, और ठीक-ठीक कौन-से checks बदले:
+
+```bash
+harness-score --json > baseline.json   # save today's report
+# ...later, after changes...
+harness-score --diff baseline.json     # see what moved
+```
+
+```
+  Compared to baseline:
+    Level: L2 · Guided → L3 · Sensing (+1)
+    Score: 61/108 (56%) → 84/108 (78%) (+22pp)
+    Sensors & Feedback   20% → 90% (+70pp)
+    Newly passing: SNS-01, SNS-02, SNS-04, CI-01, CI-02
+```
+
+`--diff` `--json` (payload में `current`/`baseline`/`diff` जोड़ता है) और `--md` («Compared to baseline» सेक्शन जोड़ता है) दोनों के साथ काम करता है — GitHub Action PR पर «harness score L2 से L3 हो गया» जैसी टिप्पणियाँ पोस्ट करने के लिए इसी का उपयोग करता है।
+
+## Cursor प्लगइन {#the-cursor-plugin}
+
+[इस रिपॉ repo के प्लगइन डायरेक्टरी](https://github.com/paladini/harness-score/tree/main/plugins/cursor) से **Harness Score** इंस्टॉल करें
+(Cursor Marketplace लिस्टिंग जमा है और समीक्षा लंबित है — लाइव होने पर यह लिंक वहाँ चला जाएगा) और आपको मिलेगा:
+
+- **`/harness-audit`** — खुले workspace पर स्कैनर चलाता है और एजेंट से रिपोर्ट उसकी शीर्ष remediations के साथ प्रस्तुत करवाता है।
+- **`harness-engineering` skill** — जब आप «ठीक करो» या «मेरा harness सुधारो» कहते हैं, तो एजेंट जानता है कि इस गाइड की recipes के अनुसार missing artifacts कैसे लिखने हैं।
+
+विश्लेषण हमेशा deterministic CLI ही है; मॉडल केवल परिणाम दिखाता है और आपके कहे अनुसार fixes लागू करता है।
+
+## CI गेट {#ci-gate}
+
+Harness चुपचाप पीछे हट जाता है — किसी ने सफ़ाई में `hooks.json` हटा दिया, rules फ़ाइल सड़ गई। CI में अपना स्तर केवल ऊपर की ओर रखें:
+
+```yaml
+- name: Harness gate
+  run: npx -y harness-score --min-level 3
+```
+
+या packaged action का उपयोग करें, जो बैज भी emit करता है:
+
+```yaml
+- uses: paladini/harness-score/action@main
+  with:
+    min-level: '3'
+    badge: 'harness-badge.svg'
+```
+
+## अपनी परिपक्वता दिखाएँ {#show-your-maturity}
+
+Harness Score **दो ब्रांडेड SVG फ़ॉर्मेट** शिप करता है, स्कैनर की progress bars के समान visual language में — कोई shields.io नहीं, कोई paid service नहीं, render समय पर नेटवर्क नहीं:
+
+| फ़ॉर्मेट | फ़ाइलें | दिखाता है | सबसे अच्छा |
+|---|---|---|---|
+| **बैज** | `harness-badge.svg` या `badge-l0.svg` … `badge-l4.svg` | `harness` · `L4` | README पंक्ति (112×20 कैप्सूल बैज) |
+| **शेयर कार्ड** | `card-l0.svg` … `card-l4.svg` | स्तर नाम के साथ पूर्ण बैनर | सोशल पोस्ट, repo hero (860×240) |
+
+बैज हमेशा **केवल स्तर** (`L0`–`L4`) दिखाता है। स्तर नाम
+(Unharnessed, Guided, …) शेयर कार्ड और स्कैनर आउटपुट में होते हैं।
+
+कैप्सूल बैज एक जैसा दिखता है चाहे CI उसे दोबारा generate करे या आप static फ़ाइल pin करें —
+केवल wiring अलग है।
+
+### बैज — स्व-अपडेट (अनुशंसित)
+
+`harness-score --badge` स्कैनर द्वारा detect किए गए स्तर के लिए SVG लिखता है।
+CI में एक बार wire करें; README की छवि आपके harness के सुधरने पर खुद अपडेट होती रहती है।
+
+```yaml
+# .github/workflows/harness.yml
+name: Harness Score
+on: { push: { branches: [main] } }
+permissions: { contents: write }
+jobs:
+  harness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: paladini/harness-score/action@main
+        with: { badge: 'harness-badge.svg' }
+      - uses: JamesIves/github-pages-deploy-action@v4
+        with: { branch: badges, folder: ., clean: false }
+```
+
+README में published फ़ाइल reference करें — पूर्ण copy-paste recipes
+[Embed snippets](#embed-snippets) में:
+
+```md
+<img alt="Harness Score" src="https://raw.githubusercontent.com/<you>/<repo>/badges/harness-badge.svg" height="20">
+```
+
+`<img>` पर `height="20"` सेट करें ताकि कैप्सूल बैज उसी पंक्ति में npm/CI shields के साथ align हो
+(112×20 SVG; केवल स्तर — स्कोर प्रतिशत CLI रिपोर्ट में रहता है)।
+
+Dogfood उदाहरण (इस गाइड का GitHub Pages पर live बैज):
+
+<div class="hs-visual">
+  <p class="hs-visual-label">Badge (this repo)</p>
+  <div class="hs-badge-row">
+    <img class="hs-badge" src="/harness-badge.svg" alt="Harness Score" height="20">
+  </div>
+</div>
+
+detect किए गए स्तर का matching शेयर कार्ड
+`harness-card.svg` के रूप में publish होता है (वर्तमान में इस रिपॉ के लिए L4):
+
+<img class="hs-share-card" src="/harness-card.svg" alt="Harness Score L4 · Self-correcting">
+
+### बैज — स्तर pin करें
+
+वही कैप्सूल बैज, static फ़ाइल — यदि आप CI से छवि regenerate नहीं चाहते, तो `badge-l0.svg` … `badge-l4.svg` चुनें। Markdown, HTML, iframe, JSX और अन्य के लिए [Embed snippets](#embed-snippets) देखें।
+
+### शेयर कार्ड
+
+hero छवि या सोशल पोस्ट के लिए, बैनर शेयर कार्ड का उपयोग करें — इसमें स्तर नाम
+(`Unharnessed`, `Guided`, …) शामिल है:
+
+| Level | Badge | Share card |
+|---|---|---|
+| L0 · Unharnessed | [badge-l0.svg](https://paladini.github.io/harness-score/maturity/badge-l0.svg) | [card-l0.svg](https://paladini.github.io/harness-score/maturity/card-l0.svg) |
+| L1 · Documented | [badge-l1.svg](https://paladini.github.io/harness-score/maturity/badge-l1.svg) | [card-l1.svg](https://paladini.github.io/harness-score/maturity/card-l1.svg) |
+| L2 · Guided | [badge-l2.svg](https://paladini.github.io/harness-score/maturity/badge-l2.svg) | [card-l2.svg](https://paladini.github.io/harness-score/maturity/card-l2.svg) |
+| L3 · Sensing | [badge-l3.svg](https://paladini.github.io/harness-score/maturity/badge-l3.svg) | [card-l3.svg](https://paladini.github.io/harness-score/maturity/card-l3.svg) |
+| L4 · Self-correcting | [badge-l4.svg](https://paladini.github.io/harness-score/maturity/badge-l4.svg) | [card-l4.svg](https://paladini.github.io/harness-score/maturity/card-l4.svg) |
+
+<div class="hs-visual">
+  <p class="hs-visual-label">All badge levels (112×20)</p>
+  <div class="hs-badge-row">
+    <img class="hs-badge" alt="L0" src="/maturity/badge-l0.svg" height="20">
+    <img class="hs-badge" alt="L1" src="/maturity/badge-l1.svg" height="20">
+    <img class="hs-badge" alt="L2" src="/maturity/badge-l2.svg" height="20">
+    <img class="hs-badge" alt="L3" src="/maturity/badge-l3.svg" height="20">
+    <img class="hs-badge" alt="L4" src="/maturity/badge-l4.svg" height="20">
+  </div>
+</div>
+
+<div class="hs-visual">
+  <p class="hs-visual-label">Share card example (860×240)</p>
+  <img class="hs-share-card" alt="L4 · Self-correcting" src="/maturity/card-l4.svg">
+  <p class="hs-visual-detail">ऊपर की तालिका से कोई भी स्तर डाउनलोड करें — शेयर कार्ड में स्तर नाम शामिल होता है।</p>
+</div>
+
+## Embed snippets {#embed-snippets}
+
+शेयर करने के लिए copy-paste recipes। placeholders बदलें:
+
+| Placeholder | स्व-अपडेट बैज | pin किया बैज (स्तर `{N}`) | शेयर कार्ड |
+|---|---|---|---|
+| `{BADGE_URL}` | `https://raw.githubusercontent.com/{owner}/{repo}/badges/harness-badge.svg` | `https://paladini.github.io/harness-score/maturity/badge-l{N}.svg` | — |
+| `{CARD_URL}` | — | — | `https://paladini.github.io/harness-score/maturity/card-l{N}.svg` |
+| `{LINK}` | आपका repo या `https://paladini.github.io/harness-score/` | वही | वही |
+
+`{N}` `0`–`4` है। इस रिपॉ का live बैज (आपके fork पर CI की ज़रूरत नहीं):
+`https://raw.githubusercontent.com/paladini/harness-score/main/docs/public/harness-badge.svg`
+
+**बैज आकार:** 112×20 — हमेशा `height="20"` (या `height={20}`) सेट करें ताकि कैप्सूल बैज shields.io बैज के साथ align हो।
+
+### बैज — Markdown
+
+केवल छवि (GitHub, GitLab, dev.to — यदि plain `![]()` stretch करता है तो HTML उपयोग करें):
+
+```md
+<img alt="Harness Score L4" src="{BADGE_URL}" height="20">
+```
+
+लिंक्ड (क्लिक योग्य):
+
+```md
+[![Harness Score L4]({BADGE_URL})]({LINK})
+```
+
+Reference-style:
+
+```md
+[![Harness Score][hs-badge]][hs-link]
+
+[hs-badge]: {BADGE_URL}
+[hs-link]: {LINK}
+```
+
+### बैज — HTML
+
+```html
+<img alt="Harness Score L4" src="{BADGE_URL}" height="20" width="112">
+```
+
+लिंक्ड:
+
+```html
+<a href="{LINK}">
+  <img alt="Harness Score L4" src="{BADGE_URL}" height="20" width="112">
+</a>
+```
+
+### बैज — iframe
+
+CMS या wiki जो केवल iframe अनुमति देते हैं (`<img>` नहीं):
+
+```html
+<iframe
+  src="{BADGE_URL}"
+  title="Harness Score L4"
+  width="112"
+  height="20"
+  style="border:0;overflow:hidden"
+></iframe>
+```
+
+### बैज — SVG object / embed
+
+```html
+<object data="{BADGE_URL}" type="image/svg+xml" width="112" height="20">
+  <a href="{BADGE_URL}">Harness Score L4</a>
+</object>
+```
+
+```html
+<embed src="{BADGE_URL}" type="image/svg+xml" width="112" height="20" />
+```
+
+### बैज — JSX / React
+
+```jsx
+<a href="{LINK}">
+  <img
+    alt="Harness Score L4"
+    src="{BADGE_URL}"
+    height={20}
+    width={112}
+    style={{ verticalAlign: 'middle' }}
+  />
+</a>
+```
+
+### बैज — AsciiDoc
+
+```asciidoc
+image:{BADGE_URL}[Harness Score L4,link={LINK},height=20]
+```
+
+### बैज — BBCode (forums)
+
+```text
+[url={LINK}][img]{BADGE_URL}[/img][/url]
+```
+
+### बैज — direct URL
+
+chat, Notion image block, Slack, Discord, या किसी भी टूल में paste करें जो
+raw image URL स्वीकार करता है:
+
+```text
+{BADGE_URL}
+```
+
+### शेयर कार्ड — Markdown / HTML
+
+README hero, blog posts, या social previews के लिए बैनर (`{N}` = `0`–`4`):
+
+```md
+[![Harness Score L4 · Self-correcting]({CARD_URL})]({LINK})
+```
+
+```html
+<a href="{LINK}">
+  <img
+    alt="Harness Score L4 · Self-correcting"
+    src="{CARD_URL}"
+    width="560"
+    style="max-width:100%;height:auto;border-radius:8px"
+  />
+</a>
+```
+
+### शेयर कार्ड — iframe
+
+```html
+<iframe
+  src="{CARD_URL}"
+  title="Harness Score L4 · Self-correcting"
+  width="560"
+  height="157"
+  style="border:0;max-width:100%"
+></iframe>
+```
+
+### शेयर कार्ड — direct URL
+
+```text
+{CARD_URL}
+```
+
+### Worked example (pinned L3 badge)
+
+```md
+<a href="https://paladini.github.io/harness-score/">
+  <img alt="Harness Score L3" src="https://paladini.github.io/harness-score/maturity/badge-l3.svg" height="20">
+</a>
+```
+
+```html
+<iframe
+  src="https://paladini.github.io/harness-score/maturity/badge-l3.svg"
+  title="Harness Score L3"
+  width="112"
+  height="20"
+  style="border:0"
+></iframe>
+```
+
+> **shields.io पसंद है?** आपका Action एक छोटी JSON फ़ाइल भी लिख सकता है और
+> [shields endpoint](https://shields.io/badges/endpoint-badge) की ओर point कर सकता है
+> (`{ "schemaVersion": 1, "label": "harness", "message": "L3", "color": "brightgreen" }`)।
+> ऊपर के brand SVG self-contained हैं और किसी third party की ज़रूरत नहीं।
+
+## check कैटलॉग {#the-check-catalog}
+
+स्कैनर जो checks चलाता है, उनकी remediation recipe के साथ। check IDs स्थिर हैं; CLI प्रत्येक failure को यहाँ के entry से लिंक करता है।
+
+### Context & Guides (20 pts)
+
+#### CTX-01 · Agent context file present — 4 pts {#ctx-01}
+रिपॉज़िटरी रूट पर `AGENTS.md` (या `CLAUDE.md` / `GEMINI.md`) मौजूद है।
+**सुधार:** `AGENTS.md` बनाएँ जो इनका उत्तर दे: यह प्रोजेक्ट क्या है, build और test कैसे करें, कौन-सी conventions लागू हैं, क्या कभी न छुएँ। recipe
+[अध्याय 3](./guides-feedforward#writing-an-agents-md-that-works) में।
+
+#### CTX-02 · Context file is substantive — 3 pts {#ctx-02}
+≥20 meaningful lines और ≥2 headings — stub को अंक नहीं मिलते।
+**सुधार:** layout, build और test commands, conventions, और no-go zones कवर करें।
+विवरण से commands; rules paste करने के बजाय उनकी ओर point करें।
+
+#### CTX-03 · Scoped rules in use — 4 pts {#ctx-03}
+किसी भी supported tool के लिए कम से कम एक scoped rule फ़ाइल (जैसे `.cursor/rules/*.mdc`,
+`.windsurf/rules/*.md`, `.clinerules/*.md`, `.continue/rules/*.md`,
+`.github/instructions/*.instructions.md`, `.agents/rules/*`)। subdirectories में nested context
+फ़ाइलें (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md` root के नीचे कहीं भी) भी गिनती हैं — Claude
+Code और Codex जैसे टूल में ये directory-scoped rules हैं।
+**सुधार:** एक छोटी always-on rule से शुरू करें जिसमें non-negotiables हों,
+फिर प्रति area path-scoped rules (या प्रति subtree nested context फ़ाइलें) जोड़ें।
+
+#### CTX-04 · Rules have valid frontmatter — 3 pts {#ctx-04}
+हर rule activation metadata declare करती है (`description`, `globs`/`trigger`/`paths`/`applyTo`, या `alwaysApply`)।
+टूल जो metadata के बिना auto-load करते हैं — `.continue/rules/*` और nested
+context फ़ाइलें — construction से pass होती हैं।
+**सुधार:** frontmatter block जोड़ें; इसके बिना एजेंट decide नहीं कर सकता कि rule
+कब लागू हो।
+
+#### CTX-05 · Rules are scoped — 2 pts {#ctx-05}
+हर rule blanket always-on नहीं है। nested context फ़ाइलें scoped गिनती हैं —
+वे केवल अपने subtree पर लागू होती हैं।
+**सुधार:** rules को paths (`globs:`, `trigger:` glob, `paths:`, `applyTo:`) तक सीमित करें
+ताकि relevant होने पर ही load हों — हर always-on rule हर request के context पर tax लगाती है।
+
+#### CTX-06 · No bloated rules — 2 pts {#ctx-06}
+कोई single rule 500 lines से अधिक नहीं।
+**सुधार:** concern के अनुसार split करें, या procedural content को skill में ले जाएँ।
+
+#### CTX-07 · README present — 1 pt {#ctx-07}
+**सुधार:** README.md जोड़ें; यह humans के लिए पहला orientation document है और
+agents के लिए fallback।
+
+#### CTX-08 · No legacy .cursorrules — 1 pt {#ctx-08}
+deprecated single-file फ़ॉर्मेट absent है (या modern scoped rules भी मौजूद हैं)।
+**सुधार:** `.cursorrules` content को अपने टूल की scoped rules में migrate करें।
+
+### Skills & Commands (17 pts)
+
+#### SKL-01 · At least one skill — 4 pts {#skl-01}
+`.cursor/skills/<name>/`, `.claude/skills/<name>/`, या `.agents/skills/<name>/` के अंतर्गत `SKILL.md`।
+**सुधार:** अपनी सबसे बार-बार दोहराई procedure (deploy, release, migration)
+को skill के रूप में package करें — [अध्याय 3](./guides-feedforward#skills-the-procedural-layer)।
+
+#### SKL-02 · Skills declare name and description — 3 pts {#skl-02}
+हर skill पर frontmatter में `name:` और `description:`।
+**सुधार:** एजेंट केवल इन दो fields से decide करता है कि skill load करनी है या नहीं;
+इनके बिना skill invisible है।
+
+#### SKL-03 · Explicit workflows/commands defined — 3 pts {#skl-03}
+Command या workflow फ़ाइलें (`.cursor/commands/`, `.windsurf/workflows/`,
+`.claude/commands/`, `.continue/prompts/`, `.zed/commands/`, `.agents/workflows/`)।
+**सुधार:** workflows जिन्हें आप जानबूझकर trigger करते हैं (`/review`, `/release`)
+को command/workflow फ़ाइलों के रूप में encode करें।
+
+#### SKL-04 · Skill descriptions are trigger-worthy — 2 pts {#skl-04}
+Descriptions ≥40 characters।
+**सुधार:** descriptions को trigger conditions के रूप में लिखें — «Use when the user asks
+to deploy or release; covers tagging, pipeline, rollback, smoke tests.»
+
+#### AGT-01 · Custom subagent defined — 3 pts {#agt-01}
+`.cursor/agents/`, `.claude/agents/`, या `.opencode/agents/` के अंतर्गत subagent फ़ाइल।
+**सुधार:** primary agent को delegate करने वाले काम (planning, review, release) के लिए purpose-built subagent package करें — देखें
+[Subagents](./cursor-harness-surface#subagents-purpose-built-delegates)
+अध्याय 2 में।
+
+#### AGT-02 · Subagents declare name and description — 2 pts {#agt-02}
+हर subagent definition पर frontmatter में `name:` और `description:`।
+**सुधार:** parent agent केवल इन दो fields से decide करता है कि delegate करना है या नहीं;
+इनके बिना subagent कभी invoke नहीं होता।
+
+### Hooks & Guardrails (14 pts)
+
+#### HKS-01 · Hooks configuration present and valid — 4 pts {#hks-01}
+`.cursor/hooks.json` या `.claude/settings.json` (`hooks` key) मौजूद है और JSON के रूप में parse होता है।
+**सुधार:** hooks config बनाएँ और
+[अध्याय 5](./guardrails-and-safety#gate-hooks) की recipes से बढ़ाएँ।
+
+#### HKS-02 · Known events, version declared — 2 pts {#hks-02}
+Version/metadata मौजूद; हर registered event आपके टूल के लिए documented
+(Cursor lifecycle events, या Claude Code `PreToolUse`/`PostToolUse`)।
+**सुधार:** typo वाले event names silently fail —
+[अध्याय 2](./cursor-harness-surface#hooks-observe-and-control-the-agent-loop) की event list से जाँचें।
+
+#### HKS-03 · Gate hook guards risky operations — 4 pts {#hks-03}
+gate hook registered (Cursor: `beforeShellExecution`, `beforeMCPExecution`,
+`preToolUse`, या `beforeReadFile`; Claude Code: `PreToolUse`)।
+**सुधार:** अध्याय 5 का destructive-command deny gate जोड़ें — prose rules
+requests हैं; gates facts हैं।
+
+#### HKS-04 · Feedback hook observes output — 2 pts {#hks-04}
+feedback hook registered (Cursor: `afterFileEdit`, `postToolUse`, …;
+Claude Code: `PostToolUse`)।
+**सुधार:** edit पर format-and-lint एजेंट को session के अंदर instant feedback देता है।
+
+#### HKS-05 · Hook scripts committed — 2 pts {#hks-05}
+hooks config द्वारा reference किए गए scripts रिपॉ में मौजूद हैं।
+**सुधार:** उन्हें commit करें; missing script की ओर point करने वाला hook author की
+machine के अलावा हर machine पर fail open होता है।
+
+### Sensors & Feedback (20 pts)
+
+#### SNS-01 · Test runner configured — 6 pts {#sns-01}
+वास्तविक test script/config (vitest, jest, pytest, go test, cargo test…)।
+**सुधार:** runner wire करें एक obvious entry point के साथ और AGENTS.md में document करें —
+tests वह तरीका हैं जिससे एजेंट अपना काम verify करता है।
+
+#### SNS-02 · Linter configured — 5 pts {#sns-02}
+eslint/biome, ruff, golangci-lint, rubocop, या equivalent।
+**सुधार:** हर convention जो lint rule के रूप में express हो सकती है, prose की ज़रूरत नहीं रहती।
+
+#### SNS-03 · Type checking in place — 4 pts {#sns-03}
+tsconfig (आदर्श रूप से `strict: true`), mypy/pyright, या statically typed
+language।
+**सुधार:** type checker वह एकमात्र sensor है जो हर agent edit की
+मुफ़्त review करता है — [अध्याय 4](./sensors-feedback#type-checking-the-free-sensor)।
+
+#### SNS-04 · Formatter configured — 3 pts {#sns-04}
+prettier/biome, black/ruff-format, gofmt/rustfmt।
+**सुधार:** diffs में formatting noise review में real mistakes छिपा देता है।
+
+#### SNS-05 · Test files exist — 2 pts {#sns-05}
+tree में कम से कम एक वास्तविक test फ़ाइल।
+**सुधार:** configured runner के साथ zero tests वह green light है जिसे किसी ने earn नहीं किया।
+
+### CI Feedback (14 pts)
+
+#### CI-01 · CI pipeline configured — 4 pts {#ci-01}
+GitHub Actions workflow (या GitLab/CircleCI/Jenkins equivalent)।
+**सुधार:** `.github/workflows/ci.yml` जोड़ें जो हर push पर sensors चलाए।
+
+#### CI-02 · CI runs the tests — 4 pts {#ci-02}
+**सुधार:** कोई agent-authored change merge योग्य नहीं होना चाहिए बिना suite
+fire किए।
+
+#### CI-03 · CI runs lint/typecheck — 3 pts {#ci-03}
+**सुधार:** सस्ते computational sensors हर push पर belong — quality
+left रखें।
+
+#### CI-04 · Pre-commit checks installed — 3 pts {#ci-04}
+husky/lint-staged, `pre-commit`, या lefthook।
+**सुधार:** commit को मिलने वाला earliest feedback; on-edit hooks
+द्वारा miss हुआ कुछ history में जाने से पहले पकड़ता है।
+
+### Hygiene & Safety (23 pts)
+
+#### HYG-01 · .gitignore present — 2 pts {#hyg-01}
+**सुधार:** agents जो देखते हैं वह commit करते हैं; build output और local state
+invisible बनाएँ।
+
+#### HYG-02 · .gitignore covers env files — 3 pts {#hyg-02}
+.gitignore में `.env` pattern।
+**सुधार:** `.env` और `.env.*` जोड़ें (`!.env.example` allow करें) — सबसे सस्ता
+guardrail।
+
+#### HYG-03 · No unprotected .env files — 4 pts {#hyg-03}
+tree में real env फ़ाइलें नहीं जब तक gitignored न हों (templates ठीक हैं)।
+**सुधार:** secrets बाहर ले जाएँ; `.env.example` रखें required
+variables document करने के लिए।
+
+#### HYG-04 · MCP config free of credentials — 4 pts {#hyg-04}
+MCP config (`.cursor/mcp.json`, `.mcp.json`,
+`.agents/mcp_config.json`) में credential signatures नहीं।
+**सुधार:** `${ENV_VAR}` interpolation उपयोग करें — MCP config में inlined key
+हर clone को publish किया secret है।
+
+#### HYG-05 · License present — 2 pts {#hyg-05}
+**सुधार:** LICENSE जोड़ें; open-source use और plugin marketplaces के लिए आवश्यक।
+
+#### HYG-06 · No secrets in harness files — 2 pts {#hyg-06}
+AGENTS.md, rules, और hooks config token signatures से clean हैं।
+**सुधार:** ये फ़ाइलें हर session में model context में load होती हैं — वहाँ key
+design से exfiltrate होती है।
+
+#### HYG-07 · Lockfile committed — 3 pts {#hyg-07}
+package-lock.json, uv.lock, Cargo.lock, go.sum, या equivalent।
+**सुधार:** reproducible installs का मतलब sensors हर जगह same dependency
+tree test करते हैं।
+
+#### HYG-08 · MCP config uses env interpolation for credentials — 3 pts {#hyg-08}
+MCP config फ़ाइल valid है, और credential-shaped field (token, key,
+secret, password…) literal के बजाय `${ENV_VAR}` interpolation उपयोग करता है।
+HYG-04 का positive complement — MCP setup न होने वाले repo को यहाँ अंक नहीं,
+जैसे कोई अन्य bonus check।
+**सुधार:** secrets को `"${VAR_NAME}"` के रूप में reference करें और `.env.example` में required
+variables document करें।
+
+## एक worked improvement plan
+
+typical L0 product repo से शुरू, प्रति स्तर एक focused session:
+
+1. **→ L1 (एक दोपहर)।** `AGENTS.md` लिखें (CTX-01/02)। build/test
+   commands शामिल करें भले sensors weak हों — एजेंट उन्हें उपयोग करेगा।
+2. **→ L2 (एक दिन)।** तीन scoped rules + एक skill आपकी सबसे बार-बार procedure के लिए
+   (CTX-03…06, SKL-01/02)। hygiene ठीक करें: gitignore, env files,
+   license (HYG-01…05)।
+3. **→ L3 (असली काम, यदि sensors missing हैं)।** test runner + linter +
+   strict types + तीनों चलाने वाला `ci.yml` (SNS-*, CI-01…03)। यदि पहले से
+   हैं, यह स्तर free है।
+4. **→ L4 (एक सुबह)।** अध्याय 5 के दो hooks — एक gate, एक
+   formatter — scripts के साथ commit (HKS-*), pre-commit (CI-04),
+   फिर CI में `--min-level 4` ताकि कभी regress न हो।

--- a/docs/hi-IN/guide/multi-harness.md
+++ b/docs/hi-IN/guide/multi-harness.md
@@ -1,0 +1,192 @@
+# Multi-Harness Support
+
+**v0.4.0** से Harness Score आपके AI coding harness की maturity **किसी भी tool** पर मापता है — केवल Cursor पर नहीं। चाहे Cursor, Claude Code, Windsurf, Cline, Continue, Codex, या कोई और AI-first IDE या editor उपयोग करें, वही 108-point scoring model लागू होता है।
+
+## Multi-harness support क्यों मायने रखता है
+
+harness tool-agnostic है। अच्छी तरह लिखा `AGENTS.md`, secrets सुरक्षित रखने वाला `.gitignore`, tests चलाने वाला CI pipeline — Cursor, Claude Code, Windsurf या किसी agent के लिए समान रूप से काम करते हैं। एक बार बनाया harness infrastructure आपके project में *हर* AI tool को लाभ देता है।
+
+Harness Score इसे explicit करता है: एक बार measure करें, कोई भी tool लाभ पाता है। Cursor harness और Claude Code harness अलग-अलग नहीं बनाते — *एक harness* बनाते हैं, और हर compatible tool जो समझता है वह हिस्सा inherit करता है।
+
+## कैसे काम करता है: OR semantics
+
+Scanner tool-specific artifacts के लिए **OR semantics** उपयोग करता है। हर check पूछता है "क्या *कोई* recognized tool यह provide करता है?" — "क्या Cursor provide करता है?" नहीं। उदाहरण:
+
+- `.cursor/rules/*.mdc` **या** `.windsurf/rules/*.md` **या** `.clinerules/*.md` **या** nested `CLAUDE.md` → **rules** में गिनता है
+- `.cursor/hooks.json` **या** `hooks` section वाला `.claude/settings.json` → **hooks** में गिनता है
+- `.cursor/skills/<name>/SKILL.md` **या** `.claude/skills/<name>/SKILL.md` → **skills** में गिनता है
+- `.cursor/agents/*.md` **या** `.claude/agents/*.md` **या** `.opencode/agents/*.md` → **subagents** में गिनता है
+- root `AGENTS.md` **या** `CLAUDE.md` **या** `GEMINI.md` → **context guides** में गिनता है
+
+सब configure करना ज़रूरी नहीं — एक काफी है। v0.5.0 से दूसरा tool जोड़ने से score कभी *कम* नहीं होता: कई hooks config होने पर सबसे अधिक registered events वाला जीतता है।
+
+## Supported tools
+
+Harness Score ये artifacts पहचानता है (exact patterns scanner के harness registry में — [`registry.ts`](https://github.com/paladini/harness-score/blob/main/packages/cli/src/harness/registry.ts)):
+
+| Tool | Rules | Skills | Commands / workflows | Subagents | Hooks | MCP |
+|---|---|---|---|---|---|---|
+| **Cursor** | `.cursor/rules/*.mdc` | `.cursor/skills/*/SKILL.md` | `.cursor/commands/*.md` | `.cursor/agents/*.md` | `.cursor/hooks.json` | `.cursor/mcp.json` |
+| **Claude Code** | nested `CLAUDE.md` files | `.claude/skills/*/SKILL.md` | `.claude/commands/*.md` | `.claude/agents/*.md` | `.claude/settings.json` (`hooks` key) | `.mcp.json` |
+| **Windsurf** | `.windsurf/rules/*.md` | — | `.windsurf/workflows/*.md` | — | — | — |
+| **Cline** | `.clinerules/*.md` | — | — | — | — | — |
+| **Continue** | `.continue/rules/*.md` | — | `.continue/prompts/*` | — | — | — |
+| **GitHub Copilot** | `.github/instructions/*.instructions.md` | — | — | — | — | — |
+| **Codex** | nested `AGENTS.md` files | `.agents/skills/*/SKILL.md` | — | — | — | — |
+| **Gemini / Antigravity** | `.agents/rules/`, `.agent/rules/`, `.gemini/rules/`, nested `GEMINI.md` | `.agents/skills/*/SKILL.md` | `.agents/workflows/`, `.agent/workflows/` | — | — | `.agents/mcp_config.json`, `.agent/mcp_config.json` |
+| **OpenCode** | — | — | — | `.opencode/agents/*.md` | — | — |
+| **Zed** | — | — | `.zed/commands/*.md` | — | — | — |
+
+Root context files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) हर tool के लिए गिनती हैं।
+और सबसे महत्वपूर्ण artifacts **tool-agnostic** हैं: tests, CI pipelines, linters, type checkers, `.gitignore`, lockfiles, और `SECURITY.md` — कौन सा tool उपयोग करें, score समान।
+
+::: tip किसी tool का column sparse होना penalty नहीं है
+Windsurf के लिए scanner hooks system recognize नहीं करता — पर hooks छह dimensions में से एक हैं। rules, sensors और CI मजबूत Windsurf-only repository भी L3 तक पहुँच सकती है। L4 के लिए gate hooks चाहिए, जिसका मतलब आज `.cursor/hooks.json` या Claude Code `settings.json` primary tool के साथ।
+:::
+
+## अपना harness एक बार बनाएँ
+
+Multi-tool repository के लिए typical upgrade path:
+
+1. **एक tool से शुरू करें** (जैसे Cursor)। `AGENTS.md` लिखें, `.cursor/rules/` जोड़ें, sensors (tests, linting, types, CI) setup करें।
+2. **टीम दूसरा tool जोड़ती है** (जैसे Claude Code)। shared artifacts — `AGENTS.md`, tests, CI, hygiene — पहले से काम करते हैं। tool-native pieces केवल जहाँ behavior अलग हो: directory-scoped guidance के लिए nested `CLAUDE.md`, hooks के लिए `.claude/settings.json`।
+3. **harness एक जगह रहता है।** सभी sensors, guards और guides repo-level — हर tool automatically inherit करता है।
+4. **Tools पर नहीं, maturity पर gate करें।** CI `harness-score --min-level 3` चलाता है और हर tool को समान standard पर रखता है।
+
+## Practical examples
+
+### Example 1: Cursor-first repo में Claude Code जोड़ना
+
+आपके पास strong Cursor setup वाली repo है:
+
+```
+.cursor/
+  rules/
+    best-practices.mdc
+    architecture.mdc
+  hooks.json
+  skills/
+    refactor/
+      SKILL.md
+AGENTS.md
+```
+
+टीम Cursor के साथ Claude Code भी चाहती है। कुछ ज़रूरी नहीं —
+score ऊपर सब कुछ पहले से गिनता है। Claude Code sessions को वही guidance देने के लिए जो Cursor `.cursor/rules/` से पाता है, Claude-native equivalents जोड़ें:
+
+- **Directory-scoped guidance**: subdirectories में `CLAUDE.md` रखें जहाँ `.mdc` rules scoped थे (v0.5.0 से nested `CLAUDE.md` scoped rules गिनते हैं)। कई टीमें root `CLAUDE.md` को `AGENTS.md` की one-line pointer — या symlink — बनाती हैं, single source of truth के लिए।
+- **Hooks**: gate hook को `.claude/settings.json` में mirror करें (Example 3 देखें)।
+- **Subagents**: `.claude/agents/reviewer.md` उसी subagent check में गिनता है जैसे `.cursor/agents/reviewer.md`।
+
+किसी भी तरह Harness Score सबसे strong configuration गिनता है — दूसरा tool जोड़ने से score केवल बना या बढ़ सकता है, कभी कम नहीं।
+
+### Example 2: Greenfield, day one से multi-tool
+
+नया project जो Cursor और Windsurf दोनों उपयोग करेगा। एक बार बनाएँ:
+
+1. root में `AGENTS.md` लिखें।
+2. architecture और naming conventions के लिए `.cursor/rules/` बनाएँ।
+3. Windsurf को ज़रूरी rules `.windsurf/rules/` में mirror करें (plain markdown, `.mdc` frontmatter नहीं)।
+4. tests लिखें, CI configure करें, linter जोड़ें।
+5. `npx harness-score` चलाएँ → L2 या उससे ऊपर। दोनों tools equally well-supported।
+
+### Example 3: Safety के लिए hooks (कई tools लाभ)
+
+dangerous shell commands block करने के लिए gate hook जोड़ते हैं। Cursor format में:
+
+```json
+// .cursor/hooks.json
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      { "command": "./scripts/hooks/gate-shell.sh" }
+    ]
+  }
+}
+```
+
+Claude Code अलग config file और event names उपयोग करता है, पर वही script:
+
+```json
+// .claude/settings.json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/scripts/hooks/gate-shell.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Harness Score "Hooks & Guardrails" dimension में किसी एक को reward करता है — gate
+events (`beforeShellExecution`, `PreToolUse`) gate-hook checks satisfy करते हैं,
+और referenced script repo में actually मौजूद होना चाहिए (committed hook scripts checks validate करने का हिस्सा)। एक script, दो configs, दोनों tools protected।
+
+## Scoring logic
+
+Scanner हर dimension OR semantics से evaluate करता है, फिर repository को single **maturity level** assign करता है। thresholds (scanner के `LEVEL_REQUIREMENTS` से mirror):
+
+- **L0 · Unharnessed** → default; कोई requirement पूरी नहीं।
+- **L1 · Documented** → context ≥ 40% (substantive root guide)।
+- **L2 · Guided** → context ≥ 60%, skills ≥ 30% **या** hooks ≥ 30%, hygiene ≥ 50%।
+- **L3 · Sensing** → sensors ≥ 60% और CI ≥ 50%।
+- **L4 · Self-correcting** → hooks ≥ 70% और total score ≥ 80%।
+
+Level पूरी repository पर लागू, per-tool नहीं। यह जानबूझकर है: developer ने जो tool चुना, AI-assisted work की overall quality बढ़ाना goal है। पूरा model, threshold प्रति rationale, [Maturity Model](./maturity-model) में है।
+
+## Migrations और tool changes
+
+Primary tool बदलें (जैसे Cursor → Claude Code), harness gradually transfer होता है और score cliff-drop नहीं होता:
+
+1. Claude-native artifacts (nested `CLAUDE.md`, `.claude/skills/`, `.claude/settings.json` hooks) existing `.cursor/` config के साथ जोड़ें।
+2. `npx harness-score` चलाएँ → **same level**, क्योंकि guides, tests, CI और hygiene tool-agnostic हैं, और दोनों tools के artifacts same checks satisfy करते हैं।
+3. जब कोई Cursor उपयोग न करे, पुराना `.cursor/` config deprecate करें (optional — रखने की कोई लागत नहीं)।
+4. Harness Score दोनों recognize करता रहता है — regression risk नहीं।
+
+## Limitations और roadmap
+
+**Current (v1.0.0):**
+
+- Plugin support staggered: **Cursor** (flagship, full audit-and-fix), **Claude Code** (Phase 0, read-only audit), बाकी TBD ([PLUGINS-ROADMAP.md](https://github.com/paladini/harness-score/blob/main/PLUGINS-ROADMAP.md) देखें)।
+- CLI tool-aware और fully multi-harness: terminal और markdown reports `Detected:` line दिखाते हैं जो हर recognized tool नाम लेती है, `--json` output में `detectedHarnesses` array। Plugins समय के साथ catch up करेंगे।
+- Hooks केवल Cursor और Claude Code के लिए recognized — अन्य tools के hook systems (जैसे emerge हों) registry entries चाहिए।
+
+**Planned (post-1.0):**
+
+- Interactive `harness-score init` scaffolding (per tool deterministic templates)।
+- Enterprise CI/security tooling के लिए SARIF output।
+- Ecosystem detector improvements (और tool variants और config locations recognize)।
+
+## FAQs
+
+**Q: क्या सभी supported tools configure करने होंगे?**
+
+A: नहीं। Cursor configure करें, Harness Score गिनता है। बाद में Claude Code artifacts जोड़ें, दोनों recognized — पर एक well-configured tool score के लिए काफी है।
+
+**Q: केवल Cursor उपयोग करूँ, तो score share कर सकता हूँ?**
+
+A: हाँ। Maturity level repo-level measure है, tool-level नहीं। L3 repository का मतलब "यहाँ AI-assisted work well-gated और verified है" — *कौन सा* tool, specify नहीं करता। बैज share करें तो credible है, चाहे टीम Cursor, Claude Code, या दोनों उपयोग करे।
+
+**Q: मेरा tool list में नहीं है तो?**
+
+A: tool का config format के साथ issue खोलें, support जोड़ देंगे। इस बीच reliable path: (1) `AGENTS.md` + tool-agnostic sensors (tests, linters, types, CI), जो हर जगह काम करते हैं, या (2) अपने tool के harness artifacts को recognized ones से map करें।
+
+**Q: कौन से tools detect हुए, देख सकता हूँ?**
+
+A: हाँ — `npx harness-score --json` में `detectedHarnesses` array। typical CI flow:
+
+```yaml
+- name: Audit harness maturity
+  run: npx harness-score --min-level 3
+
+- name: Fail if no tool is configured
+  run: npx harness-score --json | jq -e '.detectedHarnesses | length > 0'
+```
+
+यह ensure करता है maturity gate pass हो *और* कम से कम एक tool का harness recognized हो (`jq -e` non-zero exit जब expression `false` हो)।

--- a/docs/hi-IN/guide/references.md
+++ b/docs/hi-IN/guide/references.md
@@ -1,0 +1,39 @@
+# संदर्भ
+
+इस guide में समेकित स्रोत, प्रभाव के क्रम में लगभग।
+
+## Harness engineering
+
+- **[Harness engineering for coding agent users](https://martinfowler.com/articles/harness-engineering.html)** — martinfowler.com, April 2026.
+  Agents *उपयोग* करने वाली teams के लिए discipline frame करने वाला लेख: guides vs sensors, computational vs inferential checks, तीन regulation dimensions (maintainability, architecture fitness, behavior), «keep quality left», और harnessability codebase property के रूप में।
+- **[Harness Engineering — first thoughts](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering-memo.html)** — *Exploring Gen AI* series की earlier memo जहाँ term shape लेता है।
+- **[Improving Deep Agents with harness engineering](https://www.langchain.com/blog/improving-deep-agents-with-harness-engineering)** — LangChain, 2026.
+  Empirical case: model untouched, Terminal Bench 2.0 पर 52.8% → 66.5%। Self-verification loops, context assembly middleware, loop detection, reasoning sandwich।
+- **[deepagents](https://github.com/langchain-ai/deepagents)** — LangChain का open-source «batteries-included agent harness»; concrete harness implementation पढ़ने के लिए उपयोगी।
+
+## Tool documentation
+
+### Cursor (flagship)
+
+- **[Rules](https://cursor.com/docs/rules)** — `.cursor/rules/*.mdc`, frontmatter, AGENTS.md।
+- **[Agent Skills](https://cursor.com/docs/skills)** — SKILL.md standard और Cursor skills कैसे load करता है।
+- **[Hooks](https://cursor.com/docs/agent/hooks)** — hooks.json, full event list, permission decisions।
+- **[Plugins](https://cursor.com/docs/plugins)** — plugin structure, manifest, installation modes।
+- **[Cursor Marketplace](https://cursor.com/marketplace)** और
+  **[plugin spec repository](https://github.com/cursor/plugins)** — plugins package, review, distribute कैसे होते हैं।
+
+### Claude Code, Windsurf, और अन्य
+
+[Multi-Harness Support](./multi-harness) देखें — Harness Score Claude Code (`.claude/agents/`, hooks), Windsurf (`.windsurf/rules/`), Cline (`.clinerules/`), Continue, Codex, और अन्य tools के equivalent artifacts कैसे पहचानता है।
+
+## Adjacent work
+
+- Anthropic effective agents और agent SDKs पर — अधिकांश context-engineering advice Cursor harnesses में सीधे transfer।
+- Tools across Agent Skills open standard — Cursor skills portable क्यों हैं।
+- ArchUnit, dependency-cruiser, import-linter — [अध्याय 4](./sensors-feedback) में referenced architecture fitness functions।
+
+## इस project के बारे में
+
+`harness-score` (scanner, यह guide, Cursor plugin, GitHub Action) MIT under open source:
+[github.com/paladini/harness-score](https://github.com/paladini/harness-score)।
+Repository सब कुछ dogfood करती है — अपने scanner पर L4 score, CI `--min-level 4` gate।

--- a/docs/hi-IN/guide/sensors-feedback.md
+++ b/docs/hi-IN/guide/sensors-feedback.md
@@ -1,0 +1,98 @@
+# Sensors — Feedback नियंत्रण
+
+Sensors verify करते हैं कि एजेंट ने क्या किया। वे वह loop बंद करते हैं जिससे स्व-सुधार संभव हो: अच्छे sensors वाला एजेंट अपनी गलतियाँ आपके देखने से पहले ठीक कर लेता है; sensors के बिना वह confident summary के साथ उन्हें ship कर देता है।
+
+## Sensor stack
+
+गति और लागत के अनुसार क्रम — सबसे तेज़ पहले — यही क्रम «quality left» सिद्धांत है:
+
+| Sensor | Latency | Runs at |
+|---|---|---|
+| Type checker | ms–s | On edit (hook), pre-commit, CI |
+| Linter / formatter | ms–s | On edit (hook), pre-commit, CI |
+| Unit tests | s | Agent-invoked, pre-commit, CI |
+| Integration/E2E tests | min | CI |
+| Architecture fitness checks | s–min | CI |
+| AI code review (inferential) | min, $ | PR |
+| Human review | hours | PR |
+
+लक्ष्य हर जगह सब कुछ चलाना नहीं; यह है कि हर गलती **सबसे सस्ते sensor** से, **जितनी जल्दी हो सके**, पकड़ी जाए। ऊपर की दो महँगी पंक्तियाँ उसके लिए रखें जो ऊपर कुछ भी नहीं देख सकता।
+
+## Type checking: मुफ़्त sensor
+
+Strict type checker एजेंट कार्य के लिए सबसे मूल्यवान sensor है — हर edit पर शून्य marginal cost, पूरी तरह deterministic, और error messages इतनी सटीक कि एजेंट स्वतंत्र रूप से कार्य कर सके।
+
+- TypeScript: `"strict": true` — non-strict TS अधिकांश मूल्य चुपचाप खो देता है।
+- Python: mypy या pyright, CI में, केवल IDE में नहीं।
+- Go, Rust, Java, C#: compiler पहले से यह करता है; एजेंट done घोषित करने से पहले build करे, यह सुनिश्चित करें।
+
+यह भाषा रणनीति का भी तर्क है: typed codebases मापने योग्य रूप से अधिक *harnessable* हैं — compiler हर एजेंट edit की मुफ़्त में देखरेख करता है।
+
+## Tests: एजेंट जिस sensor से स्व-सुधार करता है
+
+एजेंट के लिए test suite केवल safety net नहीं — mid-task अपना काम verify करने का उपकरण है। «अच्छे tests» का मतलब बदल जाता है:
+
+1. **तेज़।** Seconds में चलने वाला suite हर बदलाव के बाद चलता है; 20-minute suite कभी नहीं। Fast subset (`npm test`) रखें, भले full suite धीमा हो।
+2. **एक स्पष्ट command से runnable**, `AGENTS.md` में documented। Tests को तीन env vars और database चाहिए तो setup script लिखें।
+3. **Deterministic।** Flaky tests एजेंट (और मनुष्य) को red ignore करना सिखाते हैं।
+4. **Behavioral।** Implementation details pin करने वाले tests वैध refactors रोकते हैं; behavior pin करने वाले real regressions पकड़ते हैं। Fowler का «approved fixtures» pattern — humans review golden files, machines check — एजेंट-heavy codebases में अच्छा काम करता है।
+
+और rule में रखने लायक convention: **नया behavior test के साथ land हो, और failing test green जाने के लिए कभी delete न हो।** अनुमति मिले तो एजेंट दोनों करेगा।
+
+## Linters: conventions को code के रूप में encode करें
+
+हर convention जिसे lint rule में व्यक्त कर सकें, rules files से हटा दें — linter deterministically enforce करता है, prose से बेहतर feedback loop के साथ। Modern stacks custom rules सस्ते बनाते हैं (ESLint flat config, Biome, Ruff, golangci-lint custom linters)।
+
+एजेंट कार्य के लिए प्राथमिकता:
+
+- *Semantic* slips पकड़ने वाले rules (unused vars, floating promises, unhandled errors) pure style से ऊपर।
+- Auto-fixable rules — formatter के साथ pair करें ताकि diffs signal-only रहें।
+- recurring «एजेंट बार-बार X करता रहता है» के लिए custom rules।
+
+## Architecture fitness: structure के sensors
+
+Fowler का दूसरा regulation dimension architectural fitness है — structure verify करने वाले sensors, केवल syntax नहीं:
+
+- **Dependency rules**: «core कभी api से import नहीं» — ArchUnit (JVM), dependency-cruiser (JS/TS), import-linter (Python)।
+- Monorepos में **module boundaries**: Nx/Turborepo boundary checks।
+- **Performance budgets**: bundle size limits, query counts, p95 assertions।
+
+Agents के साथ ये *और* महत्वपूर्ण हैं: local task optimize करता एजेंट global constraint happily तोड़ देगा जिसका किसी local file में उल्लेख नहीं। Fitness checks global constraint को local और तत्काल बनाते हैं।
+
+## Hooks: on-edit sensors के रूप में
+
+Cursor hooks sensors को «जब एजेंट याद करे» से «हमेशा» पर लाते हैं:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      { "command": "node ./.cursor/hooks/format-on-edit.js", "timeout": 30 }
+    ]
+  }
+}
+```
+
+अच्छे `afterFileEdit` citizens: file format करें, उस पर linter चलाएँ, package पर type checker — failures surface करें ताकि एजेंट *अभी*, in-context ठीक करे, CI में एक घंटे बाद नहीं। Fast रखें (जहाँ संभव sub-second); slow hook हर edit पर tax लगाता है।
+
+## CI: record का sensor
+
+Local sensors advisory हैं — एजेंट (या merge करने वाला human) ने उन्हें चलाया, यह कुछ force नहीं करता। CI वह जगह है जहाँ sensors **facts** बनते हैं:
+
+- हर push और PR पर tests, lint, typecheck चलाएँ।
+- Required checks बनाएँ; red CI वाला agent-authored PR unreviewed काम है, draft नहीं।
+- `harness-score --min-level N` job जोड़ें harness *regression* रोकने के लिए — config-drift failure जहाँ कोई hooks file delete कर दे और किसी को पता न चले ([अध्याय 7 में विवरण](./measure-and-improve#ci-gate))।
+
+Pre-commit tooling (husky + lint-staged, `pre-commit`, lefthook) on-edit hooks और CI के बीच की खाई भरती है: commit exist होने से पहले की अंतिम deterministic check।
+
+## Inferential sensors: AI reviewing AI
+
+LLM-based review (Cursor का Bugbot, judge agents, review plugins) computation जो check नहीं कर सकता वहाँ अपनी लागत justify करता है: क्या यह बदलाव *सही* चीज़ का मतलब है? क्या यह abstraction sane है? दो rules इसे honest रखते हैं:
+
+1. Computational stack को supplement करता है, कभी substitute नहीं। compile न होने वाले code approve करने वाला AI reviewer theater है।
+2. Findings *spot-checkable* होने चाहिए — file:line cite करने और failure scenario बताने वाले reviewers को vibes emit करने वालों पर प्राथमिकता दें।
+
+## स्व-सुधार loop, पूरा
+
+Stack लगने पर LangChain ने explicitly engineer किया loop स्वाभाविक उभरता है: एजेंट edit → hooks format और lint → fast tests → CI सब re-verify → inferential reviewer survivors पढ़ता है। हर layer पिछली से छूटा पकड़ती है, और हर catch सबसे सस्ते बिंदु पर। अभी भी खाली है dangerous actions को detectable के बजाय impossible बनाना — वह [Guardrails](./guardrails-and-safety) है।

--- a/docs/hi-IN/guide/what-is-harness-engineering.md
+++ b/docs/hi-IN/guide/what-is-harness-engineering.md
@@ -1,0 +1,73 @@
+# Harness engineering क्या है
+
+> एक एजेंट = मॉडल + harness। मॉडल आप rent करते हैं; harness आपका अपना होता है।
+
+जब कोई AI coding एजेंट आपके रिपॉज़िटरी में काम करता है, तो उसका व्यवहार केवल मॉडल से नहीं आता। बाकी हिस्सा मॉडल के *आस-पास* की चीज़ों से आता है — वे निर्देश जो वह लोड करता है, टूल जिन्हें वह चला सकता है, आउटपुट पर चलने वाली checks, और वे gates जो नुकसान पहुँचाने वाले काम रोकते हैं। इस पूरे घेरे को **harness** कहते हैं; इसे जानबूझकर बनाना **harness engineering** है।
+
+यह शब्द 2026 की शुरुआत में स्पष्ट हुआ। Martin Fowler की साइट ने
+[Harness engineering for coding agent users](https://martinfowler.com/articles/harness-engineering.html)
+(पहले के
+[memo](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering-memo.html)
+पर आधारित) प्रकाशित किया,
+जो उन टीमों के लिए यह discipline परिभाषित करता है जो एजेंट *उपयोग* करती हैं। लगभग उसी समय LangChain ने सिक्के का दूसरा पहलू दिखाया: coding एजेंट का harness सुधारकर — मॉडल को छुए बिना — उन्होंने Terminal Bench 2.0 पर **52.8% से 66.5%** तक पहुँचा, top 30 से बाहर से top 5 में
+([Improving Deep Agents with harness engineering](https://www.langchain.com/blog/improving-deep-agents-with-harness-engineering))।
+
+दोनों से मुख्य insight: **reliability मॉडल weights की property नहीं, बल्कि पूरे model–harness–environment system की property है**। अच्छी तरह harness वाली रिपॉज़िटरी mediocre मॉडल को उपयोगी बना देती है; harness रहित रिपॉज़िटरी frontier मॉडल को खतरनाक बना सकती है।
+
+## Guides और Sensors
+
+Fowler का framework harness controls को दो परिवारों में बाँटता है, control theory से उधार:
+
+| | **Guides** (feedforward) | **Sensors** (feedback) |
+|---|---|---|
+| कब | एजेंट के काम करने से *पहले* | एजेंट के काम करने के *बाद* |
+| उद्देश्य | अच्छे परिणामों की ओर मार्गदर्शन | गलतियों का पता लगाना और सुधार |
+| उदाहरण (tool-agnostic) | `AGENTS.md`, rules, skills, commands, MCP context | tests, linters, type checkers, CI, hooks |
+| अनुपस्थित होने पर failure mode | एजेंट आपकी conventions अनुमान लगाता है | एजेंट गलतियाँ confidently ship करता है |
+
+ये सिद्धांत Cursor, Claude Code, Windsurf और किसी भी AI coding tool में समान हैं — फर्क केवल *कहाँ* configure करें (अलग directories और frontmatter formats), *क्या* बनाएँ उसमें नहीं। Harness Score OR semantics से इन tool-specific variants को पहचानता है, ताकि आपका harness हर जगह काम करे।
+
+harness को दोनों चाहिए। Guides बिना sensors के confident, unverified output देते हैं। Sensors बिना guides के वही गलतियाँ बार-बार पकड़ते हैं, क्योंकि एजेंट को कभी बताया ही नहीं गया कि उनसे कैसे बचें।
+
+## Computational vs inferential checks
+
+Fowler एक और अंतर करता है, जिसे यह guide — और `harness-score` scanner — गंभीरता से लेता है:
+
+- **Computational checks** deterministic होती हैं: linters, type checkers, tests, structural analysis। milliseconds से seconds में चलती हैं, लागत शून्य, हर बार वही जवाब। ये *हर जगह* होनी चाहिए: hooks, pre-commit, CI में।
+- **Inferential checks** मॉडल उपयोग करती हैं: AI code review, LLM-as-judge, semantic audits। powerful हैं पर slow, costly और probabilistic। जहाँ semantics मायने रखती हैं और computation नहीं पहुँच पाता, वहाँ उपयोग करें।
+
+रणनीतिक सिद्धांत **"keep quality left"** है: fast, cheap, deterministic checks को loop में जितना जल्दी हो सके धकेला जाए, और inferential judgment बचे हुए काम के लिए रखा जाए। इसीलिए `harness-score` खुद 100% computational है — जिस maturity measurement को reproduce न कर सकें, वह measurement नहीं है।
+
+## harness आपको क्या देता है: LangChain के lessons
+
+LangChain की Terminal Bench climb harness engineering का सबसे अच्छा public case study है। जिन techniques ने needle हिलाया:
+
+1. **Self-verification loops.** एजेंट को plan → implement → test → fix करना ज़रूरी है, victory declare करने से पहले; pre-completion checklist middleware verification pass के बिना "done" मानने से इनकार करता है। आपकी repo में समकक्ष यह है: tests जो एजेंट actually चला सके — और conventions जो उसे बताएँ कि चलाए।
+2. **Context assembly एजेंट की ओर से.** उनका middleware session start पर working directory map करता है ताकि एजेंट explore करने में steps न गँवाए। Cursor में `AGENTS.md` और scoped rules यह काम करते हैं।
+3. **Loop detection.** Middleware "doom loops" तोड़ता है जहाँ एजेंट वही failing edit बार-बार retry करता है। hooks आपको वही observation point देते हैं।
+4. **Sandwich जैसा reasoning budget.** planning और final verification पर maximum thinking, बीच में moderate। Cursor के models पर आपका नियंत्रण नहीं, पर plan और verification *किसके against* check हो — यह आप नियंत्रित करते हैं: आपके rules और tests।
+
+चारों harness properties हैं, model properties नहीं। चारों का Cursor repository में direct equivalent है — guide का बाकी हिस्सा इसी पर है।
+
+## Harnessability: कुछ codebases harness करना आसान होते हैं
+
+Fowler **ambient affordances** की बात करता है — environment की properties जो एजेंटों को अधिक governable बनाती हैं:
+
+- **Typed languages** हर edit को free, instant sensor देती हैं (compiler)।
+- **Clear module boundaries** प्रति task ज़रूरी context छोटा करती हैं।
+- **Consistent conventions** guides को essays से bullet lists बना देती हैं।
+- **Fast test suites** self-verification को इतना सस्ता बनाती हैं कि आदत बन जाए।
+
+इसीलिए [maturity model](./maturity-model) type checking और test infrastructure को Cursor-specific artifacts के साथ score करता है: वे एक ही control system का हिस्सा हैं।
+
+## यह guide आगे कहाँ जाती है
+
+- अध्याय 2 पूरा [Cursor harness surface](./cursor-harness-surface) map करता है —
+  Cursor जो भी file और mechanism देता है।
+- अध्याय 3–5 तीन control families गहराई से:
+  [Guides](./guides-feedforward), [Sensors](./sensors-feedback), और
+  [Guardrails](./guardrails-and-safety)।
+- अध्याय 6 [पाँच-स्तरीय maturity model](./maturity-model) परिभाषित करता है,
+  objective maturity model के साथ।
+- अध्याय 7 दिखाता है कैसे [measure और improve](./measure-and-improve)
+  `harness-score` scanner और Cursor plugin से करें।

--- a/docs/hi-IN/index.md
+++ b/docs/hi-IN/index.md
@@ -1,0 +1,21 @@
+---
+layout: home
+
+hero:
+  name: Harness Score
+  text: आपका AI coding harness कितना mature है?
+  tagline: Cursor, Claude Code, Windsurf आदि टूल के लिए AI coding harness मापने वाला एक deterministic कमांड। AGENTS.md, rules, hooks, tests और CI स्कैन करता है। स्कैन में कोई LLM कॉल नहीं, नेटवर्क नहीं — एक ही commit पर हमेशा वही स्कोर।
+  image:
+    src: /logo.svg
+    alt: Harness Score
+  actions:
+    - theme: brand
+      text: अपनी रिपॉज़िटरी स्कैन करें
+      link: /hi-IN/guide/measure-and-improve
+    - theme: alt
+      text: पढ़ना शुरू करें
+      link: /hi-IN/guide/what-is-harness-engineering
+    - theme: alt
+      text: plugins देखें
+      link: https://github.com/paladini/harness-score/tree/main/plugins
+---

--- a/docs/i18n/glossary.md
+++ b/docs/i18n/glossary.md
@@ -4,30 +4,30 @@ Contract for translators and reviewers. English is the source of truth for check
 
 ## Stable terms
 
-| English | Português (Brasil) | Español (LatAm) | 简体中文 (zh-CN) | Notes |
-|---|---|---|---|---|
-| harness | harness | harness | harness | Keep in English; explain on first use |
-| harness engineering | engenharia de harness | ingeniería de harness | harness 工程 | Same |
+| English | Português (Brasil) | Español (LatAm) | 简体中文 (zh-CN) | हिन्दी (hi-IN) | Notes |
+|---|---|---|---|---|---|
+| harness | harness | harness | harness | harness | Keep in English; explain on first use |
+| harness engineering | engenharia de harness | ingeniería de harness | harness 工程 | harness engineering | Same |
 | feedforward | feedforward | feedforward | feedforward | Control-theory term; gloss once |
 | feedback | feedback | feedback | feedback | Same |
-| guides | guias | guías | 指南 | Feedforward controls |
-| sensors | sensores | sensores | 传感器 | Feedback controls |
+| guides | guias | guías | 指南 | guides | Feedforward controls |
+| sensors | sensores | sensores | 传感器 | sensors | Feedback controls |
 | guardrails | guardrails | guardrails | guardrails | Runtime enforcement |
-| maturity level | nível de maturidade | nivel de madurez | 成熟度等级 | Always keep `L0`–`L4` |
-| check | verificação / check | verificación / check | check / 检查 | Prefer "check" when tied to IDs |
-| scanner | scanner | scanner | 扫描器 | Product name for CLI tool |
-| self-correcting | autocorretivo | autocorrección | 自我纠正 | Level name L4 in prose only |
-| OR semantics | equivalência entre ferramentas (semântica OR) | equivalencia entre herramientas (semántica OR) | 工具等价（OR 语义） | Scanner accepts Cursor *or* Claude Code equivalents |
+| maturity level | nível de maturidade | nivel de madurez | 成熟度等级 | परिपक्वता स्तर | Always keep `L0`–`L4` |
+| check | verificação / check | verificación / check | check / 检查 | check / जाँच | Prefer "check" when tied to IDs |
+| scanner | scanner | scanner | 扫描器 | scanner / स्कैनर | Product name for CLI tool |
+| self-correcting | autocorretivo | autocorrección | 自我纠正 | स्व-सुधार | Level name L4 in prose only |
+| OR semantics | equivalência entre ferramentas (semântica OR) | equivalencia entre herramientas (semántica OR) | 工具等价（OR 语义） | OR semantics | Scanner accepts Cursor *or* Claude Code equivalents |
 
 ## Level names (prose only — CLI output stays English)
 
-| EN | pt-BR | es | zh-CN |
-|---|---|---|---|
-| Unharnessed | Sem harness | Sin harness | 无 harness |
-| Documented | Documentado | Documentado | 已文档化 |
-| Guided | Orientado | Guiado | 已引导 |
-| Sensing | Com sensores | Con sensores | 有传感器 |
-| Self-correcting | Autocorretivo | Autocorrección | 自我纠正 |
+| EN | pt-BR | es | zh-CN | hi-IN |
+|---|---|---|---|---|
+| Unharnessed | Sem harness | Sin harness | 无 harness | harness रहित |
+| Documented | Documentado | Documentado | 已文档化 | दस्तावेज़ीकृत |
+| Guided | Orientado | Guiado | 已引导 | मार्गदर्शित |
+| Sensing | Com sensores | Con sensores | 有传感器 | sensors के साथ |
+| Self-correcting | Autocorretivo | Autocorrección | 自我纠正 | स्व-सुधार |
 
 ## Never translate
 
@@ -47,6 +47,7 @@ Contract for translators and reviewers. English is the source of truth for check
 - pt-BR: Brazilian Portuguese (not European).
 - es: neutral Latin American (tú/ustedes; avoid vosotros, ordenador, fichero).
 - zh-CN: mainland Simplified Chinese (简体中文); not Traditional (繁體).
+- hi-IN: Indian Hindi in Devanagari; formal **आप**; Western numerals; English loanwords OK for lint/CI/PR where Indian IT practice keeps them.
 
 ## Links in translated pages
 
@@ -61,4 +62,4 @@ Use relative paths within the locale (`./maturity-model`, `./measure-and-improve
 5. Extend `packages/cli/test/docs.test.ts` anchor parity loop.
 6. Add glossary column + tone note; run `npm test` and `npm run docs:build`.
 
-Future example: Hindi (`hi`) — same checklist; Devanagari font coverage may need a theme tweak.
+Example: Hindi (`hi-IN`) — prefix `hi-IN`, label `हिन्दी`. Devanagari font fallback (`Noto Sans Devanagari`) in theme CSS if conjuncts render poorly.

--- a/packages/cli/test/docs.test.ts
+++ b/packages/cli/test/docs.test.ts
@@ -36,7 +36,7 @@ describe('docs stay in sync with the scanner', () => {
 describe('translated measure-and-improve guides preserve anchors', () => {
   const enAnchors = extractAnchors(fs.readFileSync(GUIDE, 'utf8'));
 
-  for (const locale of ['pt-BR', 'es', 'zh-CN'] as const) {
+  for (const locale of ['pt-BR', 'es', 'zh-CN', 'hi-IN'] as const) {
     test(`${locale} has the same anchor set as English`, () => {
       const translated = path.join(REPO, 'docs', locale, 'guide', 'measure-and-improve.md');
       expect(fs.existsSync(translated), `${locale} guide missing`).toBe(true);


### PR DESCRIPTION
## Summary
- Add full hi-IN guide translation (10 pages) with VitePress nav, sidebar, landing copy, and hreflang wiring.
- Extend anchor parity tests and editorial glossary with hi-IN column.
- Add Noto Sans Devanagari font fallback for hi-IN prose.
- Bump changeset to **minor** (v1.2.0) covering hi-IN plus the previously unreleased zh-CN docs locale.

## Test plan
- [x] \
pm test\ (202 tests, hi-IN anchor parity)
- [x] \
pm run docs:build\
- [ ] Preview: \/harness-score/hi-IN/\
