### PR TITLE
feat(sensors): include maven test and spotless in sensors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6799,7 +6799,7 @@
     },
     "packages/cli": {
       "name": "harness-score",
-      "version": "0.3.0",
+      "version": "1.2.0",
       "license": "MIT",
       "bin": {
         "harness-score": "dist/cli.js"

--- a/packages/cli/src/checks/sensors.ts
+++ b/packages/cli/src/checks/sensors.ts
@@ -69,6 +69,7 @@ export const sensorChecks: Check[] = [
       if (ctx.has('Cargo.toml') && ctx.matching(/(^|\/)tests\/[^/]+\.rs$/).length > 0) {
         evidence.push('Rust tests/ directory (cargo test built-in)');
       }
+      if (ctx.has('pom.xml')) evidence.push('Maven test lifecycle');
       return evidence.length > 0
         ? { passed: true, evidence: `${evidence.slice(0, 3).join('; ')}.` }
         : { passed: false, evidence: 'No test runner configuration or test script detected.' };
@@ -163,6 +164,11 @@ export const sensorChecks: Check[] = [
       }
       if (ecosystems.includes('go')) evidence.push('gofmt (built into Go toolchain)');
       if (ecosystems.includes('rust')) evidence.push('rustfmt (built into Rust toolchain)');
+      if (
+        ctx.has('pom.xml') &&
+        ctx.read('pom.xml')?.includes('<artifactId>spotless-maven-plugin</artifactId>')
+      )
+        evidence.push('spotless used in maven');
       return evidence.length > 0
         ? { passed: true, evidence: `${[...new Set(evidence)].slice(0, 3).join('; ')}.` }
         : { passed: false, evidence: 'No formatter configuration detected.' };


### PR DESCRIPTION
## What & why

Maven projects have a built-in test lifecycle. This is now reported as a test runner.
If spotless is set up with maven, it is now reported as a formatter.

This makes `harness-score` usable for Maven projects.

## Type of change

- [ ] Bug fix (false positive/negative in a check, incorrect output)
- [x] New or changed check (check change — see checklist below)
- [ ] Docs
- [ ] Other (plugin, GitHub Action, tooling)

## Check-change checklist (skip if not touching `score.ts`/checks)

- [ ] `packages/cli/src/checks/*.ts` updated
- [ ] `docs/guide/maturity-model.md` updated to match
- [ ] `docs/guide/measure-and-improve.md` (check catalog) updated to match
- [ ] `fixtures/level-0..4/` updated so the maturity ladder still makes sense
- [ ] Check IDs were **not** renumbered or reused

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] `npm run scan` still reports **L4** for this repo
- [x] `npm run docs:build` passes (if docs changed)
