### PR TITLE
Keep showcase navigation in one tab

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -3,7 +3,7 @@ import { hreflangPath, LOCALES, localeFromRelativePath, neutralPagePath } from '
 
 const SITE = 'https://paladini.github.io/harness-score';
 const BASE = '/harness-score/';
-const SHOWCASE = 'https://paladini.io/harness-maturity-showcase/';
+const SHOWCASE = '/harness-maturity-showcase/';
 const FOOTER_COPYRIGHT =
   'Copyright © 2026 <a href="https://paladini.github.io" target="_blank" rel="noopener">Fernando Paladini</a>';
 


### PR DESCRIPTION
Use the shared paladini.io path for the Showcase so VitePress treats it as internal navigation and keeps the product transition in the same tab.

Validation: npm run docs:build.