### PR TITLE
feat(cli): team customization via extends/rules (v1.5) + capped-level fix

### DIFF
--- a/.changeset/v1.5-config-presets.md
+++ b/.changeset/v1.5-config-presets.md
@@ -1,0 +1,9 @@
+---
+"harness-score": minor
+---
+
+Add ESLint-flavored team customization to `.harness-score.json`: `extends` (named, maintainer-curated presets) and `rules` (per-check severity override, `"off"` or `"error"`). Ships one built-in preset, `no-hooks`, for environments where local hook execution is disallowed by policy.
+
+Excluded checks are removed from both the numerator and denominator of their dimension's score — never penalized, never silently hidden. If a preset excludes every check in a dimension a maturity-level requirement depends on, that level is now correctly reported as `capped` (with a `capReason`) instead of showing a misleading "0%, keep trying" gap — L4 in particular is definitionally tied to the Hooks & Guardrails dimension, so a repo under `no-hooks` can climb every other dimension freely but stays capped at L3.
+
+New additive `Report` fields: `preset` (what customization was actually applied), `checks[].severity`, `dimensions[].applicable`, `level.capped`/`level.capReason`. `--diff` gains a `presetChanged` flag mirroring the existing `maturityModelChanged`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,40 @@ scores:
    `score.ts` and both docs pages; `npm test` fails loudly otherwise.
 4. Run the full gate before opening the PR (see below).
 
+## Proposing a preset
+
+`.harness-score.json`'s `extends` key applies named, maintainer-curated
+presets — bundles of per-check severity overrides (see [Team customization](https://paladini.github.io/harness-score/guide/metrics-and-codes#team-customization)
+in the guide). This is deliberately **not** a free-form per-repo opt-out:
+presets go through the same review that protects the check catalog, so a
+badge that says "L3 under preset X" still means something comparable across
+every repo that adopts X.
+
+1. Open an issue (the **Check change** template is close enough — describe
+   which checks the preset would set to `"off"` and why the exclusion is
+   structural, not a preference: a policy constraint, not "we don't feel
+   like it"). Presets that reduce a whole dimension to zero applicable
+   checks are the highest-scrutiny case, since they can cap the maturity
+   ladder (see below).
+2. Add the preset to `PRESET_REGISTRY` in `packages/cli/src/config.ts`.
+   Derive its severity map from `ALL_CHECKS` where possible (filter by
+   dimension or check ID) instead of hardcoding IDs, so it never drifts as
+   the catalog changes.
+3. If the preset excludes every check in a dimension that a `LEVEL_REQUIREMENTS`
+   entry depends on (`dimAtLeast` in `score.ts`), the affected level becomes
+   unreachable under that preset — `computeLevel` reports this as `capped`
+   with a `capReason`, not as a silent pass. That's expected, not a bug to
+   work around: don't add special-casing to let a preset "skip" a ladder
+   requirement it structurally can't satisfy.
+4. Document the preset in `docs/guide/metrics-and-codes.md`'s "Built-in
+   presets" table with a `{#preset-<name>}` anchor matching the preset's
+   key — `packages/cli/test/docs.test.ts` asserts every `PRESET_REGISTRY`
+   key has one. Mirror the section in `docs/pt-BR/guide/metrics-and-codes.md`
+   too.
+5. Add tests: severity resolution in `packages/cli/test/config.test.ts`,
+   and — if the preset can cap a level — a `capped`/`capReason` assertion in
+   `packages/cli/test/score.test.ts` or `scoring-integration.test.ts`.
+
 ## Before opening a PR
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -254,6 +254,26 @@ Or in CI:
     min-level: '3'
 ```
 
+## Team customization
+
+Some checks don't apply to every team for structural reasons — a policy
+that forbids local hook scripts, for instance. `.harness-score.json`
+(optional, at the repo root) supports two ESLint-style keys so a team can
+say so without forking the model:
+
+```json
+{
+  "extends": ["no-hooks"],
+  "rules": { "HYG-05": "off" }
+}
+```
+
+Excluded checks are removed from both sides of the score's fraction — never
+penalized, never silently hidden. Every exclusion shows up in the terminal,
+Markdown, and JSON output, and three checks that detect actively leaked
+credentials can never be excluded, from either a rule or a preset. Full
+story: **[Metrics & Codes → Team customization](https://paladini.github.io/harness-score/guide/metrics-and-codes#team-customization)**.
+
 ## A worked improvement plan
 
 Starting from a typical L0 product repo, one focused session per level:

--- a/action/action.yml
+++ b/action/action.yml
@@ -153,6 +153,10 @@ runs:
             ? '> ⚠ Baseline is from a different tool version or maturity model total — some deltas below may reflect that, not repository changes.\n\n'
             : '';
 
+          const presetWarning = diff.presetChanged
+            ? '> ⚠ Baseline used a different `.harness-score.json` extends/rules config — some deltas below may reflect that, not repository changes.\n\n'
+            : '';
+
           const movedDims = diff.dimensions.filter((d) => d.delta !== 0);
           const dimTable = movedDims.length
             ? [
@@ -169,7 +173,7 @@ runs:
             marker,
             `### ${arrow} Harness Score: L${diff.level.before} · ${diff.level.beforeName} → L${diff.level.after} · ${diff.level.afterName}`,
             '',
-            modelWarning + `**Score:** ${diff.score.before.earned}/${diff.score.before.max} (${diff.score.before.percent}%) → ` +
+            modelWarning + presetWarning + `**Score:** ${diff.score.before.earned}/${diff.score.before.max} (${diff.score.before.percent}%) → ` +
               `${diff.score.after.earned}/${diff.score.after.max} (${diff.score.after.percent}%) (${sign(diff.score.deltaPercent)}pp)`,
             '',
             dimTable,

--- a/docs/es/guide/maturity-model.md
+++ b/docs/es/guide/maturity-model.md
@@ -93,6 +93,28 @@ dentro de la sesión. Guías, sensores y guardrails cubren las seis dimensiones.
 Un error ahora debe pasar rules, hooks on-edit, tests, type checker, CI *y*
 gates — en gran parte sin humano en el loop.
 
+## Cuándo un nivel queda "capped" (limitado)
+
+Los requisitos de un nivel asumen que todas las dimensiones están en juego.
+Un equipo puede excluir checks específicos — o una dimensión entera — vía
+`extends`/`rules` de `.harness-score.json` (ver
+[Métricas y códigos](./metrics-and-codes#team-customization)), por una razón
+estructural que exige una política, no una preferencia.
+
+Si esa exclusión vacía una dimensión de la que depende un nivel, el escáner
+reporta el nivel como **capped** en vez de fingir que es solo otro gap por
+cerrar. L4 es el ejemplo más claro: está *definido* por la dimensión Hooks &
+Guardrails, así que un repositorio bajo el preset `no-hooks` puede subir
+todas las demás dimensiones libremente, pero L4 se queda capped — no "0%,
+sigue intentando", sino "no alcanzable bajo tu configuración actual, y aquí
+está exactamente por qué". La puntuación de todas las demás dimensiones
+queda completamente intacta.
+
+Esto es el modelo manteniéndose honesto, no una penalización: "necesaria, no
+suficiente" (abajo) ya significa que una puntuación alta no es garantía — un
+nivel capped es la misma idea aplicada a la elección deliberada y divulgada
+de un equipo sobre qué le aplica.
+
 ## Leyendo una puntuación
 
 Dos repos pueden tener 65% con formas muy distintas — por eso los niveles exigen

--- a/docs/es/guide/metrics-and-codes.md
+++ b/docs/es/guide/metrics-and-codes.md
@@ -142,7 +142,11 @@ JSON opcional en la raíz del scan (schema estricto — claves desconocidas gene
   "extraRoots": [
     { "id": "team-shared", "path": "../shared-harness" }
   ],
-  "gate": "maturity"
+  "gate": "maturity",
+  "extends": ["no-hooks"],
+  "rules": {
+    "HYG-05": "off"
+  }
 }
 ```
 
@@ -152,8 +156,29 @@ JSON opcional en la raíz del scan (schema estricto — claves desconocidas gene
 | `scopes.system` | boolean | `false` | Incluir overlay a nivel sistema |
 | `extraRoots` | `{ id, path }[]` | `[]` | Árboles extra de harness fusionados en effective |
 | `gate` | `"maturity"` \| `"effective"` | `"maturity"` | Qué puntaje usa `--min-level` |
+| `extends` | `string[]` | `[]` | Presets con nombre a aplicar (ver abajo) |
+| `rules` | `Record<checkId, severity>` | `{}` | Override de severidad por check, aplicado después de cada preset en `extends` |
 
-Precedencia: **flags de CLI → inputs de Action → archivo de config → defaults**.
+Precedencia: **flags de CLI → inputs de Action → archivo de config → defaults**. `extends`/`rules` son exclusivos del archivo de config en esta versión — todavía no hay flag `--extends`/`--rule` en la CLI ni input equivalente en la Action; usa `--config <path>` apuntando a un `.harness-score.json` que los defina.
+
+### Personalización por equipo: `extends` y `rules` {#team-customization}
+
+El vocabulario está tomado directamente de ESLint, porque es un vocabulario que la mayoría de equipos ya conoce:
+
+- **`rules`** sobrescribe la severidad de un check específico por ID: `"HYG-05": "off"`. La severidad es `"off"` o `"error"` en esta versión — `"error"` es el default implícito de todo check, y `"off"` remueve el check **del numerador y del denominador** de la puntuación de su dimensión (se excluye estructuralmente, nunca cuenta como fallo). `"warn"` es un valor reconocido pero rechazado deliberadamente hoy con un error claro de "aún no soportado" — reservado para un modo futuro, consultivo y no bloqueante.
+- **`extends`** aplica un preset con nombre, curado por los maintainers — un paquete versionado y revisado vía PR de overrides de `rules`, no una excepción libre por repositorio. Esto preserva la misma gobernanza que ya protege el catálogo de checks: proponer un preset nuevo pasa por revisión (ver [CONTRIBUTING.md](https://github.com/paladini/harness-score/blob/main/CONTRIBUTING.md#proposing-a-preset)), no es un opt-out local silencioso. Los presets en `extends` se aplican en el orden del array, y cualquier entrada explícita en `rules` siempre prevalece sobre un preset.
+
+Todo check excluido por `extends`/`rules` siempre se divulga — en la salida de terminal (línea `Preset: ...`), en el reporte Markdown (línea `**Preset:**` y estado `➖` en la tabla de checks) y en el campo `preset` del `--json` — nunca escondido silenciosamente detrás de un flag.
+
+Una excepción, a propósito: `HYG-03`, `HYG-04` y `HYG-06` — los checks que detectan credenciales activamente filtradas o expuestas — nunca pueden ponerse en `"off"`, ni vía `rules` ni vía preset. Todo lo demás en este formato de config se apoya en divulgación y revisión de PR para mantener la integridad; estos tres son el único punto que no es negociable.
+
+#### Presets nativos
+
+| Preset | Efecto | Por qué |
+|---|---|---|
+| `no-hooks` {#preset-no-hooks} | Pone `HKS-01`–`HKS-05` (toda la dimensión Hooks & Guardrails, 14 de 108 puntos) en `"off"` | Para entornos donde ejecutar scripts de hook local está prohibido por política — dev containers bloqueados, orgs reguladas, runners compartidos sin permiso de instalar hooks. El guardrail en esos casos se aplica solo vía CI. |
+
+Excluir una dimensión entera tiene una consecuencia honesta que vale la pena saber de antemano: como **L4 · Self-correcting** está *definido* por hooks de guardrail en runtime (ver el [Modelo de madurez](./maturity-model)), un repositorio bajo `no-hooks` nunca alcanza L4 — el nivel queda **capped** (limitado), no "reprobado". `report.level.capped` es `true` y `report.level.capReason` explica el motivo; el resto de dimensiones mantiene su puntuación intacta. Esto es el escáner siendo honesto sobre lo que "self-correcting" significa, no una penalización por excluir hooks.
 
 ## Flags de CLI (configuración del scan)
 
@@ -190,5 +215,9 @@ Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effect
 | `effective` | Misma forma: `{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | Herramientas vistas en el **repo** (informativo) |
 | `truncated` | El walk alcanzó límite de archivos |
+| `preset` | `{ extends, rules, resolved }` — personalización de equipo efectivamente aplicada; `resolved` solo lista checks cuya severidad difiere del default |
+| `level.capped`, `level.capReason` | `capped` es `true` cuando un requisito bloqueante del siguiente nivel nunca puede cumplirse bajo la config actual (ej.: dimensión excluida por preset); `capReason` explica el motivo |
+| `dimensions[].applicable` | `false` solo cuando todo check de esa dimensión resolvió a `"off"` |
+| `checks[].severity` | `"off"` \| `"warn"` \| `"error"` — la severidad resuelta que este scan usó para ese check |
 
 `--diff` compara campos de **maturity** por defecto (top-level `level` / `score` / `checks`).

--- a/docs/guide/maturity-model.md
+++ b/docs/guide/maturity-model.md
@@ -91,6 +91,27 @@ the session. Guides, sensors, and guardrails cover all six dimensions. A
 mistake now has to get past the rules, the on-edit hooks, the tests, the
 type checker, CI, *and* the gates — mostly without any human in the loop.
 
+## When a level is capped
+
+A level's requirements assume every dimension is in play. A team can
+exclude specific checks — or an entire dimension — via
+`.harness-score.json`'s `extends`/`rules` (see
+[Metrics & Codes](./metrics-and-codes#team-customization)), for a
+structural reason a policy demands, not a preference.
+
+If that exclusion empties out a dimension a level depends on, the scanner
+reports the level as **capped** instead of pretending it's just another gap
+to close. L4 is the clearest example: it's *defined* by the Hooks &
+Guardrails dimension, so a repository under the `no-hooks` preset can climb
+every other dimension freely, but L4 stays capped — not "0%, keep trying,"
+but "not reachable under your current configuration, and here's exactly
+why." Every other dimension's score is completely unaffected.
+
+This is the model staying honest, not a penalty: "necessary, not
+sufficient" (below) already means a high score is no guarantee — a capped
+level is the same idea applied to a team's own deliberate, disclosed choice
+about what applies to them.
+
 ## Reading a score
 
 Two repositories can both score 65% with very different shapes — that's why

--- a/docs/guide/metrics-and-codes.md
+++ b/docs/guide/metrics-and-codes.md
@@ -142,7 +142,11 @@ Optional JSON at the scan root (strict schema — unknown keys error):
   "extraRoots": [
     { "id": "team-shared", "path": "../shared-harness" }
   ],
-  "gate": "maturity"
+  "gate": "maturity",
+  "extends": ["no-hooks"],
+  "rules": {
+    "HYG-05": "off"
+  }
 }
 ```
 
@@ -152,8 +156,27 @@ Optional JSON at the scan root (strict schema — unknown keys error):
 | `scopes.system` | boolean | `false` | Include system-level overlay |
 | `extraRoots` | `{ id, path }[]` | `[]` | Extra harness trees merged into effective |
 | `gate` | `"maturity"` \| `"effective"` | `"maturity"` | Which score `--min-level` uses |
+| `extends` | `string[]` | `[]` | Named presets to apply (see below) |
+| `rules` | `Record<checkId, severity>` | `{}` | Per-check severity override, applied after every preset in `extends` |
 
-Precedence: **CLI flags → Action inputs → config file → defaults**.
+Precedence: **CLI flags → Action inputs → config file → defaults**. `extends`/`rules` are config-file-only in this release — there is no `--extends`/`--rule` CLI flag or Action input equivalent yet; use `--config <path>` to point at a `.harness-score.json` that sets them.
+
+### Team customization: `extends` and `rules` {#team-customization}
+
+Borrowed straight from ESLint's own vocabulary, because it's a vocabulary most teams already know:
+
+- **`rules`** overrides a single check's severity by ID: `"HYG-05": "off"`. Severity is `"off"` or `"error"` in this release — `"error"` is the implicit default for every check, and `"off"` removes the check from **both** the numerator and the denominator of its dimension's score (it's structurally excluded, never scored as a failure). `"warn"` is a recognized value that's deliberately rejected today with a clear "not supported yet" error — it's reserved for a future advisory, non-blocking mode.
+- **`extends`** applies a named, maintainer-curated preset — a versioned, PR-reviewed bundle of `rules` overrides, not a free-form per-repo waiver. This preserves the same governance that already protects the check catalog: proposing a new preset goes through review (see [CONTRIBUTING.md](https://github.com/paladini/harness-score/blob/main/CONTRIBUTING.md#proposing-a-preset)), not a silent local opt-out. Presets in `extends` are applied in array order, and any explicit `rules` entry always wins over a preset.
+
+Every check excluded by `extends`/`rules` is always disclosed — in the terminal output (`Preset: ...` line), in the Markdown report (`**Preset:**` line and a `➖` status in the checks table), and in `--json`'s `preset` field — never silently hidden behind a flag.
+
+#### Built-in presets
+
+| Preset | Effect | Why |
+|---|---|---|
+| `no-hooks` {#preset-no-hooks} | Sets `HKS-01`–`HKS-05` (the whole Hooks & Guardrails dimension, 14 of 108 points) to `"off"` | For environments where local hook script execution is disallowed by policy — locked-down dev containers, regulated orgs, shared runners without permission to install hooks. Guardrails there are enforced in CI only. |
+
+Excluding an entire dimension has one honest consequence worth knowing up front: because **L4 · Self-correcting** is *defined* by runtime guardrail hooks (see the [Maturity Model](./maturity-model)), a repository under `no-hooks` can never reach L4 — the level becomes **capped**, not "failed." `report.level.capped` is `true` and `report.level.capReason` explains why; every other dimension's score is completely unaffected. This is the scanner staying honest about what "self-correcting" means, not a penalty for excluding hooks.
 
 ## CLI flags (scan configuration)
 
@@ -190,5 +213,9 @@ Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effect
 | `effective` | Same shape: `{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | Tools seen in **repo** (informational) |
 | `truncated` | Walk hit file cap |
+| `preset` | `{ extends, rules, resolved }` — team customization actually applied; `resolved` lists only checks whose severity differs from the default |
+| `level.capped`, `level.capReason` | `capped` is `true` when a blocking requirement for the next level can never be met under the current config (e.g. its dimension was excluded by a preset); `capReason` explains why |
+| `dimensions[].applicable` | `false` only when every check in that dimension resolved to `"off"` |
+| `checks[].severity` | `"off"` \| `"warn"` \| `"error"` — the resolved severity this scan used for that check |
 
 `--diff` compares **maturity** fields by default (top-level `level` / `score` / `checks`).

--- a/docs/guide/metrics-and-codes.md
+++ b/docs/guide/metrics-and-codes.md
@@ -170,6 +170,8 @@ Borrowed straight from ESLint's own vocabulary, because it's a vocabulary most t
 
 Every check excluded by `extends`/`rules` is always disclosed — in the terminal output (`Preset: ...` line), in the Markdown report (`**Preset:**` line and a `➖` status in the checks table), and in `--json`'s `preset` field — never silently hidden behind a flag.
 
+One exception, on purpose: `HYG-03`, `HYG-04`, and `HYG-06` — the checks that detect actively leaked or exposed credentials — can never be set to `"off"`, from either `rules` or a preset. Everything else in this config format leans on disclosure and PR review for integrity; these three are the one place that isn't negotiable.
+
 #### Built-in presets
 
 | Preset | Effect | Why |

--- a/docs/hi-IN/guide/maturity-model.md
+++ b/docs/hi-IN/guide/maturity-model.md
@@ -56,6 +56,14 @@ Feedback loop मौजूद। Tests एजेंट चला सके, lint
 
 Loop runtime पर बंद। Gate hooks destructive actions impossible बनाते हैं, discouraged नहीं; feedback hooks हर edit पर lint और format, session के अंदर। Guides, sensors, guardrails सभी छह dimensions cover। गलती अब rules, on-edit hooks, tests, type checker, CI, *और* gates — ज़्यादातर बिना human — पार करनी होगी।
 
+## Level कब capped (सीमित) होता है
+
+किसी level की requirements मानती हैं कि सभी dimensions score में शामिल हैं। कोई team `.harness-score.json` के `extends`/`rules` से specific checks — या पूरी dimension — exclude कर सकती है ([Metrics & Codes](./metrics-and-codes#team-customization) देखें), किसी policy की मांग वाले structural कारण से, preference से नहीं।
+
+अगर वह exclusion किसी ऐसी dimension को खाली कर देता है जिस पर कोई level निर्भर करता है, तो scanner उस level को **capped** report करता है — यह दिखावा करने के बजाय कि यह बस एक और बंद करने लायक gap है। L4 सबसे स्पष्ट उदाहरण: यह Hooks & Guardrails dimension से *defined* है, इसलिए `no-hooks` preset वाली repository बाकी सभी dimensions स्वतंत्र रूप से चढ़ सकती है, पर L4 capped ही रहता है — "0%, कोशिश जारी रखें" नहीं, बल्कि "आपकी वर्तमान configuration में अप्राप्य, और यहाँ बताई गई है वजह"। बाकी हर dimension का score पूरी तरह अप्रभावित रहता है।
+
+यह model का ईमानदार बने रहना है, कोई सज़ा नहीं: नीचे दिया "आवश्यक, पर्याप्त नहीं" पहले से ही मतलब रखता है कि high score कोई गारंटी नहीं — capped level वही विचार है, बस team की अपनी जानबूझकर की गई और publicly disclosed choice पर लागू।
+
 ## Score पढ़ना
 
 दो repositories 65% score कर सकते हैं, संरचना बिल्कुल अलग — इसलिए levels dimensions पर gate:

--- a/docs/hi-IN/guide/metrics-and-codes.md
+++ b/docs/hi-IN/guide/metrics-and-codes.md
@@ -142,7 +142,11 @@ Scan root पर optional JSON (strict schema — unknown keys error):
   "extraRoots": [
     { "id": "team-shared", "path": "../shared-harness" }
   ],
-  "gate": "maturity"
+  "gate": "maturity",
+  "extends": ["no-hooks"],
+  "rules": {
+    "HYG-05": "off"
+  }
 }
 ```
 
@@ -152,8 +156,29 @@ Scan root पर optional JSON (strict schema — unknown keys error):
 | `scopes.system` | boolean | `false` | System-level overlay include करें |
 | `extraRoots` | `{ id, path }[]` | `[]` | Effective में merge होने वाली extra harness trees |
 | `gate` | `"maturity"` \| `"effective"` | `"maturity"` | `--min-level` कौन-सा score use करता है |
+| `extends` | `string[]` | `[]` | Apply करने के लिए named presets (नीचे देखें) |
+| `rules` | `Record<checkId, severity>` | `{}` | Per-check severity override, `extends` के हर preset के बाद apply होता है |
 
-Precedence: **CLI flags → Action inputs → config file → defaults**।
+Precedence: **CLI flags → Action inputs → config file → defaults**। `extends`/`rules` इस release में सिर्फ config-file तक सीमित हैं — अभी कोई `--extends`/`--rule` CLI flag या equivalent Action input नहीं है; इन्हें set करने वाली `.harness-score.json` की ओर point करने के लिए `--config <path>` use करें।
+
+### Team customization: `extends` और `rules` {#team-customization}
+
+यह vocabulary सीधे ESLint से लिया गया है, क्योंकि ज़्यादातर teams इसे पहले से जानती हैं:
+
+- **`rules`** किसी single check की severity को ID से override करता है: `"HYG-05": "off"`। इस release में severity `"off"` या `"error"` — `"error"` हर check का implicit default, और `"off"` check को उसकी dimension के score के **numerator और denominator दोनों** से हटा देता है (structurally excluded, कभी fail नहीं गिना जाता)। `"warn"` एक recognized पर आज जानबूझकर rejected value है, साफ़ "not supported yet" error के साथ — future advisory, non-blocking mode के लिए reserved।
+- **`extends`** maintainers द्वारा curate किया named preset apply करता है — `rules` overrides का versioned, PR-reviewed bundle, free-form per-repo exception नहीं। यह वही governance बनाए रखता है जो checks catalog को पहले से protect करती है: नया preset propose करना review से गुज़रता है ([CONTRIBUTING.md](https://github.com/paladini/harness-score/blob/main/CONTRIBUTING.md#proposing-a-preset) देखें), silent local opt-out नहीं। `extends` में presets array क्रम में apply होते हैं, और `rules` की कोई explicit entry हमेशा preset पर prevail करती है।
+
+`extends`/`rules` द्वारा excluded हर check हमेशा disclose होता है — terminal output में (`Preset: ...` line), Markdown report में (`**Preset:**` line और checks table में `➖` status), और `--json` के `preset` field में — कभी किसी flag के पीछे silently छुपा नहीं।
+
+एक अपवाद, जानबूझकर: `HYG-03`, `HYG-04`, और `HYG-06` — वे checks जो actively leaked या exposed credentials detect करते हैं — इन्हें `rules` या preset, किसी से भी कभी `"off"` set नहीं किया जा सकता। इस config format में बाकी सब कुछ disclosure और PR review पर integrity के लिए निर्भर है; ये तीन ही एकमात्र non-negotiable बिंदु हैं।
+
+#### Built-in presets
+
+| Preset | प्रभाव | क्यों |
+|---|---|---|
+| `no-hooks` {#preset-no-hooks} | `HKS-01`–`HKS-05` (पूरी Hooks & Guardrails dimension, 108 में से 14 points) को `"off"` set करता है | उन environments के लिए जहाँ local hook script execution policy से disallowed है — locked-down dev containers, regulated orgs, hooks install करने की permission-रहित shared runners। इन cases में guardrail केवल CI में लागू होता है। |
+
+पूरी dimension exclude करने का एक ईमानदार परिणाम है, जो पहले से जानना उपयोगी: चूंकि **L4 · Self-correcting** runtime guardrail hooks से *defined* है (देखें [Maturity Model](./maturity-model)), `no-hooks` preset वाली repository कभी L4 तक नहीं पहुँचती — level **capped** बन जाता है, "fail" नहीं। `report.level.capped` `true` होता है और `report.level.capReason` वजह बताता है; बाकी हर dimension का score पूरी तरह अप्रभावित रहता है। यह scanner का "self-correcting" के अर्थ पर ईमानदार बने रहना है, hooks exclude करने की सज़ा नहीं।
 
 ## CLI flags (स्कैन कॉन्फ़िगरेशन)
 
@@ -190,5 +215,9 @@ Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effect
 | `effective` | Same shape: `{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | **Repo** में देखे गए tools (informational) |
 | `truncated` | Walk file cap hit |
+| `preset` | `{ extends, rules, resolved }` — इस scan में actually apply हुई team customization; `resolved` सिर्फ वे checks list करता है जिनकी severity default से अलग है |
+| `level.capped`, `level.capReason` | जब अगले level की कोई blocking requirement वर्तमान config में कभी पूरी नहीं हो सकती (जैसे उसकी dimension preset से excluded), तो `capped` `true` होता है; `capReason` वजह बताता है |
+| `dimensions[].applicable` | `false` सिर्फ तब जब उस dimension का हर check `"off"` resolve हुआ हो |
+| `checks[].severity` | `"off"` \| `"warn"` \| `"error"` — इस scan ने उस check के लिए जो resolved severity use की |
 
 `--diff` default में **maturity** fields compare करता है (top-level `level` / `score` / `checks`)।

--- a/docs/pt-BR/guide/maturity-model.md
+++ b/docs/pt-BR/guide/maturity-model.md
@@ -93,6 +93,28 @@ da sessão. Guias, sensores e guardrails cobrem as seis dimensões. Um erro agor
 precisa passar pelas rules, hooks on-edit, testes, type checker, CI *e* gates —
 em grande parte sem humano no loop.
 
+## Quando um nível fica "capped" (limitado)
+
+Os requisitos de um nível assumem que todas as dimensões estão em jogo. Uma
+equipe pode excluir checks específicos — ou uma dimensão inteira — via
+`extends`/`rules` do `.harness-score.json` (veja
+[Métricas e códigos](./metrics-and-codes#team-customization)), por um motivo
+estrutural exigido por política, não por preferência.
+
+Se essa exclusão esvazia uma dimensão da qual um nível depende, o scanner
+reporta o nível como **capped** em vez de fingir que é só mais uma lacuna a
+fechar. L4 é o exemplo mais claro: ele é *definido* pela dimensão Hooks &
+Guardrails, então um repositório sob o preset `no-hooks` pode subir todas as
+outras dimensões livremente, mas L4 continua capped — não "0%, continue
+tentando", e sim "inalcançável na configuração atual, e aqui está exatamente
+o porquê". A pontuação de todas as outras dimensões continua completamente
+intacta.
+
+Isso é o modelo se mantendo honesto, não uma penalidade: "necessário, não
+suficiente" (abaixo) já significa que uma pontuação alta não é garantia — um
+nível capped é a mesma ideia aplicada à escolha deliberada e divulgada de
+uma equipe sobre o que se aplica a ela.
+
 ## Lendo uma pontuação
 
 Dois repositórios podem ter 65% com formas muito diferentes — por isso os

--- a/docs/pt-BR/guide/metrics-and-codes.md
+++ b/docs/pt-BR/guide/metrics-and-codes.md
@@ -142,7 +142,11 @@ JSON opcional na raiz do scan (schema estrito — chaves desconhecidas geram err
   "extraRoots": [
     { "id": "team-shared", "path": "../shared-harness" }
   ],
-  "gate": "maturity"
+  "gate": "maturity",
+  "extends": ["no-hooks"],
+  "rules": {
+    "HYG-05": "off"
+  }
 }
 ```
 
@@ -152,8 +156,27 @@ JSON opcional na raiz do scan (schema estrito — chaves desconhecidas geram err
 | `scopes.system` | boolean | `false` | Incluir overlay em nível de sistema |
 | `extraRoots` | `{ id, path }[]` | `[]` | Árvores extras de harness mescladas no effective |
 | `gate` | `"maturity"` \| `"effective"` | `"maturity"` | Qual pontuação o `--min-level` usa |
+| `extends` | `string[]` | `[]` | Presets nomeados a aplicar (veja abaixo) |
+| `rules` | `Record<checkId, severity>` | `{}` | Override de severidade por check, aplicado depois de cada preset em `extends` |
 
-Precedência: **flags da CLI → inputs da Action → arquivo de config → padrões**.
+Precedência: **flags da CLI → inputs da Action → arquivo de config → padrões**. `extends`/`rules` são exclusivos do arquivo de config nesta versão — ainda não existe flag `--extends`/`--rule` na CLI nem input equivalente na Action; use `--config <path>` apontando para um `.harness-score.json` que os defina.
+
+### Personalização por equipe: `extends` e `rules` {#team-customization}
+
+O vocabulário é emprestado diretamente do ESLint, porque é um vocabulário que a maioria das equipes já conhece:
+
+- **`rules`** sobrescreve a severidade de um check específico por ID: `"HYG-05": "off"`. A severidade é `"off"` ou `"error"` nesta versão — `"error"` é o padrão implícito de todo check, e `"off"` remove o check **do numerador e do denominador** da pontuação da sua dimensão (é excluído estruturalmente, nunca contado como falha). `"warn"` é um valor reconhecido mas deliberadamente rejeitado hoje com um erro claro de "ainda não suportado" — reservado para um modo futuro, consultivo e não-bloqueante.
+- **`extends`** aplica um preset nomeado e curado pelos mantenedores — um pacote versionado e revisado via PR de overrides de `rules`, não uma isenção livre por repositório. Isso preserva a mesma governança que já protege o catálogo de checks: propor um preset novo passa por revisão (veja [CONTRIBUTING.md](https://github.com/paladini/harness-score/blob/main/CONTRIBUTING.md#proposing-a-preset)), não é um opt-out local silencioso. Presets em `extends` são aplicados na ordem do array, e qualquer entrada explícita em `rules` sempre prevalece sobre um preset.
+
+Todo check excluído por `extends`/`rules` é sempre divulgado — na saída do terminal (linha `Preset: ...`), no relatório Markdown (linha `**Preset:**` e status `➖` na tabela de checks) e no campo `preset` do `--json` — nunca escondido silenciosamente atrás de uma flag.
+
+#### Presets nativos
+
+| Preset | Efeito | Por quê |
+|---|---|---|
+| `no-hooks` {#preset-no-hooks} | Define `HKS-01`–`HKS-05` (toda a dimensão Hooks & Guardrails, 14 dos 108 pontos) como `"off"` | Para ambientes onde a execução de scripts de hook local é vedada por política — dev containers travados, orgs reguladas, runners compartilhados sem permissão de instalar hooks. O guardrail nesses casos é aplicado só via CI. |
+
+Excluir uma dimensão inteira tem uma consequência honesta que vale saber de antemão: como **L4 · Self-correcting** é *definido* por hooks de guardrail em runtime (veja o [Modelo de Maturidade](./maturity-model)), um repositório sob `no-hooks` nunca alcança L4 — o nível fica **capped** (limitado), não "reprovado". `report.level.capped` é `true` e `report.level.capReason` explica o motivo; toda outra dimensão continua com a pontuação intacta. Isso é o scanner sendo honesto sobre o que "self-correcting" significa, não uma penalidade por excluir hooks.
 
 ## Flags da CLI (configuração do scan)
 
@@ -190,5 +213,9 @@ Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effect
 | `effective` | Mesma forma: `{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | Ferramentas vistas no **repo** (informativo) |
 | `truncated` | Walk atingiu limite de arquivos |
+| `preset` | `{ extends, rules, resolved }` — personalização de equipe efetivamente aplicada; `resolved` só lista checks cuja severidade difere do padrão |
+| `level.capped`, `level.capReason` | `capped` é `true` quando um requisito bloqueante do próximo nível nunca pode ser satisfeito sob a config atual (ex.: dimensão excluída por preset); `capReason` explica o motivo |
+| `dimensions[].applicable` | `false` só quando todo check daquela dimensão resolveu para `"off"` |
+| `checks[].severity` | `"off"` \| `"warn"` \| `"error"` — a severidade resolvida usada por este scan para aquele check |
 
 `--diff` compara campos de **maturity** por padrão (top-level `level` / `score` / `checks`).

--- a/docs/pt-BR/guide/metrics-and-codes.md
+++ b/docs/pt-BR/guide/metrics-and-codes.md
@@ -170,6 +170,8 @@ O vocabulário é emprestado diretamente do ESLint, porque é um vocabulário qu
 
 Todo check excluído por `extends`/`rules` é sempre divulgado — na saída do terminal (linha `Preset: ...`), no relatório Markdown (linha `**Preset:**` e status `➖` na tabela de checks) e no campo `preset` do `--json` — nunca escondido silenciosamente atrás de uma flag.
 
+Uma exceção, proposital: `HYG-03`, `HYG-04` e `HYG-06` — os checks que detectam credenciais efetivamente vazadas ou expostas — nunca podem ser definidos como `"off"`, nem via `rules` nem via preset. Todo o resto nesse formato de config se apoia em divulgação e revisão de PR pra manter a integridade; esses três são o único ponto que não é negociável.
+
 #### Presets nativos
 
 | Preset | Efeito | Por quê |

--- a/docs/zh-CN/guide/maturity-model.md
+++ b/docs/zh-CN/guide/maturity-model.md
@@ -57,6 +57,14 @@ Feedback 回路已经建立。智能体可以运行 tests，有 linter 和 type 
 
 Loop 在 runtime 闭合。Gate hooks 让破坏性操作不可能发生，而不只是「不建议」；feedback hooks 在每次 edit 时执行 lint 和 format，就在会话内完成。Guides、sensors 和 guardrails 覆盖全部六个 dimensions。一个错误现在必须依次通过 rules、on-edit hooks、tests、type checker、CI*以及* gates — 大多数情况下无需人类介入。
 
+## Level 何时会被 capped（封顶）
+
+一个 level 的 requirements 默认所有 dimensions 都在参与评分。团队可以通过 `.harness-score.json` 的 `extends`/`rules`（见 [指标与代码](./metrics-and-codes#team-customization)）排除特定 checks，甚至整个 dimension — 前提是出于 policy 要求的结构性原因，而不是单纯的偏好。
+
+如果这种排除让某个 level 依赖的 dimension 变得完全不适用，scanner 会把该 level 报告为 **capped**，而不是假装这只是又一个待补的 gap。L4 是最清晰的例子：它由 Hooks & Guardrails dimension *定义*，所以采用 `no-hooks` preset 的仓库可以自由把其他 dimensions 都拉满，但 L4 会一直 capped — 不是「0%，继续努力」，而是「在当前配置下无法达到，原因如下」。其他每个 dimension 的分数完全不受影响。
+
+这是模型在保持诚实，不是惩罚：下文的「必要条件，非充分条件」本来就意味着高分不是保证 — capped level 只是把同一个原则，套用到团队自己做出的、已被公开披露的选择上。
+
 ## 如何解读分数
 
 两个仓库都可能拿到 65%，但形态可能截然不同 — 这正是 levels 按 dimensions 门禁的原因：

--- a/docs/zh-CN/guide/metrics-and-codes.md
+++ b/docs/zh-CN/guide/metrics-and-codes.md
@@ -137,7 +137,11 @@
   "extraRoots": [
     { "id": "team-shared", "path": "../shared-harness" }
   ],
-  "gate": "maturity"
+  "gate": "maturity",
+  "extends": ["no-hooks"],
+  "rules": {
+    "HYG-05": "off"
+  }
 }
 ```
 
@@ -147,6 +151,29 @@
 | `scopes.system` | boolean | `false` | 包含系统级 overlay |
 | `extraRoots` | `{ id, path }[]` | `[]` | 合并到 effective 的额外 harness 树 |
 | `gate` | `"maturity"` \| `"effective"` | `"maturity"` | `--min-level` 使用的分数 |
+| `extends` | `string[]` | `[]` | 要应用的具名 preset（见下文） |
+| `rules` | `Record<checkId, severity>` | `{}` | 按 check 的 severity override，应用于 `extends` 中每个 preset 之后 |
+
+优先级：**CLI 标志 → Action 输入 → 配置文件 → 默认值**。`extends`/`rules` 在本版本中仅限配置文件使用 — 目前没有对应的 `--extends`/`--rule` CLI 标志或 Action 输入；可用 `--config <path>` 指向一个定义了它们的 `.harness-score.json`。
+
+### 团队定制：`extends` 与 `rules` {#team-customization}
+
+这套词汇直接借用自 ESLint，因为大多数团队已经熟悉它：
+
+- **`rules`** 按 check ID 覆盖单个 check 的 severity：`"HYG-05": "off"`。本版本 severity 只接受 `"off"` 或 `"error"` — `"error"` 是每个 check 的隐式默认值，`"off"` 会把该 check 同时从其 dimension 分数的**分子和分母**中移除（结构性排除，永不计为 fail）。`"warn"` 是一个被识别但目前故意拒绝的值，会给出清晰的「尚未支持」错误 — 预留给未来的 advisory、non-blocking 模式。
+- **`extends`** 应用一个由 maintainer 精心维护的具名 preset — 是经过版本管理、PR review 的一组 `rules` overrides，而不是自由裁量的 per-repo 例外。这保持了与保护 checks 目录相同的治理方式：提出新 preset 需要走 review（见 [CONTRIBUTING.md](https://github.com/paladini/harness-score/blob/main/CONTRIBUTING.md#proposing-a-preset)），而不是静默的本地 opt-out。`extends` 中的 preset 按数组顺序应用，`rules` 中任何显式条目始终优先于 preset。
+
+任何被 `extends`/`rules` 排除的 check 都始终会被披露 — 在终端输出中（`Preset: ...` 行）、Markdown 报告中（`**Preset:**` 行以及 checks 表格中的 `➖` 状态）、以及 `--json` 的 `preset` 字段中 — 绝不会被静默隐藏在某个 flag 后面。
+
+有一个例外，是刻意为之的：`HYG-03`、`HYG-04`、`HYG-06` — 这些检测「实际泄露或暴露的凭证」的 checks — 无论通过 `rules` 还是 preset，都永远不能设为 `"off"`。这套配置格式里的其他一切都依赖披露与 PR review 来维护 integrity；这三个是唯一不可协商的例外。
+
+#### 内置 preset
+
+| Preset | 效果 | 原因 |
+|---|---|---|
+| `no-hooks` {#preset-no-hooks} | 将 `HKS-01`–`HKS-05`（整个 Hooks & Guardrails dimension，占 108 分中的 14 分）设为 `"off"` | 用于本地 hook 脚本执行被 policy 禁止的环境 — 被锁定的 dev container、受监管的组织、没有权限安装 hooks 的共享 runner。这类场景下 guardrail 只能在 CI 中生效。|
+
+排除整个 dimension 有一个值得提前知道的、诚实的后果：由于 **L4 · Self-correcting** 就是由 runtime guardrail hooks *定义*的（见[成熟度模型](./maturity-model)），采用 `no-hooks` preset 的仓库永远无法达到 L4 — 该 level 会变成 **capped**，而不是「未通过」。`report.level.capped` 为 `true`，`report.level.capReason` 解释原因；其他所有 dimension 的分数完全不受影响。这是 scanner 在「self-correcting」这个词的含义上保持诚实，而不是对排除 hooks 的惩罚。
 
 优先级：**CLI 标志 → Action 输入 → 配置文件 → 默认值**。
 
@@ -182,6 +209,10 @@ Outputs：`level`、`level-name`、`percent`（maturity）；`effective-level`�
 | `gate` | `"maturity"` 或 `"effective"` |
 | `resolvedRoots` | overlay 的可选 `{ scope, absPath }` 列表 |
 | `level`、`score`、`dimensions`、`checks` | **maturity** 快照 |
+| `preset` | `{ extends, rules, resolved }` — 本次 scan 实际应用的团队定制；`resolved` 只列出 severity 不同于默认值的 checks |
+| `level.capped`、`level.capReason` | 当下一 level 的某个 blocking requirement 在当前配置下永远无法满足时（例如其 dimension 被 preset 排除），`capped` 为 `true`；`capReason` 说明原因 |
+| `dimensions[].applicable` | 仅当该 dimension 中所有 check 都解析为 `"off"` 时为 `false` |
+| `checks[].severity` | `"off"` \| `"warn"` \| `"error"` — 本次 scan 对该 check 使用的最终 severity |
 | `effective` | 相同结构：`{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | **repo** 中看到的工具（仅供参考） |
 | `truncated` | 遍历达到文件上限 |

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,8 +1,17 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { ALL_CHECKS } from './checks/index.js';
 
 export type GateMode = 'maturity' | 'effective';
 export type ScopeFlag = 'user' | 'system';
+
+/**
+ * A check's scoring severity, borrowing ESLint's own vocabulary. Only 'off'
+ * and 'error' are accepted in v1.5 — 'warn' is a recognized value that's
+ * deliberately rejected for now (reserved for a future "advisory, non-blocking"
+ * mode), not an unrecognized one.
+ */
+export type Severity = 'off' | 'warn' | 'error';
 
 export interface ExtraRootEntry {
   id: string;
@@ -16,6 +25,10 @@ export interface HarnessScoreConfig {
   };
   extraRoots: ExtraRootEntry[];
   gate: GateMode;
+  /** Named, maintainer-curated presets to apply, in order (see PRESET_REGISTRY). */
+  extends: string[];
+  /** Per-check-ID severity override, applied after every preset in `extends`. */
+  rules: Record<string, Severity>;
 }
 
 export interface ResolvedScanConfig {
@@ -27,18 +40,37 @@ export interface ResolvedScanConfig {
   gate: GateMode;
   /** Scopes included in the effective score (repo is always first). */
   effectiveScopes: Array<'repo' | 'user' | 'system' | string>;
+  extends: string[];
+  rules: Record<string, Severity>;
 }
 
 export const DEFAULT_CONFIG: HarnessScoreConfig = {
   scopes: { user: false, system: false },
   extraRoots: [],
   gate: 'maturity',
+  extends: [],
+  rules: {},
 };
 
 export const CONFIG_FILENAME = '.harness-score.json';
 
-const ALLOWED_TOP_KEYS = new Set(['scopes', 'extraRoots', 'gate']);
+/**
+ * Built-in, maintainer-curated presets — the ESLint-flavored alternative to
+ * free-form per-repo waivers. Each preset is a named, versioned, PR-reviewed
+ * bundle of severity overrides (see CONTRIBUTING.md "Proposing a preset").
+ * `no-hooks` is derived from ALL_CHECKS rather than hardcoded IDs so it never
+ * drifts if the hooks dimension gains a check.
+ */
+export const PRESET_REGISTRY: Record<string, Record<string, Severity>> = {
+  'no-hooks': Object.fromEntries(
+    ALL_CHECKS.filter((c) => c.dimension === 'hooks').map((c) => [c.id, 'off' as const]),
+  ),
+};
+
+const ALLOWED_TOP_KEYS = new Set(['scopes', 'extraRoots', 'gate', 'extends', 'rules']);
 const ALLOWED_SCOPE_KEYS = new Set(['user', 'system']);
+const VALID_SEVERITIES = new Set(['off', 'error']);
+const CHECK_IDS = new Set(ALL_CHECKS.map((c) => c.id));
 
 export interface CliConfigOverrides {
   configPath?: string | null;
@@ -105,6 +137,51 @@ function parseExtraRoots(value: unknown, source: string): ExtraRootEntry[] {
   });
 }
 
+function parseExtends(value: unknown, source: string): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) configError(`${source}: extends must be an array`);
+  return value.map((entry, index) => {
+    const label = `${source}.extends[${index}]`;
+    if (typeof entry !== 'string' || entry.trim() === '') {
+      configError(`${label}: must be a non-empty string`);
+    }
+    if (!Object.hasOwn(PRESET_REGISTRY, entry)) {
+      configError(
+        `${label}: unknown preset "${entry}" (known presets: ${Object.keys(PRESET_REGISTRY).join(', ') || 'none'})`,
+      );
+    }
+    return entry;
+  });
+}
+
+function parseSeverityValue(value: unknown, source: string, checkId: string): Severity {
+  if (value === 'warn') {
+    configError(
+      `${source}.rules["${checkId}"]: severity "warn" is not supported yet (only "off" and "error")`,
+    );
+  }
+  if (typeof value !== 'string' || !VALID_SEVERITIES.has(value)) {
+    configError(`${source}.rules["${checkId}"]: severity must be "off" or "error"`);
+  }
+  return value as Severity;
+}
+
+function parseRules(value: unknown, source: string): Record<string, Severity> {
+  if (value === undefined) return {};
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    configError(`${source}: rules must be an object`);
+  }
+  const obj = value as Record<string, unknown>;
+  const rules: Record<string, Severity> = {};
+  for (const [checkId, severity] of Object.entries(obj)) {
+    if (!CHECK_IDS.has(checkId)) {
+      configError(`${source}.rules: unknown check ID "${checkId}"`);
+    }
+    rules[checkId] = parseSeverityValue(severity, source, checkId);
+  }
+  return rules;
+}
+
 /** Parse and validate a config object (strict — unknown keys are rejected). */
 export function parseConfigObject(raw: unknown, source: string): HarnessScoreConfig {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
@@ -120,7 +197,41 @@ export function parseConfigObject(raw: unknown, source: string): HarnessScoreCon
     scopes: parseScopes(obj.scopes, source),
     extraRoots: parseExtraRoots(obj.extraRoots, source),
     gate: obj.gate === undefined ? 'maturity' : parseGate(obj.gate, source),
+    extends: parseExtends(obj.extends, source),
+    rules: parseRules(obj.rules, source),
   };
+}
+
+export interface ResolvedSeverity {
+  severity: Severity;
+  source: 'default' | string;
+}
+
+/**
+ * Resolves the final severity for every check: default 'error' → each preset
+ * in `extends`, applied in array order → `rules` local overrides, applied
+ * last (highest precedence). Map insertion order follows ALL_CHECKS order and
+ * is never disturbed by later overwrites, keeping output deterministic.
+ */
+export function resolveSeverities(cfg: {
+  extends: string[];
+  rules: Record<string, Severity>;
+}): Map<string, ResolvedSeverity> {
+  const resolved = new Map<string, ResolvedSeverity>();
+  for (const check of ALL_CHECKS) {
+    resolved.set(check.id, { severity: 'error', source: 'default' });
+  }
+  for (const presetName of cfg.extends) {
+    const preset = PRESET_REGISTRY[presetName];
+    if (!preset) continue;
+    for (const [checkId, severity] of Object.entries(preset)) {
+      resolved.set(checkId, { severity, source: `extends:${presetName}` });
+    }
+  }
+  for (const [checkId, severity] of Object.entries(cfg.rules)) {
+    resolved.set(checkId, { severity, source: 'rules' });
+  }
+  return resolved;
 }
 
 export function loadConfigFile(configPath: string): HarnessScoreConfig {
@@ -156,7 +267,13 @@ export function parseScopeFlagList(value: string): ScopeFlag[] {
 
 /** Merge defaults → config file → CLI overrides. */
 export function resolveScanConfig(repoRoot: string, overrides: CliConfigOverrides = {}): ResolvedScanConfig {
-  let base: HarnessScoreConfig = { ...DEFAULT_CONFIG, scopes: { ...DEFAULT_CONFIG.scopes }, extraRoots: [] };
+  let base: HarnessScoreConfig = {
+    ...DEFAULT_CONFIG,
+    scopes: { ...DEFAULT_CONFIG.scopes },
+    extraRoots: [],
+    extends: [],
+    rules: {},
+  };
 
   const explicitConfigPath = overrides.configPath;
   if (explicitConfigPath) {
@@ -187,5 +304,7 @@ export function resolveScanConfig(repoRoot: string, overrides: CliConfigOverride
     extraRoots: base.extraRoots,
     gate,
     effectiveScopes,
+    extends: base.extends,
+    rules: base.rules,
   };
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -72,6 +72,15 @@ const ALLOWED_SCOPE_KEYS = new Set(['user', 'system']);
 const VALID_SEVERITIES = new Set(['off', 'error']);
 const CHECK_IDS = new Set(ALL_CHECKS.map((c) => c.id));
 
+/**
+ * Checks that detect actively leaked/exposed credentials — never eligible for
+ * "off", from either a local `rules` override or a preset, regardless of how
+ * the exclusion is justified. This is the one thing "customizable, but still
+ * serious" can't bend on: nothing in this config format may silence an actual
+ * secret-leak detector, only disclosure-and-review protects everything else.
+ */
+export const PROTECTED_CHECKS = new Set(['HYG-03', 'HYG-04', 'HYG-06']);
+
 export interface CliConfigOverrides {
   configPath?: string | null;
   /** When set, replaces config-file scope toggles. */
@@ -177,7 +186,13 @@ function parseRules(value: unknown, source: string): Record<string, Severity> {
     if (!CHECK_IDS.has(checkId)) {
       configError(`${source}.rules: unknown check ID "${checkId}"`);
     }
-    rules[checkId] = parseSeverityValue(severity, source, checkId);
+    const parsed = parseSeverityValue(severity, source, checkId);
+    if (parsed === 'off' && PROTECTED_CHECKS.has(checkId)) {
+      configError(
+        `${source}.rules["${checkId}"]: this check detects leaked/exposed credentials and can never be set to "off"`,
+      );
+    }
+    rules[checkId] = parsed;
   }
   return rules;
 }

--- a/packages/cli/src/diff.ts
+++ b/packages/cli/src/diff.ts
@@ -32,7 +32,16 @@ export interface ReportDiff {
    * reflect a maturity model change rather than an actual change in the repository.
    */
   maturityModelChanged: boolean;
+  /**
+   * True when the team customization (`.harness-score.json`'s `extends`/`rules`) actually
+   * applied differs between baseline and current — dimension/score deltas may then reflect
+   * a config change rather than an actual change in the repository.
+   */
+  presetChanged: boolean;
 }
+
+/** Baselines saved by pre-v1.5 tool versions have no `preset` field at all. */
+const EMPTY_PRESET: Report['preset'] = { extends: [], rules: {}, resolved: [] };
 
 /**
  * Compares two reports from the same maturity model version. Checks present in
@@ -84,5 +93,7 @@ export function computeDiff(baseline: Report, current: Report): ReportDiff {
     checksChanged,
     maturityModelChanged:
       baseline.tool.version !== current.tool.version || baseline.score.max !== current.score.max,
+    presetChanged:
+      JSON.stringify(baseline.preset ?? EMPTY_PRESET) !== JSON.stringify(current.preset ?? EMPTY_PRESET),
   };
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,9 +5,11 @@ export {
   DEFAULT_CONFIG,
   discoverConfig,
   loadConfigFile,
+  PRESET_REGISTRY,
   parseConfigObject,
   parseScopeFlagList,
   resolveScanConfig,
+  resolveSeverities,
 } from './config.js';
 export type * from './diff.js';
 export { computeDiff } from './diff.js';

--- a/packages/cli/src/report/markdown.ts
+++ b/packages/cli/src/report/markdown.ts
@@ -72,6 +72,12 @@ export function renderMarkdown(report: Report, diff?: ReportDiff | null): string
   if (detected.length > 0) {
     lines.push(`**Detected harnesses:** ${detected.map(toolDisplayName).join(', ')}`);
   }
+  if (report.preset.resolved.length > 0) {
+    const extendsLabel = report.preset.extends.length > 0 ? report.preset.extends.join(', ') : 'local rules';
+    const offIds = report.preset.resolved.filter((r) => r.severity === 'off').map((r) => r.id);
+    const offText = offIds.length > 0 ? ` — ${offIds.join(', ')} → off` : '';
+    lines.push(`**Preset:** ${extendsLabel}${offText}`);
+  }
   lines.push('');
   if (diff) {
     lines.push(...renderDiffSection(diff));
@@ -81,7 +87,10 @@ export function renderMarkdown(report: Report, diff?: ReportDiff | null): string
   lines.push('| Dimension | Score | % |');
   lines.push('|---|---|---|');
   for (const dimension of report.dimensions) {
-    lines.push(`| ${dimension.title} | ${dimension.earned}/${dimension.max} | ${dimension.percent}% |`);
+    const cell = dimension.applicable
+      ? `${dimension.earned}/${dimension.max} | ${dimension.percent}%`
+      : '— | N/A (excluded by preset)';
+    lines.push(`| ${dimension.title} | ${cell} |`);
   }
   lines.push('');
   lines.push('## Checks');
@@ -89,12 +98,12 @@ export function renderMarkdown(report: Report, diff?: ReportDiff | null): string
   lines.push('| | Check | Points | Evidence |');
   lines.push('|---|---|---|---|');
   for (const check of report.checks) {
-    const status = check.passed ? '✅' : '❌';
+    const status = check.severity === 'off' ? '➖' : check.passed ? '✅' : '❌';
     lines.push(
       `| ${status} | [${check.id}](${check.docsUrl}) ${check.title} | ${check.earned}/${check.points} | ${check.evidence.replace(/\|/g, '\\|')} |`,
     );
   }
-  const failed = report.checks.filter((c) => !c.passed);
+  const failed = report.checks.filter((c) => !c.passed && c.severity !== 'off');
   if (failed.length > 0) {
     lines.push('');
     lines.push('## Recommended improvements');
@@ -106,6 +115,10 @@ export function renderMarkdown(report: Report, diff?: ReportDiff | null): string
   if (report.level.nextLevelGaps.length > 0) {
     lines.push('');
     lines.push(`**To reach L${report.level.index + 1}:** ${report.level.nextLevelGaps.join('; ')}`);
+    if (report.level.capped && report.level.capReason) {
+      lines.push('');
+      lines.push(`> ⚠ **Capped:** ${report.level.capReason}`);
+    }
   }
   lines.push('');
   return lines.join('\n');

--- a/packages/cli/src/report/markdown.ts
+++ b/packages/cli/src/report/markdown.ts
@@ -16,6 +16,12 @@ function renderDiffSection(diff: ReportDiff): string[] {
     );
     lines.push('');
   }
+  if (diff.presetChanged) {
+    lines.push(
+      '> ⚠ Baseline used a different extends/rules config — some deltas below may reflect that, not repository changes.',
+    );
+    lines.push('');
+  }
   lines.push(
     `**Level:** L${diff.level.before} · ${diff.level.beforeName} → ` +
       `L${diff.level.after} · ${diff.level.afterName} (${signed(diff.level.delta)})`,

--- a/packages/cli/src/report/terminal.ts
+++ b/packages/cli/src/report/terminal.ts
@@ -93,8 +93,9 @@ export function renderTerminal(report: Report, diff?: ReportDiff | null): string
     );
     lines.push('');
   }
+  const cappedMarker = report.level.capped ? ` ${yellow('(capped)')}` : '';
   lines.push(
-    `  ${bold('Maturity:')} ${levelPaint(bold(`L${report.level.index} ${MIDDOT} ${report.level.name}`))}` +
+    `  ${bold('Maturity:')} ${levelPaint(bold(`L${report.level.index} ${MIDDOT} ${report.level.name}`))}${cappedMarker}` +
       `   ${bold('Score:')} ${report.score.earned}/${report.score.max} (${report.score.percent}%)` +
       dim(`   scopes: ${formatScopes(report.scopes.maturity)}`),
   );
@@ -113,11 +114,21 @@ export function renderTerminal(report: Report, diff?: ReportDiff | null): string
   if (detected.length > 0) {
     lines.push(dim(`  Detected: ${detected.map(toolDisplayName).join(', ')}`));
   }
+  if (report.preset.resolved.length > 0) {
+    const extendsLabel = report.preset.extends.length > 0 ? report.preset.extends.join(', ') : 'local rules';
+    const offIds = report.preset.resolved.filter((r) => r.severity === 'off').map((r) => r.id);
+    const offText = offIds.length > 0 ? ` ${MIDDOT} ${offIds.join(', ')} ${ARROW} off` : '';
+    lines.push(dim(`  Preset: ${extendsLabel}${offText}`));
+  }
   lines.push('');
   if (diff) {
     lines.push(...renderDiffSection(diff));
   }
   for (const dimension of report.dimensions) {
+    if (!dimension.applicable) {
+      lines.push(`  ${dimension.title.padEnd(20)} ${dim('excluded by preset')}`);
+      continue;
+    }
     const pct = `${dimension.percent}%`.padStart(4);
     lines.push(
       `  ${dimension.title.padEnd(20)} ${bar(dimension.percent)} ${pct}  ${dim(`${dimension.earned}/${dimension.max} pts`)}`,
@@ -125,7 +136,7 @@ export function renderTerminal(report: Report, diff?: ReportDiff | null): string
   }
   lines.push('');
 
-  const failed = report.checks.filter((c) => !c.passed);
+  const failed = report.checks.filter((c) => !c.passed && c.severity !== 'off');
   if (failed.length === 0) {
     lines.push(green(`  All checks passed ${MIDDOT} this repository is fully harnessed.`));
   } else {
@@ -140,6 +151,9 @@ export function renderTerminal(report: Report, diff?: ReportDiff | null): string
   lines.push('');
   if (report.level.nextLevelGaps.length > 0) {
     lines.push(`  ${bold(`To reach L${report.level.index + 1}:`)} ${report.level.nextLevelGaps.join('; ')}`);
+    if (report.level.capped && report.level.capReason) {
+      lines.push(yellow(`  ${WARN} ${report.level.capReason}`));
+    }
     lines.push('');
   }
   return lines.join('\n');

--- a/packages/cli/src/report/terminal.ts
+++ b/packages/cli/src/report/terminal.ts
@@ -40,6 +40,13 @@ function renderDiffSection(diff: ReportDiff): string[] {
       ),
     );
   }
+  if (diff.presetChanged) {
+    lines.push(
+      yellow(
+        `  ${WARN} Baseline used a different extends/rules config ${MIDDOT} some deltas below may reflect that, not repository changes.`,
+      ),
+    );
+  }
   lines.push(
     `    Level: L${diff.level.before} ${MIDDOT} ${diff.level.beforeName} ${ARROW} ` +
       `L${diff.level.after} ${MIDDOT} ${diff.level.afterName} (${signed(diff.level.delta)})`,

--- a/packages/cli/src/score.ts
+++ b/packages/cli/src/score.ts
@@ -1,5 +1,6 @@
 import { ALL_CHECKS } from './checks/index.js';
-import type { ResolvedScanConfig } from './config.js';
+import type { ResolvedScanConfig, ResolvedSeverity } from './config.js';
+import { resolveSeverities } from './config.js';
 import { buildOverlays } from './harness/global-paths.js';
 import { detectHarnesses } from './harness/index.js';
 import { createScanContext } from './scan.js';
@@ -20,7 +21,7 @@ export const TOOL_VERSION = '1.3.2';
 
 export const LEVEL_NAMES = ['Unharnessed', 'Documented', 'Guided', 'Sensing', 'Self-correcting'] as const;
 
-function runChecks(ctx: ScanContext): CheckResult[] {
+function runChecks(ctx: ScanContext, severities: Map<string, ResolvedSeverity>): CheckResult[] {
   return ALL_CHECKS.map((check) => {
     let outcome: CheckOutcome;
     try {
@@ -38,33 +39,45 @@ function runChecks(ctx: ScanContext): CheckResult[] {
       evidence: outcome.evidence,
       remediation: check.remediation,
       docsUrl: `${DOCS_BASE_URL}#${check.id.toLowerCase()}`,
+      severity: severities.get(check.id)?.severity ?? 'error',
     };
   });
 }
 
+/** Checks with severity 'off' are excluded from both the numerator and denominator — structurally removed, never scored as failing. */
 function scoreDimensions(checks: CheckResult[]): DimensionScore[] {
   return DIMENSIONS.map((dim) => {
     const own = checks.filter((c) => c.dimension === dim.id);
-    const earned = own.reduce((sum, c) => sum + c.earned, 0);
-    const max = own.reduce((sum, c) => sum + c.points, 0);
+    const scored = own.filter((c) => c.severity !== 'off');
+    const earned = scored.reduce((sum, c) => sum + c.earned, 0);
+    const max = scored.reduce((sum, c) => sum + c.points, 0);
     return {
       id: dim.id,
       title: dim.title,
       earned,
       max,
       percent: max === 0 ? 0 : Math.round((earned / max) * 100),
+      /** False only when every check originally in this dimension resolved to 'off'. */
+      applicable: scored.length > 0,
     };
   });
 }
 
 interface Requirement {
   label: string;
+  /** Set only by dimAtLeast — lets computeLevel tell "structurally unreachable" apart from "not yet met". */
+  blockedDimension?: DimensionId;
   met(dims: Map<DimensionId, DimensionScore>, totalPercent: number): boolean;
 }
 
 const dimAtLeast = (id: DimensionId, pct: number): Requirement => ({
   label: `${id} ≥ ${pct}%`,
-  met: (dims) => (dims.get(id)?.percent ?? 0) >= pct,
+  blockedDimension: id,
+  met: (dims) => {
+    const dim = dims.get(id);
+    if (!dim?.applicable) return false;
+    return dim.percent >= pct;
+  },
 });
 
 /**
@@ -93,23 +106,38 @@ function computeLevel(dimensions: DimensionScore[], totalPercent: number): Level
   const dims = new Map<DimensionId, DimensionScore>(dimensions.map((d) => [d.id, d]));
   let index = 0;
   let gaps: string[] = [];
+  let capped = false;
+  let capReason: string | undefined;
   for (let level = 0; level < LEVEL_REQUIREMENTS.length; level += 1) {
     const unmet = LEVEL_REQUIREMENTS[level]!.filter((r) => !r.met(dims, totalPercent));
     if (unmet.length === 0) {
       index = level + 1;
     } else {
       gaps = unmet.map((r) => r.label);
+      // At least one unmet requirement can never be satisfied (its dimension has zero
+      // applicable checks under the current config) — the level itself is unreachable,
+      // not just "not yet climbed," even if other unmet requirements are still actionable.
+      const cappedReq = unmet.find(
+        (r) => r.blockedDimension !== undefined && dims.get(r.blockedDimension)?.applicable === false,
+      );
+      if (cappedReq) {
+        capped = true;
+        capReason =
+          `L${level + 1} requires ${cappedReq.label}, which is not reachable: the "${cappedReq.blockedDimension}" ` +
+          'dimension has no applicable checks under the current config.';
+      }
       break;
     }
   }
-  return { index, name: LEVEL_NAMES[index]!, nextLevelGaps: gaps };
+  return { index, name: LEVEL_NAMES[index]!, nextLevelGaps: gaps, capped, capReason };
 }
 
-function buildSnapshot(ctx: ScanContext): ScoreSnapshot {
-  const checks = runChecks(ctx);
+function buildSnapshot(ctx: ScanContext, severities: Map<string, ResolvedSeverity>): ScoreSnapshot {
+  const checks = runChecks(ctx, severities);
   const dimensions = scoreDimensions(checks);
-  const earned = checks.reduce((sum, c) => sum + c.earned, 0);
-  const max = checks.reduce((sum, c) => sum + c.points, 0);
+  const scored = checks.filter((c) => c.severity !== 'off');
+  const earned = scored.reduce((sum, c) => sum + c.earned, 0);
+  const max = scored.reduce((sum, c) => sum + c.points, 0);
   const percent = max === 0 ? 0 : Math.round((earned / max) * 100);
   return {
     level: computeLevel(dimensions, percent),
@@ -135,14 +163,19 @@ export function buildReportFromContext(
   config: ResolvedScanConfig,
   resolvedRoots: Report['resolvedRoots'],
 ): Report {
-  const maturity = buildSnapshot(maturityCtx);
+  const severities = resolveSeverities(config);
+  const maturity = buildSnapshot(maturityCtx, severities);
   let effective = maturity;
   if (effectiveCtx !== maturityCtx) {
-    const effSnapshot = buildSnapshot(effectiveCtx);
+    const effSnapshot = buildSnapshot(effectiveCtx, severities);
     if (!snapshotsEqual(maturity, effSnapshot)) {
       effective = effSnapshot;
     }
   }
+
+  const resolvedEntries = [...severities.entries()]
+    .filter(([, v]) => v.source !== 'default')
+    .map(([id, v]) => ({ id, severity: v.severity, source: v.source }));
 
   return {
     tool: { name: 'harness-score', version: TOOL_VERSION },
@@ -157,6 +190,7 @@ export function buildReportFromContext(
     dimensions: maturity.dimensions,
     checks: maturity.checks,
     effective,
+    preset: { extends: config.extends, rules: config.rules, resolved: resolvedEntries },
   };
 }
 
@@ -168,6 +202,8 @@ export function buildReport(rootInput: string, config?: ResolvedScanConfig): Rep
     extraRoots: [],
     gate: 'maturity' as const,
     effectiveScopes: ['repo'] as const,
+    extends: [],
+    rules: {},
   };
 
   const maturityCtx = createScanContext(root);
@@ -189,6 +225,8 @@ export function buildReportFromScanContext(ctx: ScanContext): Report {
     extraRoots: [],
     gate: 'maturity',
     effectiveScopes: ['repo'],
+    extends: [],
+    rules: {},
   };
   return buildReportFromContext(ctx, ctx, defaultConfig, undefined);
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -57,6 +57,8 @@ export interface CheckResult {
   evidence: string;
   remediation: string;
   docsUrl: string;
+  /** Resolved severity ('off' checks are excluded from scoring but still listed here). */
+  severity: Severity;
 }
 
 export interface DimensionScore {
@@ -66,6 +68,8 @@ export interface DimensionScore {
   max: number;
   /** 0–100, rounded. */
   percent: number;
+  /** False only when every check in this dimension resolved to 'off' (excluded by config). */
+  applicable: boolean;
 }
 
 export interface LevelInfo {
@@ -74,6 +78,10 @@ export interface LevelInfo {
   name: string;
   /** What is missing to reach the next level; empty at L4. */
   nextLevelGaps: string[];
+  /** True when at least one blocking requirement for the next level can never be met under the current config (e.g. its dimension was excluded by a preset). */
+  capped: boolean;
+  /** Human-readable explanation of why the level is capped; set only when `capped` is true. */
+  capReason?: string;
 }
 
 /** One scored snapshot (maturity or effective). */
@@ -85,7 +93,17 @@ export interface ScoreSnapshot {
   detectedHarnesses: string[];
 }
 
-import type { GateMode } from './config.js';
+import type { GateMode, Severity } from './config.js';
+
+/** Local team customization actually applied to this scan, always present and never hidden behind a flag. */
+export interface PresetInfo {
+  /** Preset names from `.harness-score.json`'s `extends`, in application order. */
+  extends: string[];
+  /** Raw per-check severity overrides from `.harness-score.json`'s `rules`. */
+  rules: Record<string, Severity>;
+  /** Every check whose resolved severity differs from the 'default' error baseline, with why. */
+  resolved: Array<{ id: string; severity: Severity; source: string }>;
+}
 
 export interface Report {
   tool: { name: string; version: string };
@@ -107,4 +125,6 @@ export interface Report {
   checks: CheckResult[];
   /** Repo ∪ configured global/extra scopes — what the agent likely sees on this machine. */
   effective: ScoreSnapshot;
+  /** Team customization (extends/rules) actually applied to this scan. */
+  preset: PresetInfo;
 }

--- a/packages/cli/test/__snapshots__/golden-output.test.ts.snap
+++ b/packages/cli/test/__snapshots__/golden-output.test.ts.snap
@@ -12,6 +12,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Create an AGENTS.md at the repository root describing what the project is, how to build/test it, and the conventions agents must follow.",
+      "severity": "error",
       "title": "Agent context file present (AGENTS.md)",
     },
     {
@@ -23,6 +24,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Flesh out AGENTS.md: add sections for project overview, build & test commands, architecture, and conventions (aim for 20+ meaningful lines with headings).",
+      "severity": "error",
       "title": "Agent context file is substantive",
     },
     {
@@ -34,6 +36,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Add at least one scoped rule file for your AI tool (e.g. .cursor/rules/*.mdc, .windsurf/rules/*.md, .clinerules/*.md) or a nested AGENTS.md/CLAUDE.md in a subdirectory, stating the project non-negotiables.",
+      "severity": "error",
       "title": "Scoped rules in use",
     },
     {
@@ -45,6 +48,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Give every rule activation metadata in frontmatter (description, globs/trigger/paths/applyTo, or alwaysApply) so the agent knows when to load it.",
+      "severity": "error",
       "title": "Rules have valid frontmatter",
     },
     {
@@ -56,6 +60,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Scope rules to paths (globs, trigger glob, paths, applyTo) instead of making everything always-on — blanket rules consume context on every request.",
+      "severity": "error",
       "title": "Rules are scoped, not all always-on",
     },
     {
@@ -67,6 +72,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Split rules longer than 500 lines into focused, scoped rules or move procedural content into a skill — huge rules crowd out task context.",
+      "severity": "error",
       "title": "No bloated rules (≤500 lines each)",
     },
     {
@@ -78,6 +84,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 1,
       "remediation": "Add a README.md — agents (and humans) use it as the first orientation document.",
+      "severity": "error",
       "title": "README present",
     },
     {
@@ -89,6 +96,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 1,
       "remediation": "Migrate the legacy .cursorrules file to scoped rules with frontmatter (.cursor/rules/*.mdc or your tool equivalent) — .cursorrules is deprecated.",
+      "severity": "error",
       "title": "No legacy .cursorrules file",
     },
     {
@@ -100,6 +108,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Create a SKILL.md under your tool skills directory (.cursor/skills/, .claude/skills/, or .agents/skills/) packaging a procedural workflow the agent should follow on demand.",
+      "severity": "error",
       "title": "At least one agent skill defined",
     },
     {
@@ -111,6 +120,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add frontmatter with name: and description: to every SKILL.md — the agent decides whether to load a skill from those two fields alone.",
+      "severity": "error",
       "title": "Skills declare name and description",
     },
     {
@@ -122,6 +132,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add explicit workflow/command entry points (.cursor/commands/, .windsurf/workflows/, .claude/commands/, .continue/prompts/, …) for workflows you trigger intentionally.",
+      "severity": "error",
       "title": "Explicit workflows/commands defined",
     },
     {
@@ -133,6 +144,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Write skill descriptions of 40+ characters that say when to use the skill ("Use when…"), not just what it is — vague descriptions never trigger.",
+      "severity": "error",
       "title": "Skill descriptions are trigger-worthy",
     },
     {
@@ -144,6 +156,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Create a subagent definition (.cursor/agents/, .claude/agents/, or .opencode/agents/) for a purpose-built delegate (planning, review, release…).",
+      "severity": "error",
       "title": "Custom subagent defined",
     },
     {
@@ -155,6 +168,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Add frontmatter with name: and description: to every subagent definition — the parent agent decides whether to delegate from those two fields alone.",
+      "severity": "error",
       "title": "Subagents declare name and description",
     },
     {
@@ -166,6 +180,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Create a hooks configuration (.cursor/hooks.json or .claude/settings.json hooks key) — hooks are the harness layer that can observe and control the agent loop deterministically.",
+      "severity": "error",
       "title": "Hooks configuration present and valid JSON",
     },
     {
@@ -177,6 +192,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Register handlers only on documented events for your tool (Cursor: beforeShellExecution, afterFileEdit, …; Claude Code: PreToolUse, PostToolUse, …) — typos fail silently.",
+      "severity": "error",
       "title": "Hooks use known events and a version field",
     },
     {
@@ -188,6 +204,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Register a gate hook (Cursor: beforeShellExecution / beforeMCPExecution / preToolUse; Claude Code: PreToolUse) that returns allow/deny/ask for destructive operations.",
+      "severity": "error",
       "title": "Gate hook guards risky operations",
     },
     {
@@ -199,6 +216,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Register a feedback hook (Cursor: afterFileEdit / postToolUse / stop; Claude Code: PostToolUse) — e.g. auto-format edited files or run a quick lint.",
+      "severity": "error",
       "title": "Feedback hook observes agent output",
     },
     {
@@ -210,6 +228,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Commit the scripts referenced by your hooks config — a hook pointing at a missing script fails open on every machine but yours.",
+      "severity": "error",
       "title": "Hook scripts exist in the repository",
     },
     {
@@ -221,6 +240,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 6,
       "remediation": "Wire up a test runner (vitest/jest, pytest, go test, cargo test…) with a standard entry point — tests are the strongest feedback sensor an agent can run on its own work.",
+      "severity": "error",
       "title": "Test runner configured",
     },
     {
@@ -232,6 +252,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 5,
       "remediation": "Add a linter config (eslint/biome, ruff, golangci-lint, clippy.toml, rubocop…) — linters give the agent instant, deterministic feedback on every edit.",
+      "severity": "error",
       "title": "Linter configured",
     },
     {
@@ -243,6 +264,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Enable static type checking (tsconfig.json with strict: true, mypy/pyright for Python) — typed code is dramatically more harnessable: the compiler catches agent mistakes for free.",
+      "severity": "error",
       "title": "Type checking in place",
     },
     {
@@ -254,6 +276,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add an auto-formatter (prettier/biome, black or ruff format, gofmt/rustfmt are built-in) — formatting noise in diffs hides real agent mistakes from review.",
+      "severity": "error",
       "title": "Formatter configured",
     },
     {
@@ -265,6 +288,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Write at least one real test file — a configured runner with zero tests gives the agent a green light it did not earn.",
+      "severity": "error",
       "title": "Test files actually exist",
     },
     {
@@ -276,6 +300,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Add a CI workflow (.github/workflows/ci.yml) — CI is the harness sensor that catches what slipped past local checks, on every push.",
+      "severity": "error",
       "title": "CI pipeline configured",
     },
     {
@@ -287,6 +312,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Make CI execute the test suite (npm test, pytest, go test…) so no agent-authored change can merge without the sensors firing.",
+      "severity": "error",
       "title": "CI runs the test suite",
     },
     {
@@ -298,6 +324,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add lint and typecheck steps to CI — cheap computational sensors belong on every push ("keep quality left").",
+      "severity": "error",
       "title": "CI runs lint / type checks",
     },
     {
@@ -309,6 +336,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add pre-commit tooling (husky + lint-staged, pre-commit, lefthook) so fast checks run before a commit exists — the earliest possible feedback loop.",
+      "severity": "error",
       "title": "Pre-commit checks installed",
     },
     {
@@ -320,6 +348,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Add a .gitignore — agents commit what they see; make sure build output and local state are invisible.",
+      "severity": "error",
       "title": ".gitignore present",
     },
     {
@@ -331,6 +360,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add ".env" and ".env.*" to .gitignore so an agent can never stage credentials by accident.",
+      "severity": "error",
       "title": ".gitignore covers environment files",
     },
     {
@@ -342,6 +372,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Remove committed .env files (keep only .env.example) or at minimum ensure .gitignore excludes them — env files in an agent's working tree leak into context and commits.",
+      "severity": "error",
       "title": "No unprotected .env files in the tree",
     },
     {
@@ -353,6 +384,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Never inline API keys in MCP config (.cursor/mcp.json, .mcp.json, .agents/mcp_config.json) — use \${VAR} interpolation and document required variables in .env.example.",
+      "severity": "error",
       "title": "MCP configuration free of credentials",
     },
     {
@@ -364,6 +396,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Add a LICENSE file — required for open-source distribution and plugin marketplaces.",
+      "severity": "error",
       "title": "License present",
     },
     {
@@ -375,6 +408,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Remove any API keys or tokens from AGENTS.md, rules, and hooks configuration — harness files are loaded into model context on every session.",
+      "severity": "error",
       "title": "No credential signatures in harness files",
     },
     {
@@ -386,6 +420,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Commit the lockfile (package-lock.json, uv.lock, Cargo.lock…) — reproducible installs mean the agent's sensors run against the same dependencies everywhere.",
+      "severity": "error",
       "title": "Dependency lockfile committed",
     },
     {
@@ -397,12 +432,14 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Reference credential-shaped values in MCP config via \${ENV_VAR} interpolation instead of literals — this rewards deliberate, safe tool-access configuration.",
+      "severity": "error",
       "title": "MCP config uses env interpolation for credentials",
     },
   ],
   "detectedHarnesses": [],
   "dimensions": [
     {
+      "applicable": true,
       "earned": 1,
       "id": "context",
       "max": 20,
@@ -410,6 +447,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Context & Guides",
     },
     {
+      "applicable": true,
       "earned": 0,
       "id": "skills",
       "max": 17,
@@ -417,6 +455,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Skills & Commands",
     },
     {
+      "applicable": true,
       "earned": 0,
       "id": "hooks",
       "max": 14,
@@ -424,6 +463,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Hooks & Guardrails",
     },
     {
+      "applicable": true,
       "earned": 0,
       "id": "sensors",
       "max": 20,
@@ -431,6 +471,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Sensors & Feedback",
     },
     {
+      "applicable": true,
       "earned": 0,
       "id": "ci",
       "max": 14,
@@ -438,6 +479,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "CI Feedback",
     },
     {
+      "applicable": true,
       "earned": 13,
       "id": "hygiene",
       "max": 23,
@@ -456,6 +498,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Create an AGENTS.md at the repository root describing what the project is, how to build/test it, and the conventions agents must follow.",
+        "severity": "error",
         "title": "Agent context file present (AGENTS.md)",
       },
       {
@@ -467,6 +510,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Flesh out AGENTS.md: add sections for project overview, build & test commands, architecture, and conventions (aim for 20+ meaningful lines with headings).",
+        "severity": "error",
         "title": "Agent context file is substantive",
       },
       {
@@ -478,6 +522,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Add at least one scoped rule file for your AI tool (e.g. .cursor/rules/*.mdc, .windsurf/rules/*.md, .clinerules/*.md) or a nested AGENTS.md/CLAUDE.md in a subdirectory, stating the project non-negotiables.",
+        "severity": "error",
         "title": "Scoped rules in use",
       },
       {
@@ -489,6 +534,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Give every rule activation metadata in frontmatter (description, globs/trigger/paths/applyTo, or alwaysApply) so the agent knows when to load it.",
+        "severity": "error",
         "title": "Rules have valid frontmatter",
       },
       {
@@ -500,6 +546,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Scope rules to paths (globs, trigger glob, paths, applyTo) instead of making everything always-on — blanket rules consume context on every request.",
+        "severity": "error",
         "title": "Rules are scoped, not all always-on",
       },
       {
@@ -511,6 +558,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Split rules longer than 500 lines into focused, scoped rules or move procedural content into a skill — huge rules crowd out task context.",
+        "severity": "error",
         "title": "No bloated rules (≤500 lines each)",
       },
       {
@@ -522,6 +570,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 1,
         "remediation": "Add a README.md — agents (and humans) use it as the first orientation document.",
+        "severity": "error",
         "title": "README present",
       },
       {
@@ -533,6 +582,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 1,
         "remediation": "Migrate the legacy .cursorrules file to scoped rules with frontmatter (.cursor/rules/*.mdc or your tool equivalent) — .cursorrules is deprecated.",
+        "severity": "error",
         "title": "No legacy .cursorrules file",
       },
       {
@@ -544,6 +594,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Create a SKILL.md under your tool skills directory (.cursor/skills/, .claude/skills/, or .agents/skills/) packaging a procedural workflow the agent should follow on demand.",
+        "severity": "error",
         "title": "At least one agent skill defined",
       },
       {
@@ -555,6 +606,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add frontmatter with name: and description: to every SKILL.md — the agent decides whether to load a skill from those two fields alone.",
+        "severity": "error",
         "title": "Skills declare name and description",
       },
       {
@@ -566,6 +618,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add explicit workflow/command entry points (.cursor/commands/, .windsurf/workflows/, .claude/commands/, .continue/prompts/, …) for workflows you trigger intentionally.",
+        "severity": "error",
         "title": "Explicit workflows/commands defined",
       },
       {
@@ -577,6 +630,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Write skill descriptions of 40+ characters that say when to use the skill ("Use when…"), not just what it is — vague descriptions never trigger.",
+        "severity": "error",
         "title": "Skill descriptions are trigger-worthy",
       },
       {
@@ -588,6 +642,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Create a subagent definition (.cursor/agents/, .claude/agents/, or .opencode/agents/) for a purpose-built delegate (planning, review, release…).",
+        "severity": "error",
         "title": "Custom subagent defined",
       },
       {
@@ -599,6 +654,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Add frontmatter with name: and description: to every subagent definition — the parent agent decides whether to delegate from those two fields alone.",
+        "severity": "error",
         "title": "Subagents declare name and description",
       },
       {
@@ -610,6 +666,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Create a hooks configuration (.cursor/hooks.json or .claude/settings.json hooks key) — hooks are the harness layer that can observe and control the agent loop deterministically.",
+        "severity": "error",
         "title": "Hooks configuration present and valid JSON",
       },
       {
@@ -621,6 +678,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Register handlers only on documented events for your tool (Cursor: beforeShellExecution, afterFileEdit, …; Claude Code: PreToolUse, PostToolUse, …) — typos fail silently.",
+        "severity": "error",
         "title": "Hooks use known events and a version field",
       },
       {
@@ -632,6 +690,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Register a gate hook (Cursor: beforeShellExecution / beforeMCPExecution / preToolUse; Claude Code: PreToolUse) that returns allow/deny/ask for destructive operations.",
+        "severity": "error",
         "title": "Gate hook guards risky operations",
       },
       {
@@ -643,6 +702,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Register a feedback hook (Cursor: afterFileEdit / postToolUse / stop; Claude Code: PostToolUse) — e.g. auto-format edited files or run a quick lint.",
+        "severity": "error",
         "title": "Feedback hook observes agent output",
       },
       {
@@ -654,6 +714,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Commit the scripts referenced by your hooks config — a hook pointing at a missing script fails open on every machine but yours.",
+        "severity": "error",
         "title": "Hook scripts exist in the repository",
       },
       {
@@ -665,6 +726,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 6,
         "remediation": "Wire up a test runner (vitest/jest, pytest, go test, cargo test…) with a standard entry point — tests are the strongest feedback sensor an agent can run on its own work.",
+        "severity": "error",
         "title": "Test runner configured",
       },
       {
@@ -676,6 +738,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 5,
         "remediation": "Add a linter config (eslint/biome, ruff, golangci-lint, clippy.toml, rubocop…) — linters give the agent instant, deterministic feedback on every edit.",
+        "severity": "error",
         "title": "Linter configured",
       },
       {
@@ -687,6 +750,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Enable static type checking (tsconfig.json with strict: true, mypy/pyright for Python) — typed code is dramatically more harnessable: the compiler catches agent mistakes for free.",
+        "severity": "error",
         "title": "Type checking in place",
       },
       {
@@ -698,6 +762,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add an auto-formatter (prettier/biome, black or ruff format, gofmt/rustfmt are built-in) — formatting noise in diffs hides real agent mistakes from review.",
+        "severity": "error",
         "title": "Formatter configured",
       },
       {
@@ -709,6 +774,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Write at least one real test file — a configured runner with zero tests gives the agent a green light it did not earn.",
+        "severity": "error",
         "title": "Test files actually exist",
       },
       {
@@ -720,6 +786,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Add a CI workflow (.github/workflows/ci.yml) — CI is the harness sensor that catches what slipped past local checks, on every push.",
+        "severity": "error",
         "title": "CI pipeline configured",
       },
       {
@@ -731,6 +798,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Make CI execute the test suite (npm test, pytest, go test…) so no agent-authored change can merge without the sensors firing.",
+        "severity": "error",
         "title": "CI runs the test suite",
       },
       {
@@ -742,6 +810,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add lint and typecheck steps to CI — cheap computational sensors belong on every push ("keep quality left").",
+        "severity": "error",
         "title": "CI runs lint / type checks",
       },
       {
@@ -753,6 +822,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add pre-commit tooling (husky + lint-staged, pre-commit, lefthook) so fast checks run before a commit exists — the earliest possible feedback loop.",
+        "severity": "error",
         "title": "Pre-commit checks installed",
       },
       {
@@ -764,6 +834,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Add a .gitignore — agents commit what they see; make sure build output and local state are invisible.",
+        "severity": "error",
         "title": ".gitignore present",
       },
       {
@@ -775,6 +846,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add ".env" and ".env.*" to .gitignore so an agent can never stage credentials by accident.",
+        "severity": "error",
         "title": ".gitignore covers environment files",
       },
       {
@@ -786,6 +858,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Remove committed .env files (keep only .env.example) or at minimum ensure .gitignore excludes them — env files in an agent's working tree leak into context and commits.",
+        "severity": "error",
         "title": "No unprotected .env files in the tree",
       },
       {
@@ -797,6 +870,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Never inline API keys in MCP config (.cursor/mcp.json, .mcp.json, .agents/mcp_config.json) — use \${VAR} interpolation and document required variables in .env.example.",
+        "severity": "error",
         "title": "MCP configuration free of credentials",
       },
       {
@@ -808,6 +882,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Add a LICENSE file — required for open-source distribution and plugin marketplaces.",
+        "severity": "error",
         "title": "License present",
       },
       {
@@ -819,6 +894,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Remove any API keys or tokens from AGENTS.md, rules, and hooks configuration — harness files are loaded into model context on every session.",
+        "severity": "error",
         "title": "No credential signatures in harness files",
       },
       {
@@ -830,6 +906,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Commit the lockfile (package-lock.json, uv.lock, Cargo.lock…) — reproducible installs mean the agent's sensors run against the same dependencies everywhere.",
+        "severity": "error",
         "title": "Dependency lockfile committed",
       },
       {
@@ -841,12 +918,14 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Reference credential-shaped values in MCP config via \${ENV_VAR} interpolation instead of literals — this rewards deliberate, safe tool-access configuration.",
+        "severity": "error",
         "title": "MCP config uses env interpolation for credentials",
       },
     ],
     "detectedHarnesses": [],
     "dimensions": [
       {
+        "applicable": true,
         "earned": 1,
         "id": "context",
         "max": 20,
@@ -854,6 +933,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Context & Guides",
       },
       {
+        "applicable": true,
         "earned": 0,
         "id": "skills",
         "max": 17,
@@ -861,6 +941,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Skills & Commands",
       },
       {
+        "applicable": true,
         "earned": 0,
         "id": "hooks",
         "max": 14,
@@ -868,6 +949,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Hooks & Guardrails",
       },
       {
+        "applicable": true,
         "earned": 0,
         "id": "sensors",
         "max": 20,
@@ -875,6 +957,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Sensors & Feedback",
       },
       {
+        "applicable": true,
         "earned": 0,
         "id": "ci",
         "max": 14,
@@ -882,6 +965,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "CI Feedback",
       },
       {
+        "applicable": true,
         "earned": 13,
         "id": "hygiene",
         "max": 23,
@@ -890,6 +974,8 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       },
     ],
     "level": {
+      "capReason": undefined,
+      "capped": false,
       "index": 0,
       "name": "Unharnessed",
       "nextLevelGaps": [
@@ -904,11 +990,18 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
   },
   "gate": "maturity",
   "level": {
+    "capReason": undefined,
+    "capped": false,
     "index": 0,
     "name": "Unharnessed",
     "nextLevelGaps": [
       "context ≥ 40%",
     ],
+  },
+  "preset": {
+    "extends": [],
+    "resolved": [],
+    "rules": {},
   },
   "resolvedRoots": undefined,
   "scopes": {
@@ -940,6 +1033,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Create an AGENTS.md at the repository root describing what the project is, how to build/test it, and the conventions agents must follow.",
+      "severity": "error",
       "title": "Agent context file present (AGENTS.md)",
     },
     {
@@ -951,6 +1045,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Flesh out AGENTS.md: add sections for project overview, build & test commands, architecture, and conventions (aim for 20+ meaningful lines with headings).",
+      "severity": "error",
       "title": "Agent context file is substantive",
     },
     {
@@ -962,6 +1057,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Add at least one scoped rule file for your AI tool (e.g. .cursor/rules/*.mdc, .windsurf/rules/*.md, .clinerules/*.md) or a nested AGENTS.md/CLAUDE.md in a subdirectory, stating the project non-negotiables.",
+      "severity": "error",
       "title": "Scoped rules in use",
     },
     {
@@ -973,6 +1069,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Give every rule activation metadata in frontmatter (description, globs/trigger/paths/applyTo, or alwaysApply) so the agent knows when to load it.",
+      "severity": "error",
       "title": "Rules have valid frontmatter",
     },
     {
@@ -984,6 +1081,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Scope rules to paths (globs, trigger glob, paths, applyTo) instead of making everything always-on — blanket rules consume context on every request.",
+      "severity": "error",
       "title": "Rules are scoped, not all always-on",
     },
     {
@@ -995,6 +1093,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Split rules longer than 500 lines into focused, scoped rules or move procedural content into a skill — huge rules crowd out task context.",
+      "severity": "error",
       "title": "No bloated rules (≤500 lines each)",
     },
     {
@@ -1006,6 +1105,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 1,
       "remediation": "Add a README.md — agents (and humans) use it as the first orientation document.",
+      "severity": "error",
       "title": "README present",
     },
     {
@@ -1017,6 +1117,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 1,
       "remediation": "Migrate the legacy .cursorrules file to scoped rules with frontmatter (.cursor/rules/*.mdc or your tool equivalent) — .cursorrules is deprecated.",
+      "severity": "error",
       "title": "No legacy .cursorrules file",
     },
     {
@@ -1028,6 +1129,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Create a SKILL.md under your tool skills directory (.cursor/skills/, .claude/skills/, or .agents/skills/) packaging a procedural workflow the agent should follow on demand.",
+      "severity": "error",
       "title": "At least one agent skill defined",
     },
     {
@@ -1039,6 +1141,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add frontmatter with name: and description: to every SKILL.md — the agent decides whether to load a skill from those two fields alone.",
+      "severity": "error",
       "title": "Skills declare name and description",
     },
     {
@@ -1050,6 +1153,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add explicit workflow/command entry points (.cursor/commands/, .windsurf/workflows/, .claude/commands/, .continue/prompts/, …) for workflows you trigger intentionally.",
+      "severity": "error",
       "title": "Explicit workflows/commands defined",
     },
     {
@@ -1061,6 +1165,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Write skill descriptions of 40+ characters that say when to use the skill ("Use when…"), not just what it is — vague descriptions never trigger.",
+      "severity": "error",
       "title": "Skill descriptions are trigger-worthy",
     },
     {
@@ -1072,6 +1177,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Create a subagent definition (.cursor/agents/, .claude/agents/, or .opencode/agents/) for a purpose-built delegate (planning, review, release…).",
+      "severity": "error",
       "title": "Custom subagent defined",
     },
     {
@@ -1083,6 +1189,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Add frontmatter with name: and description: to every subagent definition — the parent agent decides whether to delegate from those two fields alone.",
+      "severity": "error",
       "title": "Subagents declare name and description",
     },
     {
@@ -1094,6 +1201,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Create a hooks configuration (.cursor/hooks.json or .claude/settings.json hooks key) — hooks are the harness layer that can observe and control the agent loop deterministically.",
+      "severity": "error",
       "title": "Hooks configuration present and valid JSON",
     },
     {
@@ -1105,6 +1213,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Register handlers only on documented events for your tool (Cursor: beforeShellExecution, afterFileEdit, …; Claude Code: PreToolUse, PostToolUse, …) — typos fail silently.",
+      "severity": "error",
       "title": "Hooks use known events and a version field",
     },
     {
@@ -1116,6 +1225,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Register a gate hook (Cursor: beforeShellExecution / beforeMCPExecution / preToolUse; Claude Code: PreToolUse) that returns allow/deny/ask for destructive operations.",
+      "severity": "error",
       "title": "Gate hook guards risky operations",
     },
     {
@@ -1127,6 +1237,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Register a feedback hook (Cursor: afterFileEdit / postToolUse / stop; Claude Code: PostToolUse) — e.g. auto-format edited files or run a quick lint.",
+      "severity": "error",
       "title": "Feedback hook observes agent output",
     },
     {
@@ -1138,6 +1249,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Commit the scripts referenced by your hooks config — a hook pointing at a missing script fails open on every machine but yours.",
+      "severity": "error",
       "title": "Hook scripts exist in the repository",
     },
     {
@@ -1149,6 +1261,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 6,
       "remediation": "Wire up a test runner (vitest/jest, pytest, go test, cargo test…) with a standard entry point — tests are the strongest feedback sensor an agent can run on its own work.",
+      "severity": "error",
       "title": "Test runner configured",
     },
     {
@@ -1160,6 +1273,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 5,
       "remediation": "Add a linter config (eslint/biome, ruff, golangci-lint, clippy.toml, rubocop…) — linters give the agent instant, deterministic feedback on every edit.",
+      "severity": "error",
       "title": "Linter configured",
     },
     {
@@ -1171,6 +1285,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Enable static type checking (tsconfig.json with strict: true, mypy/pyright for Python) — typed code is dramatically more harnessable: the compiler catches agent mistakes for free.",
+      "severity": "error",
       "title": "Type checking in place",
     },
     {
@@ -1182,6 +1297,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add an auto-formatter (prettier/biome, black or ruff format, gofmt/rustfmt are built-in) — formatting noise in diffs hides real agent mistakes from review.",
+      "severity": "error",
       "title": "Formatter configured",
     },
     {
@@ -1193,6 +1309,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Write at least one real test file — a configured runner with zero tests gives the agent a green light it did not earn.",
+      "severity": "error",
       "title": "Test files actually exist",
     },
     {
@@ -1204,6 +1321,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Add a CI workflow (.github/workflows/ci.yml) — CI is the harness sensor that catches what slipped past local checks, on every push.",
+      "severity": "error",
       "title": "CI pipeline configured",
     },
     {
@@ -1215,6 +1333,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Make CI execute the test suite (npm test, pytest, go test…) so no agent-authored change can merge without the sensors firing.",
+      "severity": "error",
       "title": "CI runs the test suite",
     },
     {
@@ -1226,6 +1345,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add lint and typecheck steps to CI — cheap computational sensors belong on every push ("keep quality left").",
+      "severity": "error",
       "title": "CI runs lint / type checks",
     },
     {
@@ -1237,6 +1357,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add pre-commit tooling (husky + lint-staged, pre-commit, lefthook) so fast checks run before a commit exists — the earliest possible feedback loop.",
+      "severity": "error",
       "title": "Pre-commit checks installed",
     },
     {
@@ -1248,6 +1369,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Add a .gitignore — agents commit what they see; make sure build output and local state are invisible.",
+      "severity": "error",
       "title": ".gitignore present",
     },
     {
@@ -1259,6 +1381,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add ".env" and ".env.*" to .gitignore so an agent can never stage credentials by accident.",
+      "severity": "error",
       "title": ".gitignore covers environment files",
     },
     {
@@ -1270,6 +1393,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Remove committed .env files (keep only .env.example) or at minimum ensure .gitignore excludes them — env files in an agent's working tree leak into context and commits.",
+      "severity": "error",
       "title": "No unprotected .env files in the tree",
     },
     {
@@ -1281,6 +1405,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Never inline API keys in MCP config (.cursor/mcp.json, .mcp.json, .agents/mcp_config.json) — use \${VAR} interpolation and document required variables in .env.example.",
+      "severity": "error",
       "title": "MCP configuration free of credentials",
     },
     {
@@ -1292,6 +1417,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Add a LICENSE file — required for open-source distribution and plugin marketplaces.",
+      "severity": "error",
       "title": "License present",
     },
     {
@@ -1303,6 +1429,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Remove any API keys or tokens from AGENTS.md, rules, and hooks configuration — harness files are loaded into model context on every session.",
+      "severity": "error",
       "title": "No credential signatures in harness files",
     },
     {
@@ -1314,6 +1441,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Commit the lockfile (package-lock.json, uv.lock, Cargo.lock…) — reproducible installs mean the agent's sensors run against the same dependencies everywhere.",
+      "severity": "error",
       "title": "Dependency lockfile committed",
     },
     {
@@ -1325,12 +1453,14 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Reference credential-shaped values in MCP config via \${ENV_VAR} interpolation instead of literals — this rewards deliberate, safe tool-access configuration.",
+      "severity": "error",
       "title": "MCP config uses env interpolation for credentials",
     },
   ],
   "detectedHarnesses": [],
   "dimensions": [
     {
+      "applicable": true,
       "earned": 9,
       "id": "context",
       "max": 20,
@@ -1338,6 +1468,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Context & Guides",
     },
     {
+      "applicable": true,
       "earned": 0,
       "id": "skills",
       "max": 17,
@@ -1345,6 +1476,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Skills & Commands",
     },
     {
+      "applicable": true,
       "earned": 0,
       "id": "hooks",
       "max": 14,
@@ -1352,6 +1484,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Hooks & Guardrails",
     },
     {
+      "applicable": true,
       "earned": 0,
       "id": "sensors",
       "max": 20,
@@ -1359,6 +1492,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Sensors & Feedback",
     },
     {
+      "applicable": true,
       "earned": 0,
       "id": "ci",
       "max": 14,
@@ -1366,6 +1500,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "CI Feedback",
     },
     {
+      "applicable": true,
       "earned": 13,
       "id": "hygiene",
       "max": 23,
@@ -1384,6 +1519,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Create an AGENTS.md at the repository root describing what the project is, how to build/test it, and the conventions agents must follow.",
+        "severity": "error",
         "title": "Agent context file present (AGENTS.md)",
       },
       {
@@ -1395,6 +1531,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Flesh out AGENTS.md: add sections for project overview, build & test commands, architecture, and conventions (aim for 20+ meaningful lines with headings).",
+        "severity": "error",
         "title": "Agent context file is substantive",
       },
       {
@@ -1406,6 +1543,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Add at least one scoped rule file for your AI tool (e.g. .cursor/rules/*.mdc, .windsurf/rules/*.md, .clinerules/*.md) or a nested AGENTS.md/CLAUDE.md in a subdirectory, stating the project non-negotiables.",
+        "severity": "error",
         "title": "Scoped rules in use",
       },
       {
@@ -1417,6 +1555,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Give every rule activation metadata in frontmatter (description, globs/trigger/paths/applyTo, or alwaysApply) so the agent knows when to load it.",
+        "severity": "error",
         "title": "Rules have valid frontmatter",
       },
       {
@@ -1428,6 +1567,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Scope rules to paths (globs, trigger glob, paths, applyTo) instead of making everything always-on — blanket rules consume context on every request.",
+        "severity": "error",
         "title": "Rules are scoped, not all always-on",
       },
       {
@@ -1439,6 +1579,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Split rules longer than 500 lines into focused, scoped rules or move procedural content into a skill — huge rules crowd out task context.",
+        "severity": "error",
         "title": "No bloated rules (≤500 lines each)",
       },
       {
@@ -1450,6 +1591,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 1,
         "remediation": "Add a README.md — agents (and humans) use it as the first orientation document.",
+        "severity": "error",
         "title": "README present",
       },
       {
@@ -1461,6 +1603,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 1,
         "remediation": "Migrate the legacy .cursorrules file to scoped rules with frontmatter (.cursor/rules/*.mdc or your tool equivalent) — .cursorrules is deprecated.",
+        "severity": "error",
         "title": "No legacy .cursorrules file",
       },
       {
@@ -1472,6 +1615,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Create a SKILL.md under your tool skills directory (.cursor/skills/, .claude/skills/, or .agents/skills/) packaging a procedural workflow the agent should follow on demand.",
+        "severity": "error",
         "title": "At least one agent skill defined",
       },
       {
@@ -1483,6 +1627,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add frontmatter with name: and description: to every SKILL.md — the agent decides whether to load a skill from those two fields alone.",
+        "severity": "error",
         "title": "Skills declare name and description",
       },
       {
@@ -1494,6 +1639,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add explicit workflow/command entry points (.cursor/commands/, .windsurf/workflows/, .claude/commands/, .continue/prompts/, …) for workflows you trigger intentionally.",
+        "severity": "error",
         "title": "Explicit workflows/commands defined",
       },
       {
@@ -1505,6 +1651,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Write skill descriptions of 40+ characters that say when to use the skill ("Use when…"), not just what it is — vague descriptions never trigger.",
+        "severity": "error",
         "title": "Skill descriptions are trigger-worthy",
       },
       {
@@ -1516,6 +1663,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Create a subagent definition (.cursor/agents/, .claude/agents/, or .opencode/agents/) for a purpose-built delegate (planning, review, release…).",
+        "severity": "error",
         "title": "Custom subagent defined",
       },
       {
@@ -1527,6 +1675,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Add frontmatter with name: and description: to every subagent definition — the parent agent decides whether to delegate from those two fields alone.",
+        "severity": "error",
         "title": "Subagents declare name and description",
       },
       {
@@ -1538,6 +1687,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Create a hooks configuration (.cursor/hooks.json or .claude/settings.json hooks key) — hooks are the harness layer that can observe and control the agent loop deterministically.",
+        "severity": "error",
         "title": "Hooks configuration present and valid JSON",
       },
       {
@@ -1549,6 +1699,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Register handlers only on documented events for your tool (Cursor: beforeShellExecution, afterFileEdit, …; Claude Code: PreToolUse, PostToolUse, …) — typos fail silently.",
+        "severity": "error",
         "title": "Hooks use known events and a version field",
       },
       {
@@ -1560,6 +1711,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Register a gate hook (Cursor: beforeShellExecution / beforeMCPExecution / preToolUse; Claude Code: PreToolUse) that returns allow/deny/ask for destructive operations.",
+        "severity": "error",
         "title": "Gate hook guards risky operations",
       },
       {
@@ -1571,6 +1723,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Register a feedback hook (Cursor: afterFileEdit / postToolUse / stop; Claude Code: PostToolUse) — e.g. auto-format edited files or run a quick lint.",
+        "severity": "error",
         "title": "Feedback hook observes agent output",
       },
       {
@@ -1582,6 +1735,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Commit the scripts referenced by your hooks config — a hook pointing at a missing script fails open on every machine but yours.",
+        "severity": "error",
         "title": "Hook scripts exist in the repository",
       },
       {
@@ -1593,6 +1747,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 6,
         "remediation": "Wire up a test runner (vitest/jest, pytest, go test, cargo test…) with a standard entry point — tests are the strongest feedback sensor an agent can run on its own work.",
+        "severity": "error",
         "title": "Test runner configured",
       },
       {
@@ -1604,6 +1759,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 5,
         "remediation": "Add a linter config (eslint/biome, ruff, golangci-lint, clippy.toml, rubocop…) — linters give the agent instant, deterministic feedback on every edit.",
+        "severity": "error",
         "title": "Linter configured",
       },
       {
@@ -1615,6 +1771,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Enable static type checking (tsconfig.json with strict: true, mypy/pyright for Python) — typed code is dramatically more harnessable: the compiler catches agent mistakes for free.",
+        "severity": "error",
         "title": "Type checking in place",
       },
       {
@@ -1626,6 +1783,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add an auto-formatter (prettier/biome, black or ruff format, gofmt/rustfmt are built-in) — formatting noise in diffs hides real agent mistakes from review.",
+        "severity": "error",
         "title": "Formatter configured",
       },
       {
@@ -1637,6 +1795,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Write at least one real test file — a configured runner with zero tests gives the agent a green light it did not earn.",
+        "severity": "error",
         "title": "Test files actually exist",
       },
       {
@@ -1648,6 +1807,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Add a CI workflow (.github/workflows/ci.yml) — CI is the harness sensor that catches what slipped past local checks, on every push.",
+        "severity": "error",
         "title": "CI pipeline configured",
       },
       {
@@ -1659,6 +1819,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Make CI execute the test suite (npm test, pytest, go test…) so no agent-authored change can merge without the sensors firing.",
+        "severity": "error",
         "title": "CI runs the test suite",
       },
       {
@@ -1670,6 +1831,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add lint and typecheck steps to CI — cheap computational sensors belong on every push ("keep quality left").",
+        "severity": "error",
         "title": "CI runs lint / type checks",
       },
       {
@@ -1681,6 +1843,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add pre-commit tooling (husky + lint-staged, pre-commit, lefthook) so fast checks run before a commit exists — the earliest possible feedback loop.",
+        "severity": "error",
         "title": "Pre-commit checks installed",
       },
       {
@@ -1692,6 +1855,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Add a .gitignore — agents commit what they see; make sure build output and local state are invisible.",
+        "severity": "error",
         "title": ".gitignore present",
       },
       {
@@ -1703,6 +1867,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add ".env" and ".env.*" to .gitignore so an agent can never stage credentials by accident.",
+        "severity": "error",
         "title": ".gitignore covers environment files",
       },
       {
@@ -1714,6 +1879,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Remove committed .env files (keep only .env.example) or at minimum ensure .gitignore excludes them — env files in an agent's working tree leak into context and commits.",
+        "severity": "error",
         "title": "No unprotected .env files in the tree",
       },
       {
@@ -1725,6 +1891,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Never inline API keys in MCP config (.cursor/mcp.json, .mcp.json, .agents/mcp_config.json) — use \${VAR} interpolation and document required variables in .env.example.",
+        "severity": "error",
         "title": "MCP configuration free of credentials",
       },
       {
@@ -1736,6 +1903,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Add a LICENSE file — required for open-source distribution and plugin marketplaces.",
+        "severity": "error",
         "title": "License present",
       },
       {
@@ -1747,6 +1915,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Remove any API keys or tokens from AGENTS.md, rules, and hooks configuration — harness files are loaded into model context on every session.",
+        "severity": "error",
         "title": "No credential signatures in harness files",
       },
       {
@@ -1758,6 +1927,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Commit the lockfile (package-lock.json, uv.lock, Cargo.lock…) — reproducible installs mean the agent's sensors run against the same dependencies everywhere.",
+        "severity": "error",
         "title": "Dependency lockfile committed",
       },
       {
@@ -1769,12 +1939,14 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Reference credential-shaped values in MCP config via \${ENV_VAR} interpolation instead of literals — this rewards deliberate, safe tool-access configuration.",
+        "severity": "error",
         "title": "MCP config uses env interpolation for credentials",
       },
     ],
     "detectedHarnesses": [],
     "dimensions": [
       {
+        "applicable": true,
         "earned": 9,
         "id": "context",
         "max": 20,
@@ -1782,6 +1954,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Context & Guides",
       },
       {
+        "applicable": true,
         "earned": 0,
         "id": "skills",
         "max": 17,
@@ -1789,6 +1962,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Skills & Commands",
       },
       {
+        "applicable": true,
         "earned": 0,
         "id": "hooks",
         "max": 14,
@@ -1796,6 +1970,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Hooks & Guardrails",
       },
       {
+        "applicable": true,
         "earned": 0,
         "id": "sensors",
         "max": 20,
@@ -1803,6 +1978,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Sensors & Feedback",
       },
       {
+        "applicable": true,
         "earned": 0,
         "id": "ci",
         "max": 14,
@@ -1810,6 +1986,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "CI Feedback",
       },
       {
+        "applicable": true,
         "earned": 13,
         "id": "hygiene",
         "max": 23,
@@ -1818,6 +1995,8 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       },
     ],
     "level": {
+      "capReason": undefined,
+      "capped": false,
       "index": 1,
       "name": "Documented",
       "nextLevelGaps": [
@@ -1833,12 +2012,19 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
   },
   "gate": "maturity",
   "level": {
+    "capReason": undefined,
+    "capped": false,
     "index": 1,
     "name": "Documented",
     "nextLevelGaps": [
       "context ≥ 60%",
       "skills ≥ 30% or hooks ≥ 30%",
     ],
+  },
+  "preset": {
+    "extends": [],
+    "resolved": [],
+    "rules": {},
   },
   "resolvedRoots": undefined,
   "scopes": {
@@ -1870,6 +2056,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Create an AGENTS.md at the repository root describing what the project is, how to build/test it, and the conventions agents must follow.",
+      "severity": "error",
       "title": "Agent context file present (AGENTS.md)",
     },
     {
@@ -1881,6 +2068,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Flesh out AGENTS.md: add sections for project overview, build & test commands, architecture, and conventions (aim for 20+ meaningful lines with headings).",
+      "severity": "error",
       "title": "Agent context file is substantive",
     },
     {
@@ -1892,6 +2080,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Add at least one scoped rule file for your AI tool (e.g. .cursor/rules/*.mdc, .windsurf/rules/*.md, .clinerules/*.md) or a nested AGENTS.md/CLAUDE.md in a subdirectory, stating the project non-negotiables.",
+      "severity": "error",
       "title": "Scoped rules in use",
     },
     {
@@ -1903,6 +2092,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Give every rule activation metadata in frontmatter (description, globs/trigger/paths/applyTo, or alwaysApply) so the agent knows when to load it.",
+      "severity": "error",
       "title": "Rules have valid frontmatter",
     },
     {
@@ -1914,6 +2104,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Scope rules to paths (globs, trigger glob, paths, applyTo) instead of making everything always-on — blanket rules consume context on every request.",
+      "severity": "error",
       "title": "Rules are scoped, not all always-on",
     },
     {
@@ -1925,6 +2116,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Split rules longer than 500 lines into focused, scoped rules or move procedural content into a skill — huge rules crowd out task context.",
+      "severity": "error",
       "title": "No bloated rules (≤500 lines each)",
     },
     {
@@ -1936,6 +2128,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 1,
       "remediation": "Add a README.md — agents (and humans) use it as the first orientation document.",
+      "severity": "error",
       "title": "README present",
     },
     {
@@ -1947,6 +2140,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 1,
       "remediation": "Migrate the legacy .cursorrules file to scoped rules with frontmatter (.cursor/rules/*.mdc or your tool equivalent) — .cursorrules is deprecated.",
+      "severity": "error",
       "title": "No legacy .cursorrules file",
     },
     {
@@ -1958,6 +2152,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Create a SKILL.md under your tool skills directory (.cursor/skills/, .claude/skills/, or .agents/skills/) packaging a procedural workflow the agent should follow on demand.",
+      "severity": "error",
       "title": "At least one agent skill defined",
     },
     {
@@ -1969,6 +2164,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add frontmatter with name: and description: to every SKILL.md — the agent decides whether to load a skill from those two fields alone.",
+      "severity": "error",
       "title": "Skills declare name and description",
     },
     {
@@ -1980,6 +2176,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add explicit workflow/command entry points (.cursor/commands/, .windsurf/workflows/, .claude/commands/, .continue/prompts/, …) for workflows you trigger intentionally.",
+      "severity": "error",
       "title": "Explicit workflows/commands defined",
     },
     {
@@ -1991,6 +2188,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Write skill descriptions of 40+ characters that say when to use the skill ("Use when…"), not just what it is — vague descriptions never trigger.",
+      "severity": "error",
       "title": "Skill descriptions are trigger-worthy",
     },
     {
@@ -2002,6 +2200,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Create a subagent definition (.cursor/agents/, .claude/agents/, or .opencode/agents/) for a purpose-built delegate (planning, review, release…).",
+      "severity": "error",
       "title": "Custom subagent defined",
     },
     {
@@ -2013,6 +2212,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Add frontmatter with name: and description: to every subagent definition — the parent agent decides whether to delegate from those two fields alone.",
+      "severity": "error",
       "title": "Subagents declare name and description",
     },
     {
@@ -2024,6 +2224,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Create a hooks configuration (.cursor/hooks.json or .claude/settings.json hooks key) — hooks are the harness layer that can observe and control the agent loop deterministically.",
+      "severity": "error",
       "title": "Hooks configuration present and valid JSON",
     },
     {
@@ -2035,6 +2236,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Register handlers only on documented events for your tool (Cursor: beforeShellExecution, afterFileEdit, …; Claude Code: PreToolUse, PostToolUse, …) — typos fail silently.",
+      "severity": "error",
       "title": "Hooks use known events and a version field",
     },
     {
@@ -2046,6 +2248,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Register a gate hook (Cursor: beforeShellExecution / beforeMCPExecution / preToolUse; Claude Code: PreToolUse) that returns allow/deny/ask for destructive operations.",
+      "severity": "error",
       "title": "Gate hook guards risky operations",
     },
     {
@@ -2057,6 +2260,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Register a feedback hook (Cursor: afterFileEdit / postToolUse / stop; Claude Code: PostToolUse) — e.g. auto-format edited files or run a quick lint.",
+      "severity": "error",
       "title": "Feedback hook observes agent output",
     },
     {
@@ -2068,6 +2272,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Commit the scripts referenced by your hooks config — a hook pointing at a missing script fails open on every machine but yours.",
+      "severity": "error",
       "title": "Hook scripts exist in the repository",
     },
     {
@@ -2079,6 +2284,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 6,
       "remediation": "Wire up a test runner (vitest/jest, pytest, go test, cargo test…) with a standard entry point — tests are the strongest feedback sensor an agent can run on its own work.",
+      "severity": "error",
       "title": "Test runner configured",
     },
     {
@@ -2090,6 +2296,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 5,
       "remediation": "Add a linter config (eslint/biome, ruff, golangci-lint, clippy.toml, rubocop…) — linters give the agent instant, deterministic feedback on every edit.",
+      "severity": "error",
       "title": "Linter configured",
     },
     {
@@ -2101,6 +2308,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Enable static type checking (tsconfig.json with strict: true, mypy/pyright for Python) — typed code is dramatically more harnessable: the compiler catches agent mistakes for free.",
+      "severity": "error",
       "title": "Type checking in place",
     },
     {
@@ -2112,6 +2320,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add an auto-formatter (prettier/biome, black or ruff format, gofmt/rustfmt are built-in) — formatting noise in diffs hides real agent mistakes from review.",
+      "severity": "error",
       "title": "Formatter configured",
     },
     {
@@ -2123,6 +2332,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Write at least one real test file — a configured runner with zero tests gives the agent a green light it did not earn.",
+      "severity": "error",
       "title": "Test files actually exist",
     },
     {
@@ -2134,6 +2344,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Add a CI workflow (.github/workflows/ci.yml) — CI is the harness sensor that catches what slipped past local checks, on every push.",
+      "severity": "error",
       "title": "CI pipeline configured",
     },
     {
@@ -2145,6 +2356,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Make CI execute the test suite (npm test, pytest, go test…) so no agent-authored change can merge without the sensors firing.",
+      "severity": "error",
       "title": "CI runs the test suite",
     },
     {
@@ -2156,6 +2368,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add lint and typecheck steps to CI — cheap computational sensors belong on every push ("keep quality left").",
+      "severity": "error",
       "title": "CI runs lint / type checks",
     },
     {
@@ -2167,6 +2380,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add pre-commit tooling (husky + lint-staged, pre-commit, lefthook) so fast checks run before a commit exists — the earliest possible feedback loop.",
+      "severity": "error",
       "title": "Pre-commit checks installed",
     },
     {
@@ -2178,6 +2392,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Add a .gitignore — agents commit what they see; make sure build output and local state are invisible.",
+      "severity": "error",
       "title": ".gitignore present",
     },
     {
@@ -2189,6 +2404,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add ".env" and ".env.*" to .gitignore so an agent can never stage credentials by accident.",
+      "severity": "error",
       "title": ".gitignore covers environment files",
     },
     {
@@ -2200,6 +2416,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Remove committed .env files (keep only .env.example) or at minimum ensure .gitignore excludes them — env files in an agent's working tree leak into context and commits.",
+      "severity": "error",
       "title": "No unprotected .env files in the tree",
     },
     {
@@ -2211,6 +2428,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Never inline API keys in MCP config (.cursor/mcp.json, .mcp.json, .agents/mcp_config.json) — use \${VAR} interpolation and document required variables in .env.example.",
+      "severity": "error",
       "title": "MCP configuration free of credentials",
     },
     {
@@ -2222,6 +2440,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Add a LICENSE file — required for open-source distribution and plugin marketplaces.",
+      "severity": "error",
       "title": "License present",
     },
     {
@@ -2233,6 +2452,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Remove any API keys or tokens from AGENTS.md, rules, and hooks configuration — harness files are loaded into model context on every session.",
+      "severity": "error",
       "title": "No credential signatures in harness files",
     },
     {
@@ -2244,6 +2464,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Commit the lockfile (package-lock.json, uv.lock, Cargo.lock…) — reproducible installs mean the agent's sensors run against the same dependencies everywhere.",
+      "severity": "error",
       "title": "Dependency lockfile committed",
     },
     {
@@ -2255,6 +2476,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Reference credential-shaped values in MCP config via \${ENV_VAR} interpolation instead of literals — this rewards deliberate, safe tool-access configuration.",
+      "severity": "error",
       "title": "MCP config uses env interpolation for credentials",
     },
   ],
@@ -2263,6 +2485,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
   ],
   "dimensions": [
     {
+      "applicable": true,
       "earned": 20,
       "id": "context",
       "max": 20,
@@ -2270,6 +2493,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Context & Guides",
     },
     {
+      "applicable": true,
       "earned": 12,
       "id": "skills",
       "max": 17,
@@ -2277,6 +2501,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Skills & Commands",
     },
     {
+      "applicable": true,
       "earned": 0,
       "id": "hooks",
       "max": 14,
@@ -2284,6 +2509,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Hooks & Guardrails",
     },
     {
+      "applicable": true,
       "earned": 0,
       "id": "sensors",
       "max": 20,
@@ -2291,6 +2517,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Sensors & Feedback",
     },
     {
+      "applicable": true,
       "earned": 0,
       "id": "ci",
       "max": 14,
@@ -2298,6 +2525,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "CI Feedback",
     },
     {
+      "applicable": true,
       "earned": 20,
       "id": "hygiene",
       "max": 23,
@@ -2316,6 +2544,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Create an AGENTS.md at the repository root describing what the project is, how to build/test it, and the conventions agents must follow.",
+        "severity": "error",
         "title": "Agent context file present (AGENTS.md)",
       },
       {
@@ -2327,6 +2556,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Flesh out AGENTS.md: add sections for project overview, build & test commands, architecture, and conventions (aim for 20+ meaningful lines with headings).",
+        "severity": "error",
         "title": "Agent context file is substantive",
       },
       {
@@ -2338,6 +2568,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Add at least one scoped rule file for your AI tool (e.g. .cursor/rules/*.mdc, .windsurf/rules/*.md, .clinerules/*.md) or a nested AGENTS.md/CLAUDE.md in a subdirectory, stating the project non-negotiables.",
+        "severity": "error",
         "title": "Scoped rules in use",
       },
       {
@@ -2349,6 +2580,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Give every rule activation metadata in frontmatter (description, globs/trigger/paths/applyTo, or alwaysApply) so the agent knows when to load it.",
+        "severity": "error",
         "title": "Rules have valid frontmatter",
       },
       {
@@ -2360,6 +2592,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Scope rules to paths (globs, trigger glob, paths, applyTo) instead of making everything always-on — blanket rules consume context on every request.",
+        "severity": "error",
         "title": "Rules are scoped, not all always-on",
       },
       {
@@ -2371,6 +2604,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Split rules longer than 500 lines into focused, scoped rules or move procedural content into a skill — huge rules crowd out task context.",
+        "severity": "error",
         "title": "No bloated rules (≤500 lines each)",
       },
       {
@@ -2382,6 +2616,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 1,
         "remediation": "Add a README.md — agents (and humans) use it as the first orientation document.",
+        "severity": "error",
         "title": "README present",
       },
       {
@@ -2393,6 +2628,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 1,
         "remediation": "Migrate the legacy .cursorrules file to scoped rules with frontmatter (.cursor/rules/*.mdc or your tool equivalent) — .cursorrules is deprecated.",
+        "severity": "error",
         "title": "No legacy .cursorrules file",
       },
       {
@@ -2404,6 +2640,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Create a SKILL.md under your tool skills directory (.cursor/skills/, .claude/skills/, or .agents/skills/) packaging a procedural workflow the agent should follow on demand.",
+        "severity": "error",
         "title": "At least one agent skill defined",
       },
       {
@@ -2415,6 +2652,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add frontmatter with name: and description: to every SKILL.md — the agent decides whether to load a skill from those two fields alone.",
+        "severity": "error",
         "title": "Skills declare name and description",
       },
       {
@@ -2426,6 +2664,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add explicit workflow/command entry points (.cursor/commands/, .windsurf/workflows/, .claude/commands/, .continue/prompts/, …) for workflows you trigger intentionally.",
+        "severity": "error",
         "title": "Explicit workflows/commands defined",
       },
       {
@@ -2437,6 +2676,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Write skill descriptions of 40+ characters that say when to use the skill ("Use when…"), not just what it is — vague descriptions never trigger.",
+        "severity": "error",
         "title": "Skill descriptions are trigger-worthy",
       },
       {
@@ -2448,6 +2688,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Create a subagent definition (.cursor/agents/, .claude/agents/, or .opencode/agents/) for a purpose-built delegate (planning, review, release…).",
+        "severity": "error",
         "title": "Custom subagent defined",
       },
       {
@@ -2459,6 +2700,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Add frontmatter with name: and description: to every subagent definition — the parent agent decides whether to delegate from those two fields alone.",
+        "severity": "error",
         "title": "Subagents declare name and description",
       },
       {
@@ -2470,6 +2712,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Create a hooks configuration (.cursor/hooks.json or .claude/settings.json hooks key) — hooks are the harness layer that can observe and control the agent loop deterministically.",
+        "severity": "error",
         "title": "Hooks configuration present and valid JSON",
       },
       {
@@ -2481,6 +2724,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Register handlers only on documented events for your tool (Cursor: beforeShellExecution, afterFileEdit, …; Claude Code: PreToolUse, PostToolUse, …) — typos fail silently.",
+        "severity": "error",
         "title": "Hooks use known events and a version field",
       },
       {
@@ -2492,6 +2736,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Register a gate hook (Cursor: beforeShellExecution / beforeMCPExecution / preToolUse; Claude Code: PreToolUse) that returns allow/deny/ask for destructive operations.",
+        "severity": "error",
         "title": "Gate hook guards risky operations",
       },
       {
@@ -2503,6 +2748,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Register a feedback hook (Cursor: afterFileEdit / postToolUse / stop; Claude Code: PostToolUse) — e.g. auto-format edited files or run a quick lint.",
+        "severity": "error",
         "title": "Feedback hook observes agent output",
       },
       {
@@ -2514,6 +2760,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Commit the scripts referenced by your hooks config — a hook pointing at a missing script fails open on every machine but yours.",
+        "severity": "error",
         "title": "Hook scripts exist in the repository",
       },
       {
@@ -2525,6 +2772,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 6,
         "remediation": "Wire up a test runner (vitest/jest, pytest, go test, cargo test…) with a standard entry point — tests are the strongest feedback sensor an agent can run on its own work.",
+        "severity": "error",
         "title": "Test runner configured",
       },
       {
@@ -2536,6 +2784,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 5,
         "remediation": "Add a linter config (eslint/biome, ruff, golangci-lint, clippy.toml, rubocop…) — linters give the agent instant, deterministic feedback on every edit.",
+        "severity": "error",
         "title": "Linter configured",
       },
       {
@@ -2547,6 +2796,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Enable static type checking (tsconfig.json with strict: true, mypy/pyright for Python) — typed code is dramatically more harnessable: the compiler catches agent mistakes for free.",
+        "severity": "error",
         "title": "Type checking in place",
       },
       {
@@ -2558,6 +2808,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add an auto-formatter (prettier/biome, black or ruff format, gofmt/rustfmt are built-in) — formatting noise in diffs hides real agent mistakes from review.",
+        "severity": "error",
         "title": "Formatter configured",
       },
       {
@@ -2569,6 +2820,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Write at least one real test file — a configured runner with zero tests gives the agent a green light it did not earn.",
+        "severity": "error",
         "title": "Test files actually exist",
       },
       {
@@ -2580,6 +2832,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Add a CI workflow (.github/workflows/ci.yml) — CI is the harness sensor that catches what slipped past local checks, on every push.",
+        "severity": "error",
         "title": "CI pipeline configured",
       },
       {
@@ -2591,6 +2844,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Make CI execute the test suite (npm test, pytest, go test…) so no agent-authored change can merge without the sensors firing.",
+        "severity": "error",
         "title": "CI runs the test suite",
       },
       {
@@ -2602,6 +2856,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add lint and typecheck steps to CI — cheap computational sensors belong on every push ("keep quality left").",
+        "severity": "error",
         "title": "CI runs lint / type checks",
       },
       {
@@ -2613,6 +2868,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add pre-commit tooling (husky + lint-staged, pre-commit, lefthook) so fast checks run before a commit exists — the earliest possible feedback loop.",
+        "severity": "error",
         "title": "Pre-commit checks installed",
       },
       {
@@ -2624,6 +2880,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Add a .gitignore — agents commit what they see; make sure build output and local state are invisible.",
+        "severity": "error",
         "title": ".gitignore present",
       },
       {
@@ -2635,6 +2892,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add ".env" and ".env.*" to .gitignore so an agent can never stage credentials by accident.",
+        "severity": "error",
         "title": ".gitignore covers environment files",
       },
       {
@@ -2646,6 +2904,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Remove committed .env files (keep only .env.example) or at minimum ensure .gitignore excludes them — env files in an agent's working tree leak into context and commits.",
+        "severity": "error",
         "title": "No unprotected .env files in the tree",
       },
       {
@@ -2657,6 +2916,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Never inline API keys in MCP config (.cursor/mcp.json, .mcp.json, .agents/mcp_config.json) — use \${VAR} interpolation and document required variables in .env.example.",
+        "severity": "error",
         "title": "MCP configuration free of credentials",
       },
       {
@@ -2668,6 +2928,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Add a LICENSE file — required for open-source distribution and plugin marketplaces.",
+        "severity": "error",
         "title": "License present",
       },
       {
@@ -2679,6 +2940,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Remove any API keys or tokens from AGENTS.md, rules, and hooks configuration — harness files are loaded into model context on every session.",
+        "severity": "error",
         "title": "No credential signatures in harness files",
       },
       {
@@ -2690,6 +2952,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Commit the lockfile (package-lock.json, uv.lock, Cargo.lock…) — reproducible installs mean the agent's sensors run against the same dependencies everywhere.",
+        "severity": "error",
         "title": "Dependency lockfile committed",
       },
       {
@@ -2701,6 +2964,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Reference credential-shaped values in MCP config via \${ENV_VAR} interpolation instead of literals — this rewards deliberate, safe tool-access configuration.",
+        "severity": "error",
         "title": "MCP config uses env interpolation for credentials",
       },
     ],
@@ -2709,6 +2973,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
     ],
     "dimensions": [
       {
+        "applicable": true,
         "earned": 20,
         "id": "context",
         "max": 20,
@@ -2716,6 +2981,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Context & Guides",
       },
       {
+        "applicable": true,
         "earned": 12,
         "id": "skills",
         "max": 17,
@@ -2723,6 +2989,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Skills & Commands",
       },
       {
+        "applicable": true,
         "earned": 0,
         "id": "hooks",
         "max": 14,
@@ -2730,6 +2997,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Hooks & Guardrails",
       },
       {
+        "applicable": true,
         "earned": 0,
         "id": "sensors",
         "max": 20,
@@ -2737,6 +3005,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Sensors & Feedback",
       },
       {
+        "applicable": true,
         "earned": 0,
         "id": "ci",
         "max": 14,
@@ -2744,6 +3013,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "CI Feedback",
       },
       {
+        "applicable": true,
         "earned": 20,
         "id": "hygiene",
         "max": 23,
@@ -2752,6 +3022,8 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       },
     ],
     "level": {
+      "capReason": undefined,
+      "capped": false,
       "index": 2,
       "name": "Guided",
       "nextLevelGaps": [
@@ -2767,12 +3039,19 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
   },
   "gate": "maturity",
   "level": {
+    "capReason": undefined,
+    "capped": false,
     "index": 2,
     "name": "Guided",
     "nextLevelGaps": [
       "sensors ≥ 60%",
       "ci ≥ 50%",
     ],
+  },
+  "preset": {
+    "extends": [],
+    "resolved": [],
+    "rules": {},
   },
   "resolvedRoots": undefined,
   "scopes": {
@@ -2804,6 +3083,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Create an AGENTS.md at the repository root describing what the project is, how to build/test it, and the conventions agents must follow.",
+      "severity": "error",
       "title": "Agent context file present (AGENTS.md)",
     },
     {
@@ -2815,6 +3095,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Flesh out AGENTS.md: add sections for project overview, build & test commands, architecture, and conventions (aim for 20+ meaningful lines with headings).",
+      "severity": "error",
       "title": "Agent context file is substantive",
     },
     {
@@ -2826,6 +3107,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Add at least one scoped rule file for your AI tool (e.g. .cursor/rules/*.mdc, .windsurf/rules/*.md, .clinerules/*.md) or a nested AGENTS.md/CLAUDE.md in a subdirectory, stating the project non-negotiables.",
+      "severity": "error",
       "title": "Scoped rules in use",
     },
     {
@@ -2837,6 +3119,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Give every rule activation metadata in frontmatter (description, globs/trigger/paths/applyTo, or alwaysApply) so the agent knows when to load it.",
+      "severity": "error",
       "title": "Rules have valid frontmatter",
     },
     {
@@ -2848,6 +3131,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Scope rules to paths (globs, trigger glob, paths, applyTo) instead of making everything always-on — blanket rules consume context on every request.",
+      "severity": "error",
       "title": "Rules are scoped, not all always-on",
     },
     {
@@ -2859,6 +3143,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Split rules longer than 500 lines into focused, scoped rules or move procedural content into a skill — huge rules crowd out task context.",
+      "severity": "error",
       "title": "No bloated rules (≤500 lines each)",
     },
     {
@@ -2870,6 +3155,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 1,
       "remediation": "Add a README.md — agents (and humans) use it as the first orientation document.",
+      "severity": "error",
       "title": "README present",
     },
     {
@@ -2881,6 +3167,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 1,
       "remediation": "Migrate the legacy .cursorrules file to scoped rules with frontmatter (.cursor/rules/*.mdc or your tool equivalent) — .cursorrules is deprecated.",
+      "severity": "error",
       "title": "No legacy .cursorrules file",
     },
     {
@@ -2892,6 +3179,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Create a SKILL.md under your tool skills directory (.cursor/skills/, .claude/skills/, or .agents/skills/) packaging a procedural workflow the agent should follow on demand.",
+      "severity": "error",
       "title": "At least one agent skill defined",
     },
     {
@@ -2903,6 +3191,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add frontmatter with name: and description: to every SKILL.md — the agent decides whether to load a skill from those two fields alone.",
+      "severity": "error",
       "title": "Skills declare name and description",
     },
     {
@@ -2914,6 +3203,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add explicit workflow/command entry points (.cursor/commands/, .windsurf/workflows/, .claude/commands/, .continue/prompts/, …) for workflows you trigger intentionally.",
+      "severity": "error",
       "title": "Explicit workflows/commands defined",
     },
     {
@@ -2925,6 +3215,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Write skill descriptions of 40+ characters that say when to use the skill ("Use when…"), not just what it is — vague descriptions never trigger.",
+      "severity": "error",
       "title": "Skill descriptions are trigger-worthy",
     },
     {
@@ -2936,6 +3227,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Create a subagent definition (.cursor/agents/, .claude/agents/, or .opencode/agents/) for a purpose-built delegate (planning, review, release…).",
+      "severity": "error",
       "title": "Custom subagent defined",
     },
     {
@@ -2947,6 +3239,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Add frontmatter with name: and description: to every subagent definition — the parent agent decides whether to delegate from those two fields alone.",
+      "severity": "error",
       "title": "Subagents declare name and description",
     },
     {
@@ -2958,6 +3251,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Create a hooks configuration (.cursor/hooks.json or .claude/settings.json hooks key) — hooks are the harness layer that can observe and control the agent loop deterministically.",
+      "severity": "error",
       "title": "Hooks configuration present and valid JSON",
     },
     {
@@ -2969,6 +3263,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Register handlers only on documented events for your tool (Cursor: beforeShellExecution, afterFileEdit, …; Claude Code: PreToolUse, PostToolUse, …) — typos fail silently.",
+      "severity": "error",
       "title": "Hooks use known events and a version field",
     },
     {
@@ -2980,6 +3275,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 4,
       "remediation": "Register a gate hook (Cursor: beforeShellExecution / beforeMCPExecution / preToolUse; Claude Code: PreToolUse) that returns allow/deny/ask for destructive operations.",
+      "severity": "error",
       "title": "Gate hook guards risky operations",
     },
     {
@@ -2991,6 +3287,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Register a feedback hook (Cursor: afterFileEdit / postToolUse / stop; Claude Code: PostToolUse) — e.g. auto-format edited files or run a quick lint.",
+      "severity": "error",
       "title": "Feedback hook observes agent output",
     },
     {
@@ -3002,6 +3299,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 2,
       "remediation": "Commit the scripts referenced by your hooks config — a hook pointing at a missing script fails open on every machine but yours.",
+      "severity": "error",
       "title": "Hook scripts exist in the repository",
     },
     {
@@ -3013,6 +3311,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 6,
       "remediation": "Wire up a test runner (vitest/jest, pytest, go test, cargo test…) with a standard entry point — tests are the strongest feedback sensor an agent can run on its own work.",
+      "severity": "error",
       "title": "Test runner configured",
     },
     {
@@ -3024,6 +3323,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 5,
       "remediation": "Add a linter config (eslint/biome, ruff, golangci-lint, clippy.toml, rubocop…) — linters give the agent instant, deterministic feedback on every edit.",
+      "severity": "error",
       "title": "Linter configured",
     },
     {
@@ -3035,6 +3335,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Enable static type checking (tsconfig.json with strict: true, mypy/pyright for Python) — typed code is dramatically more harnessable: the compiler catches agent mistakes for free.",
+      "severity": "error",
       "title": "Type checking in place",
     },
     {
@@ -3046,6 +3347,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add an auto-formatter (prettier/biome, black or ruff format, gofmt/rustfmt are built-in) — formatting noise in diffs hides real agent mistakes from review.",
+      "severity": "error",
       "title": "Formatter configured",
     },
     {
@@ -3057,6 +3359,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Write at least one real test file — a configured runner with zero tests gives the agent a green light it did not earn.",
+      "severity": "error",
       "title": "Test files actually exist",
     },
     {
@@ -3068,6 +3371,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Add a CI workflow (.github/workflows/ci.yml) — CI is the harness sensor that catches what slipped past local checks, on every push.",
+      "severity": "error",
       "title": "CI pipeline configured",
     },
     {
@@ -3079,6 +3383,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Make CI execute the test suite (npm test, pytest, go test…) so no agent-authored change can merge without the sensors firing.",
+      "severity": "error",
       "title": "CI runs the test suite",
     },
     {
@@ -3090,6 +3395,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add lint and typecheck steps to CI — cheap computational sensors belong on every push ("keep quality left").",
+      "severity": "error",
       "title": "CI runs lint / type checks",
     },
     {
@@ -3101,6 +3407,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Add pre-commit tooling (husky + lint-staged, pre-commit, lefthook) so fast checks run before a commit exists — the earliest possible feedback loop.",
+      "severity": "error",
       "title": "Pre-commit checks installed",
     },
     {
@@ -3112,6 +3419,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Add a .gitignore — agents commit what they see; make sure build output and local state are invisible.",
+      "severity": "error",
       "title": ".gitignore present",
     },
     {
@@ -3123,6 +3431,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add ".env" and ".env.*" to .gitignore so an agent can never stage credentials by accident.",
+      "severity": "error",
       "title": ".gitignore covers environment files",
     },
     {
@@ -3134,6 +3443,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Remove committed .env files (keep only .env.example) or at minimum ensure .gitignore excludes them — env files in an agent's working tree leak into context and commits.",
+      "severity": "error",
       "title": "No unprotected .env files in the tree",
     },
     {
@@ -3145,6 +3455,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Never inline API keys in MCP config (.cursor/mcp.json, .mcp.json, .agents/mcp_config.json) — use \${VAR} interpolation and document required variables in .env.example.",
+      "severity": "error",
       "title": "MCP configuration free of credentials",
     },
     {
@@ -3156,6 +3467,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Add a LICENSE file — required for open-source distribution and plugin marketplaces.",
+      "severity": "error",
       "title": "License present",
     },
     {
@@ -3167,6 +3479,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Remove any API keys or tokens from AGENTS.md, rules, and hooks configuration — harness files are loaded into model context on every session.",
+      "severity": "error",
       "title": "No credential signatures in harness files",
     },
     {
@@ -3178,6 +3491,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Commit the lockfile (package-lock.json, uv.lock, Cargo.lock…) — reproducible installs mean the agent's sensors run against the same dependencies everywhere.",
+      "severity": "error",
       "title": "Dependency lockfile committed",
     },
     {
@@ -3189,6 +3503,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": false,
       "points": 3,
       "remediation": "Reference credential-shaped values in MCP config via \${ENV_VAR} interpolation instead of literals — this rewards deliberate, safe tool-access configuration.",
+      "severity": "error",
       "title": "MCP config uses env interpolation for credentials",
     },
   ],
@@ -3197,6 +3512,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
   ],
   "dimensions": [
     {
+      "applicable": true,
       "earned": 20,
       "id": "context",
       "max": 20,
@@ -3204,6 +3520,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Context & Guides",
     },
     {
+      "applicable": true,
       "earned": 17,
       "id": "skills",
       "max": 17,
@@ -3211,6 +3528,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Skills & Commands",
     },
     {
+      "applicable": true,
       "earned": 0,
       "id": "hooks",
       "max": 14,
@@ -3218,6 +3536,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Hooks & Guardrails",
     },
     {
+      "applicable": true,
       "earned": 20,
       "id": "sensors",
       "max": 20,
@@ -3225,6 +3544,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Sensors & Feedback",
     },
     {
+      "applicable": true,
       "earned": 11,
       "id": "ci",
       "max": 14,
@@ -3232,6 +3552,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "CI Feedback",
     },
     {
+      "applicable": true,
       "earned": 20,
       "id": "hygiene",
       "max": 23,
@@ -3250,6 +3571,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Create an AGENTS.md at the repository root describing what the project is, how to build/test it, and the conventions agents must follow.",
+        "severity": "error",
         "title": "Agent context file present (AGENTS.md)",
       },
       {
@@ -3261,6 +3583,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Flesh out AGENTS.md: add sections for project overview, build & test commands, architecture, and conventions (aim for 20+ meaningful lines with headings).",
+        "severity": "error",
         "title": "Agent context file is substantive",
       },
       {
@@ -3272,6 +3595,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Add at least one scoped rule file for your AI tool (e.g. .cursor/rules/*.mdc, .windsurf/rules/*.md, .clinerules/*.md) or a nested AGENTS.md/CLAUDE.md in a subdirectory, stating the project non-negotiables.",
+        "severity": "error",
         "title": "Scoped rules in use",
       },
       {
@@ -3283,6 +3607,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Give every rule activation metadata in frontmatter (description, globs/trigger/paths/applyTo, or alwaysApply) so the agent knows when to load it.",
+        "severity": "error",
         "title": "Rules have valid frontmatter",
       },
       {
@@ -3294,6 +3619,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Scope rules to paths (globs, trigger glob, paths, applyTo) instead of making everything always-on — blanket rules consume context on every request.",
+        "severity": "error",
         "title": "Rules are scoped, not all always-on",
       },
       {
@@ -3305,6 +3631,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Split rules longer than 500 lines into focused, scoped rules or move procedural content into a skill — huge rules crowd out task context.",
+        "severity": "error",
         "title": "No bloated rules (≤500 lines each)",
       },
       {
@@ -3316,6 +3643,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 1,
         "remediation": "Add a README.md — agents (and humans) use it as the first orientation document.",
+        "severity": "error",
         "title": "README present",
       },
       {
@@ -3327,6 +3655,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 1,
         "remediation": "Migrate the legacy .cursorrules file to scoped rules with frontmatter (.cursor/rules/*.mdc or your tool equivalent) — .cursorrules is deprecated.",
+        "severity": "error",
         "title": "No legacy .cursorrules file",
       },
       {
@@ -3338,6 +3667,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Create a SKILL.md under your tool skills directory (.cursor/skills/, .claude/skills/, or .agents/skills/) packaging a procedural workflow the agent should follow on demand.",
+        "severity": "error",
         "title": "At least one agent skill defined",
       },
       {
@@ -3349,6 +3679,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add frontmatter with name: and description: to every SKILL.md — the agent decides whether to load a skill from those two fields alone.",
+        "severity": "error",
         "title": "Skills declare name and description",
       },
       {
@@ -3360,6 +3691,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add explicit workflow/command entry points (.cursor/commands/, .windsurf/workflows/, .claude/commands/, .continue/prompts/, …) for workflows you trigger intentionally.",
+        "severity": "error",
         "title": "Explicit workflows/commands defined",
       },
       {
@@ -3371,6 +3703,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Write skill descriptions of 40+ characters that say when to use the skill ("Use when…"), not just what it is — vague descriptions never trigger.",
+        "severity": "error",
         "title": "Skill descriptions are trigger-worthy",
       },
       {
@@ -3382,6 +3715,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Create a subagent definition (.cursor/agents/, .claude/agents/, or .opencode/agents/) for a purpose-built delegate (planning, review, release…).",
+        "severity": "error",
         "title": "Custom subagent defined",
       },
       {
@@ -3393,6 +3727,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Add frontmatter with name: and description: to every subagent definition — the parent agent decides whether to delegate from those two fields alone.",
+        "severity": "error",
         "title": "Subagents declare name and description",
       },
       {
@@ -3404,6 +3739,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Create a hooks configuration (.cursor/hooks.json or .claude/settings.json hooks key) — hooks are the harness layer that can observe and control the agent loop deterministically.",
+        "severity": "error",
         "title": "Hooks configuration present and valid JSON",
       },
       {
@@ -3415,6 +3751,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Register handlers only on documented events for your tool (Cursor: beforeShellExecution, afterFileEdit, …; Claude Code: PreToolUse, PostToolUse, …) — typos fail silently.",
+        "severity": "error",
         "title": "Hooks use known events and a version field",
       },
       {
@@ -3426,6 +3763,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 4,
         "remediation": "Register a gate hook (Cursor: beforeShellExecution / beforeMCPExecution / preToolUse; Claude Code: PreToolUse) that returns allow/deny/ask for destructive operations.",
+        "severity": "error",
         "title": "Gate hook guards risky operations",
       },
       {
@@ -3437,6 +3775,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Register a feedback hook (Cursor: afterFileEdit / postToolUse / stop; Claude Code: PostToolUse) — e.g. auto-format edited files or run a quick lint.",
+        "severity": "error",
         "title": "Feedback hook observes agent output",
       },
       {
@@ -3448,6 +3787,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 2,
         "remediation": "Commit the scripts referenced by your hooks config — a hook pointing at a missing script fails open on every machine but yours.",
+        "severity": "error",
         "title": "Hook scripts exist in the repository",
       },
       {
@@ -3459,6 +3799,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 6,
         "remediation": "Wire up a test runner (vitest/jest, pytest, go test, cargo test…) with a standard entry point — tests are the strongest feedback sensor an agent can run on its own work.",
+        "severity": "error",
         "title": "Test runner configured",
       },
       {
@@ -3470,6 +3811,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 5,
         "remediation": "Add a linter config (eslint/biome, ruff, golangci-lint, clippy.toml, rubocop…) — linters give the agent instant, deterministic feedback on every edit.",
+        "severity": "error",
         "title": "Linter configured",
       },
       {
@@ -3481,6 +3823,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Enable static type checking (tsconfig.json with strict: true, mypy/pyright for Python) — typed code is dramatically more harnessable: the compiler catches agent mistakes for free.",
+        "severity": "error",
         "title": "Type checking in place",
       },
       {
@@ -3492,6 +3835,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add an auto-formatter (prettier/biome, black or ruff format, gofmt/rustfmt are built-in) — formatting noise in diffs hides real agent mistakes from review.",
+        "severity": "error",
         "title": "Formatter configured",
       },
       {
@@ -3503,6 +3847,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Write at least one real test file — a configured runner with zero tests gives the agent a green light it did not earn.",
+        "severity": "error",
         "title": "Test files actually exist",
       },
       {
@@ -3514,6 +3859,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Add a CI workflow (.github/workflows/ci.yml) — CI is the harness sensor that catches what slipped past local checks, on every push.",
+        "severity": "error",
         "title": "CI pipeline configured",
       },
       {
@@ -3525,6 +3871,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Make CI execute the test suite (npm test, pytest, go test…) so no agent-authored change can merge without the sensors firing.",
+        "severity": "error",
         "title": "CI runs the test suite",
       },
       {
@@ -3536,6 +3883,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add lint and typecheck steps to CI — cheap computational sensors belong on every push ("keep quality left").",
+        "severity": "error",
         "title": "CI runs lint / type checks",
       },
       {
@@ -3547,6 +3895,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Add pre-commit tooling (husky + lint-staged, pre-commit, lefthook) so fast checks run before a commit exists — the earliest possible feedback loop.",
+        "severity": "error",
         "title": "Pre-commit checks installed",
       },
       {
@@ -3558,6 +3907,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Add a .gitignore — agents commit what they see; make sure build output and local state are invisible.",
+        "severity": "error",
         "title": ".gitignore present",
       },
       {
@@ -3569,6 +3919,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add ".env" and ".env.*" to .gitignore so an agent can never stage credentials by accident.",
+        "severity": "error",
         "title": ".gitignore covers environment files",
       },
       {
@@ -3580,6 +3931,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Remove committed .env files (keep only .env.example) or at minimum ensure .gitignore excludes them — env files in an agent's working tree leak into context and commits.",
+        "severity": "error",
         "title": "No unprotected .env files in the tree",
       },
       {
@@ -3591,6 +3943,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Never inline API keys in MCP config (.cursor/mcp.json, .mcp.json, .agents/mcp_config.json) — use \${VAR} interpolation and document required variables in .env.example.",
+        "severity": "error",
         "title": "MCP configuration free of credentials",
       },
       {
@@ -3602,6 +3955,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Add a LICENSE file — required for open-source distribution and plugin marketplaces.",
+        "severity": "error",
         "title": "License present",
       },
       {
@@ -3613,6 +3967,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Remove any API keys or tokens from AGENTS.md, rules, and hooks configuration — harness files are loaded into model context on every session.",
+        "severity": "error",
         "title": "No credential signatures in harness files",
       },
       {
@@ -3624,6 +3979,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Commit the lockfile (package-lock.json, uv.lock, Cargo.lock…) — reproducible installs mean the agent's sensors run against the same dependencies everywhere.",
+        "severity": "error",
         "title": "Dependency lockfile committed",
       },
       {
@@ -3635,6 +3991,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": false,
         "points": 3,
         "remediation": "Reference credential-shaped values in MCP config via \${ENV_VAR} interpolation instead of literals — this rewards deliberate, safe tool-access configuration.",
+        "severity": "error",
         "title": "MCP config uses env interpolation for credentials",
       },
     ],
@@ -3643,6 +4000,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
     ],
     "dimensions": [
       {
+        "applicable": true,
         "earned": 20,
         "id": "context",
         "max": 20,
@@ -3650,6 +4008,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Context & Guides",
       },
       {
+        "applicable": true,
         "earned": 17,
         "id": "skills",
         "max": 17,
@@ -3657,6 +4016,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Skills & Commands",
       },
       {
+        "applicable": true,
         "earned": 0,
         "id": "hooks",
         "max": 14,
@@ -3664,6 +4024,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Hooks & Guardrails",
       },
       {
+        "applicable": true,
         "earned": 20,
         "id": "sensors",
         "max": 20,
@@ -3671,6 +4032,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Sensors & Feedback",
       },
       {
+        "applicable": true,
         "earned": 11,
         "id": "ci",
         "max": 14,
@@ -3678,6 +4040,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "CI Feedback",
       },
       {
+        "applicable": true,
         "earned": 20,
         "id": "hygiene",
         "max": 23,
@@ -3686,6 +4049,8 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       },
     ],
     "level": {
+      "capReason": undefined,
+      "capped": false,
       "index": 3,
       "name": "Sensing",
       "nextLevelGaps": [
@@ -3700,11 +4065,18 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
   },
   "gate": "maturity",
   "level": {
+    "capReason": undefined,
+    "capped": false,
     "index": 3,
     "name": "Sensing",
     "nextLevelGaps": [
       "hooks ≥ 70%",
     ],
+  },
+  "preset": {
+    "extends": [],
+    "resolved": [],
+    "rules": {},
   },
   "resolvedRoots": undefined,
   "scopes": {
@@ -3736,6 +4108,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Create an AGENTS.md at the repository root describing what the project is, how to build/test it, and the conventions agents must follow.",
+      "severity": "error",
       "title": "Agent context file present (AGENTS.md)",
     },
     {
@@ -3747,6 +4120,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Flesh out AGENTS.md: add sections for project overview, build & test commands, architecture, and conventions (aim for 20+ meaningful lines with headings).",
+      "severity": "error",
       "title": "Agent context file is substantive",
     },
     {
@@ -3758,6 +4132,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Add at least one scoped rule file for your AI tool (e.g. .cursor/rules/*.mdc, .windsurf/rules/*.md, .clinerules/*.md) or a nested AGENTS.md/CLAUDE.md in a subdirectory, stating the project non-negotiables.",
+      "severity": "error",
       "title": "Scoped rules in use",
     },
     {
@@ -3769,6 +4144,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Give every rule activation metadata in frontmatter (description, globs/trigger/paths/applyTo, or alwaysApply) so the agent knows when to load it.",
+      "severity": "error",
       "title": "Rules have valid frontmatter",
     },
     {
@@ -3780,6 +4156,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Scope rules to paths (globs, trigger glob, paths, applyTo) instead of making everything always-on — blanket rules consume context on every request.",
+      "severity": "error",
       "title": "Rules are scoped, not all always-on",
     },
     {
@@ -3791,6 +4168,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Split rules longer than 500 lines into focused, scoped rules or move procedural content into a skill — huge rules crowd out task context.",
+      "severity": "error",
       "title": "No bloated rules (≤500 lines each)",
     },
     {
@@ -3802,6 +4180,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 1,
       "remediation": "Add a README.md — agents (and humans) use it as the first orientation document.",
+      "severity": "error",
       "title": "README present",
     },
     {
@@ -3813,6 +4192,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 1,
       "remediation": "Migrate the legacy .cursorrules file to scoped rules with frontmatter (.cursor/rules/*.mdc or your tool equivalent) — .cursorrules is deprecated.",
+      "severity": "error",
       "title": "No legacy .cursorrules file",
     },
     {
@@ -3824,6 +4204,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Create a SKILL.md under your tool skills directory (.cursor/skills/, .claude/skills/, or .agents/skills/) packaging a procedural workflow the agent should follow on demand.",
+      "severity": "error",
       "title": "At least one agent skill defined",
     },
     {
@@ -3835,6 +4216,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add frontmatter with name: and description: to every SKILL.md — the agent decides whether to load a skill from those two fields alone.",
+      "severity": "error",
       "title": "Skills declare name and description",
     },
     {
@@ -3846,6 +4228,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add explicit workflow/command entry points (.cursor/commands/, .windsurf/workflows/, .claude/commands/, .continue/prompts/, …) for workflows you trigger intentionally.",
+      "severity": "error",
       "title": "Explicit workflows/commands defined",
     },
     {
@@ -3857,6 +4240,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Write skill descriptions of 40+ characters that say when to use the skill ("Use when…"), not just what it is — vague descriptions never trigger.",
+      "severity": "error",
       "title": "Skill descriptions are trigger-worthy",
     },
     {
@@ -3868,6 +4252,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Create a subagent definition (.cursor/agents/, .claude/agents/, or .opencode/agents/) for a purpose-built delegate (planning, review, release…).",
+      "severity": "error",
       "title": "Custom subagent defined",
     },
     {
@@ -3879,6 +4264,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Add frontmatter with name: and description: to every subagent definition — the parent agent decides whether to delegate from those two fields alone.",
+      "severity": "error",
       "title": "Subagents declare name and description",
     },
     {
@@ -3890,6 +4276,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Create a hooks configuration (.cursor/hooks.json or .claude/settings.json hooks key) — hooks are the harness layer that can observe and control the agent loop deterministically.",
+      "severity": "error",
       "title": "Hooks configuration present and valid JSON",
     },
     {
@@ -3901,6 +4288,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Register handlers only on documented events for your tool (Cursor: beforeShellExecution, afterFileEdit, …; Claude Code: PreToolUse, PostToolUse, …) — typos fail silently.",
+      "severity": "error",
       "title": "Hooks use known events and a version field",
     },
     {
@@ -3912,6 +4300,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Register a gate hook (Cursor: beforeShellExecution / beforeMCPExecution / preToolUse; Claude Code: PreToolUse) that returns allow/deny/ask for destructive operations.",
+      "severity": "error",
       "title": "Gate hook guards risky operations",
     },
     {
@@ -3923,6 +4312,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Register a feedback hook (Cursor: afterFileEdit / postToolUse / stop; Claude Code: PostToolUse) — e.g. auto-format edited files or run a quick lint.",
+      "severity": "error",
       "title": "Feedback hook observes agent output",
     },
     {
@@ -3934,6 +4324,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Commit the scripts referenced by your hooks config — a hook pointing at a missing script fails open on every machine but yours.",
+      "severity": "error",
       "title": "Hook scripts exist in the repository",
     },
     {
@@ -3945,6 +4336,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 6,
       "remediation": "Wire up a test runner (vitest/jest, pytest, go test, cargo test…) with a standard entry point — tests are the strongest feedback sensor an agent can run on its own work.",
+      "severity": "error",
       "title": "Test runner configured",
     },
     {
@@ -3956,6 +4348,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 5,
       "remediation": "Add a linter config (eslint/biome, ruff, golangci-lint, clippy.toml, rubocop…) — linters give the agent instant, deterministic feedback on every edit.",
+      "severity": "error",
       "title": "Linter configured",
     },
     {
@@ -3967,6 +4360,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Enable static type checking (tsconfig.json with strict: true, mypy/pyright for Python) — typed code is dramatically more harnessable: the compiler catches agent mistakes for free.",
+      "severity": "error",
       "title": "Type checking in place",
     },
     {
@@ -3978,6 +4372,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add an auto-formatter (prettier/biome, black or ruff format, gofmt/rustfmt are built-in) — formatting noise in diffs hides real agent mistakes from review.",
+      "severity": "error",
       "title": "Formatter configured",
     },
     {
@@ -3989,6 +4384,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Write at least one real test file — a configured runner with zero tests gives the agent a green light it did not earn.",
+      "severity": "error",
       "title": "Test files actually exist",
     },
     {
@@ -4000,6 +4396,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Add a CI workflow (.github/workflows/ci.yml) — CI is the harness sensor that catches what slipped past local checks, on every push.",
+      "severity": "error",
       "title": "CI pipeline configured",
     },
     {
@@ -4011,6 +4408,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Make CI execute the test suite (npm test, pytest, go test…) so no agent-authored change can merge without the sensors firing.",
+      "severity": "error",
       "title": "CI runs the test suite",
     },
     {
@@ -4022,6 +4420,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add lint and typecheck steps to CI — cheap computational sensors belong on every push ("keep quality left").",
+      "severity": "error",
       "title": "CI runs lint / type checks",
     },
     {
@@ -4033,6 +4432,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add pre-commit tooling (husky + lint-staged, pre-commit, lefthook) so fast checks run before a commit exists — the earliest possible feedback loop.",
+      "severity": "error",
       "title": "Pre-commit checks installed",
     },
     {
@@ -4044,6 +4444,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Add a .gitignore — agents commit what they see; make sure build output and local state are invisible.",
+      "severity": "error",
       "title": ".gitignore present",
     },
     {
@@ -4055,6 +4456,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add ".env" and ".env.*" to .gitignore so an agent can never stage credentials by accident.",
+      "severity": "error",
       "title": ".gitignore covers environment files",
     },
     {
@@ -4066,6 +4468,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Remove committed .env files (keep only .env.example) or at minimum ensure .gitignore excludes them — env files in an agent's working tree leak into context and commits.",
+      "severity": "error",
       "title": "No unprotected .env files in the tree",
     },
     {
@@ -4077,6 +4480,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Never inline API keys in MCP config (.cursor/mcp.json, .mcp.json, .agents/mcp_config.json) — use \${VAR} interpolation and document required variables in .env.example.",
+      "severity": "error",
       "title": "MCP configuration free of credentials",
     },
     {
@@ -4088,6 +4492,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Add a LICENSE file — required for open-source distribution and plugin marketplaces.",
+      "severity": "error",
       "title": "License present",
     },
     {
@@ -4099,6 +4504,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Remove any API keys or tokens from AGENTS.md, rules, and hooks configuration — harness files are loaded into model context on every session.",
+      "severity": "error",
       "title": "No credential signatures in harness files",
     },
     {
@@ -4110,6 +4516,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Commit the lockfile (package-lock.json, uv.lock, Cargo.lock…) — reproducible installs mean the agent's sensors run against the same dependencies everywhere.",
+      "severity": "error",
       "title": "Dependency lockfile committed",
     },
     {
@@ -4121,6 +4528,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Reference credential-shaped values in MCP config via \${ENV_VAR} interpolation instead of literals — this rewards deliberate, safe tool-access configuration.",
+      "severity": "error",
       "title": "MCP config uses env interpolation for credentials",
     },
   ],
@@ -4129,6 +4537,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
   ],
   "dimensions": [
     {
+      "applicable": true,
       "earned": 20,
       "id": "context",
       "max": 20,
@@ -4136,6 +4545,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Context & Guides",
     },
     {
+      "applicable": true,
       "earned": 17,
       "id": "skills",
       "max": 17,
@@ -4143,6 +4553,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Skills & Commands",
     },
     {
+      "applicable": true,
       "earned": 14,
       "id": "hooks",
       "max": 14,
@@ -4150,6 +4561,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Hooks & Guardrails",
     },
     {
+      "applicable": true,
       "earned": 20,
       "id": "sensors",
       "max": 20,
@@ -4157,6 +4569,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Sensors & Feedback",
     },
     {
+      "applicable": true,
       "earned": 14,
       "id": "ci",
       "max": 14,
@@ -4164,6 +4577,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "CI Feedback",
     },
     {
+      "applicable": true,
       "earned": 23,
       "id": "hygiene",
       "max": 23,
@@ -4182,6 +4596,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Create an AGENTS.md at the repository root describing what the project is, how to build/test it, and the conventions agents must follow.",
+        "severity": "error",
         "title": "Agent context file present (AGENTS.md)",
       },
       {
@@ -4193,6 +4608,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Flesh out AGENTS.md: add sections for project overview, build & test commands, architecture, and conventions (aim for 20+ meaningful lines with headings).",
+        "severity": "error",
         "title": "Agent context file is substantive",
       },
       {
@@ -4204,6 +4620,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Add at least one scoped rule file for your AI tool (e.g. .cursor/rules/*.mdc, .windsurf/rules/*.md, .clinerules/*.md) or a nested AGENTS.md/CLAUDE.md in a subdirectory, stating the project non-negotiables.",
+        "severity": "error",
         "title": "Scoped rules in use",
       },
       {
@@ -4215,6 +4632,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Give every rule activation metadata in frontmatter (description, globs/trigger/paths/applyTo, or alwaysApply) so the agent knows when to load it.",
+        "severity": "error",
         "title": "Rules have valid frontmatter",
       },
       {
@@ -4226,6 +4644,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Scope rules to paths (globs, trigger glob, paths, applyTo) instead of making everything always-on — blanket rules consume context on every request.",
+        "severity": "error",
         "title": "Rules are scoped, not all always-on",
       },
       {
@@ -4237,6 +4656,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Split rules longer than 500 lines into focused, scoped rules or move procedural content into a skill — huge rules crowd out task context.",
+        "severity": "error",
         "title": "No bloated rules (≤500 lines each)",
       },
       {
@@ -4248,6 +4668,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 1,
         "remediation": "Add a README.md — agents (and humans) use it as the first orientation document.",
+        "severity": "error",
         "title": "README present",
       },
       {
@@ -4259,6 +4680,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 1,
         "remediation": "Migrate the legacy .cursorrules file to scoped rules with frontmatter (.cursor/rules/*.mdc or your tool equivalent) — .cursorrules is deprecated.",
+        "severity": "error",
         "title": "No legacy .cursorrules file",
       },
       {
@@ -4270,6 +4692,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Create a SKILL.md under your tool skills directory (.cursor/skills/, .claude/skills/, or .agents/skills/) packaging a procedural workflow the agent should follow on demand.",
+        "severity": "error",
         "title": "At least one agent skill defined",
       },
       {
@@ -4281,6 +4704,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add frontmatter with name: and description: to every SKILL.md — the agent decides whether to load a skill from those two fields alone.",
+        "severity": "error",
         "title": "Skills declare name and description",
       },
       {
@@ -4292,6 +4716,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add explicit workflow/command entry points (.cursor/commands/, .windsurf/workflows/, .claude/commands/, .continue/prompts/, …) for workflows you trigger intentionally.",
+        "severity": "error",
         "title": "Explicit workflows/commands defined",
       },
       {
@@ -4303,6 +4728,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Write skill descriptions of 40+ characters that say when to use the skill ("Use when…"), not just what it is — vague descriptions never trigger.",
+        "severity": "error",
         "title": "Skill descriptions are trigger-worthy",
       },
       {
@@ -4314,6 +4740,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Create a subagent definition (.cursor/agents/, .claude/agents/, or .opencode/agents/) for a purpose-built delegate (planning, review, release…).",
+        "severity": "error",
         "title": "Custom subagent defined",
       },
       {
@@ -4325,6 +4752,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Add frontmatter with name: and description: to every subagent definition — the parent agent decides whether to delegate from those two fields alone.",
+        "severity": "error",
         "title": "Subagents declare name and description",
       },
       {
@@ -4336,6 +4764,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Create a hooks configuration (.cursor/hooks.json or .claude/settings.json hooks key) — hooks are the harness layer that can observe and control the agent loop deterministically.",
+        "severity": "error",
         "title": "Hooks configuration present and valid JSON",
       },
       {
@@ -4347,6 +4776,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Register handlers only on documented events for your tool (Cursor: beforeShellExecution, afterFileEdit, …; Claude Code: PreToolUse, PostToolUse, …) — typos fail silently.",
+        "severity": "error",
         "title": "Hooks use known events and a version field",
       },
       {
@@ -4358,6 +4788,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Register a gate hook (Cursor: beforeShellExecution / beforeMCPExecution / preToolUse; Claude Code: PreToolUse) that returns allow/deny/ask for destructive operations.",
+        "severity": "error",
         "title": "Gate hook guards risky operations",
       },
       {
@@ -4369,6 +4800,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Register a feedback hook (Cursor: afterFileEdit / postToolUse / stop; Claude Code: PostToolUse) — e.g. auto-format edited files or run a quick lint.",
+        "severity": "error",
         "title": "Feedback hook observes agent output",
       },
       {
@@ -4380,6 +4812,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Commit the scripts referenced by your hooks config — a hook pointing at a missing script fails open on every machine but yours.",
+        "severity": "error",
         "title": "Hook scripts exist in the repository",
       },
       {
@@ -4391,6 +4824,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 6,
         "remediation": "Wire up a test runner (vitest/jest, pytest, go test, cargo test…) with a standard entry point — tests are the strongest feedback sensor an agent can run on its own work.",
+        "severity": "error",
         "title": "Test runner configured",
       },
       {
@@ -4402,6 +4836,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 5,
         "remediation": "Add a linter config (eslint/biome, ruff, golangci-lint, clippy.toml, rubocop…) — linters give the agent instant, deterministic feedback on every edit.",
+        "severity": "error",
         "title": "Linter configured",
       },
       {
@@ -4413,6 +4848,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Enable static type checking (tsconfig.json with strict: true, mypy/pyright for Python) — typed code is dramatically more harnessable: the compiler catches agent mistakes for free.",
+        "severity": "error",
         "title": "Type checking in place",
       },
       {
@@ -4424,6 +4860,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add an auto-formatter (prettier/biome, black or ruff format, gofmt/rustfmt are built-in) — formatting noise in diffs hides real agent mistakes from review.",
+        "severity": "error",
         "title": "Formatter configured",
       },
       {
@@ -4435,6 +4872,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Write at least one real test file — a configured runner with zero tests gives the agent a green light it did not earn.",
+        "severity": "error",
         "title": "Test files actually exist",
       },
       {
@@ -4446,6 +4884,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Add a CI workflow (.github/workflows/ci.yml) — CI is the harness sensor that catches what slipped past local checks, on every push.",
+        "severity": "error",
         "title": "CI pipeline configured",
       },
       {
@@ -4457,6 +4896,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Make CI execute the test suite (npm test, pytest, go test…) so no agent-authored change can merge without the sensors firing.",
+        "severity": "error",
         "title": "CI runs the test suite",
       },
       {
@@ -4468,6 +4908,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add lint and typecheck steps to CI — cheap computational sensors belong on every push ("keep quality left").",
+        "severity": "error",
         "title": "CI runs lint / type checks",
       },
       {
@@ -4479,6 +4920,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add pre-commit tooling (husky + lint-staged, pre-commit, lefthook) so fast checks run before a commit exists — the earliest possible feedback loop.",
+        "severity": "error",
         "title": "Pre-commit checks installed",
       },
       {
@@ -4490,6 +4932,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Add a .gitignore — agents commit what they see; make sure build output and local state are invisible.",
+        "severity": "error",
         "title": ".gitignore present",
       },
       {
@@ -4501,6 +4944,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add ".env" and ".env.*" to .gitignore so an agent can never stage credentials by accident.",
+        "severity": "error",
         "title": ".gitignore covers environment files",
       },
       {
@@ -4512,6 +4956,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Remove committed .env files (keep only .env.example) or at minimum ensure .gitignore excludes them — env files in an agent's working tree leak into context and commits.",
+        "severity": "error",
         "title": "No unprotected .env files in the tree",
       },
       {
@@ -4523,6 +4968,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Never inline API keys in MCP config (.cursor/mcp.json, .mcp.json, .agents/mcp_config.json) — use \${VAR} interpolation and document required variables in .env.example.",
+        "severity": "error",
         "title": "MCP configuration free of credentials",
       },
       {
@@ -4534,6 +4980,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Add a LICENSE file — required for open-source distribution and plugin marketplaces.",
+        "severity": "error",
         "title": "License present",
       },
       {
@@ -4545,6 +4992,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Remove any API keys or tokens from AGENTS.md, rules, and hooks configuration — harness files are loaded into model context on every session.",
+        "severity": "error",
         "title": "No credential signatures in harness files",
       },
       {
@@ -4556,6 +5004,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Commit the lockfile (package-lock.json, uv.lock, Cargo.lock…) — reproducible installs mean the agent's sensors run against the same dependencies everywhere.",
+        "severity": "error",
         "title": "Dependency lockfile committed",
       },
       {
@@ -4567,6 +5016,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Reference credential-shaped values in MCP config via \${ENV_VAR} interpolation instead of literals — this rewards deliberate, safe tool-access configuration.",
+        "severity": "error",
         "title": "MCP config uses env interpolation for credentials",
       },
     ],
@@ -4575,6 +5025,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
     ],
     "dimensions": [
       {
+        "applicable": true,
         "earned": 20,
         "id": "context",
         "max": 20,
@@ -4582,6 +5033,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Context & Guides",
       },
       {
+        "applicable": true,
         "earned": 17,
         "id": "skills",
         "max": 17,
@@ -4589,6 +5041,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Skills & Commands",
       },
       {
+        "applicable": true,
         "earned": 14,
         "id": "hooks",
         "max": 14,
@@ -4596,6 +5049,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Hooks & Guardrails",
       },
       {
+        "applicable": true,
         "earned": 20,
         "id": "sensors",
         "max": 20,
@@ -4603,6 +5057,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Sensors & Feedback",
       },
       {
+        "applicable": true,
         "earned": 14,
         "id": "ci",
         "max": 14,
@@ -4610,6 +5065,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "CI Feedback",
       },
       {
+        "applicable": true,
         "earned": 23,
         "id": "hygiene",
         "max": 23,
@@ -4618,6 +5074,8 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       },
     ],
     "level": {
+      "capReason": undefined,
+      "capped": false,
       "index": 4,
       "name": "Self-correcting",
       "nextLevelGaps": [],
@@ -4630,9 +5088,16 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
   },
   "gate": "maturity",
   "level": {
+    "capReason": undefined,
+    "capped": false,
     "index": 4,
     "name": "Self-correcting",
     "nextLevelGaps": [],
+  },
+  "preset": {
+    "extends": [],
+    "resolved": [],
+    "rules": {},
   },
   "resolvedRoots": undefined,
   "scopes": {
@@ -4664,6 +5129,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Create an AGENTS.md at the repository root describing what the project is, how to build/test it, and the conventions agents must follow.",
+      "severity": "error",
       "title": "Agent context file present (AGENTS.md)",
     },
     {
@@ -4675,6 +5141,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Flesh out AGENTS.md: add sections for project overview, build & test commands, architecture, and conventions (aim for 20+ meaningful lines with headings).",
+      "severity": "error",
       "title": "Agent context file is substantive",
     },
     {
@@ -4686,6 +5153,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Add at least one scoped rule file for your AI tool (e.g. .cursor/rules/*.mdc, .windsurf/rules/*.md, .clinerules/*.md) or a nested AGENTS.md/CLAUDE.md in a subdirectory, stating the project non-negotiables.",
+      "severity": "error",
       "title": "Scoped rules in use",
     },
     {
@@ -4697,6 +5165,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Give every rule activation metadata in frontmatter (description, globs/trigger/paths/applyTo, or alwaysApply) so the agent knows when to load it.",
+      "severity": "error",
       "title": "Rules have valid frontmatter",
     },
     {
@@ -4708,6 +5177,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Scope rules to paths (globs, trigger glob, paths, applyTo) instead of making everything always-on — blanket rules consume context on every request.",
+      "severity": "error",
       "title": "Rules are scoped, not all always-on",
     },
     {
@@ -4719,6 +5189,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Split rules longer than 500 lines into focused, scoped rules or move procedural content into a skill — huge rules crowd out task context.",
+      "severity": "error",
       "title": "No bloated rules (≤500 lines each)",
     },
     {
@@ -4730,6 +5201,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 1,
       "remediation": "Add a README.md — agents (and humans) use it as the first orientation document.",
+      "severity": "error",
       "title": "README present",
     },
     {
@@ -4741,6 +5213,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 1,
       "remediation": "Migrate the legacy .cursorrules file to scoped rules with frontmatter (.cursor/rules/*.mdc or your tool equivalent) — .cursorrules is deprecated.",
+      "severity": "error",
       "title": "No legacy .cursorrules file",
     },
     {
@@ -4752,6 +5225,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Create a SKILL.md under your tool skills directory (.cursor/skills/, .claude/skills/, or .agents/skills/) packaging a procedural workflow the agent should follow on demand.",
+      "severity": "error",
       "title": "At least one agent skill defined",
     },
     {
@@ -4763,6 +5237,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add frontmatter with name: and description: to every SKILL.md — the agent decides whether to load a skill from those two fields alone.",
+      "severity": "error",
       "title": "Skills declare name and description",
     },
     {
@@ -4774,6 +5249,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add explicit workflow/command entry points (.cursor/commands/, .windsurf/workflows/, .claude/commands/, .continue/prompts/, …) for workflows you trigger intentionally.",
+      "severity": "error",
       "title": "Explicit workflows/commands defined",
     },
     {
@@ -4785,6 +5261,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Write skill descriptions of 40+ characters that say when to use the skill ("Use when…"), not just what it is — vague descriptions never trigger.",
+      "severity": "error",
       "title": "Skill descriptions are trigger-worthy",
     },
     {
@@ -4796,6 +5273,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Create a subagent definition (.cursor/agents/, .claude/agents/, or .opencode/agents/) for a purpose-built delegate (planning, review, release…).",
+      "severity": "error",
       "title": "Custom subagent defined",
     },
     {
@@ -4807,6 +5285,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Add frontmatter with name: and description: to every subagent definition — the parent agent decides whether to delegate from those two fields alone.",
+      "severity": "error",
       "title": "Subagents declare name and description",
     },
     {
@@ -4818,6 +5297,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Create a hooks configuration (.cursor/hooks.json or .claude/settings.json hooks key) — hooks are the harness layer that can observe and control the agent loop deterministically.",
+      "severity": "error",
       "title": "Hooks configuration present and valid JSON",
     },
     {
@@ -4829,6 +5309,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Register handlers only on documented events for your tool (Cursor: beforeShellExecution, afterFileEdit, …; Claude Code: PreToolUse, PostToolUse, …) — typos fail silently.",
+      "severity": "error",
       "title": "Hooks use known events and a version field",
     },
     {
@@ -4840,6 +5321,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Register a gate hook (Cursor: beforeShellExecution / beforeMCPExecution / preToolUse; Claude Code: PreToolUse) that returns allow/deny/ask for destructive operations.",
+      "severity": "error",
       "title": "Gate hook guards risky operations",
     },
     {
@@ -4851,6 +5333,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Register a feedback hook (Cursor: afterFileEdit / postToolUse / stop; Claude Code: PostToolUse) — e.g. auto-format edited files or run a quick lint.",
+      "severity": "error",
       "title": "Feedback hook observes agent output",
     },
     {
@@ -4862,6 +5345,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Commit the scripts referenced by your hooks config — a hook pointing at a missing script fails open on every machine but yours.",
+      "severity": "error",
       "title": "Hook scripts exist in the repository",
     },
     {
@@ -4873,6 +5357,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 6,
       "remediation": "Wire up a test runner (vitest/jest, pytest, go test, cargo test…) with a standard entry point — tests are the strongest feedback sensor an agent can run on its own work.",
+      "severity": "error",
       "title": "Test runner configured",
     },
     {
@@ -4884,6 +5369,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 5,
       "remediation": "Add a linter config (eslint/biome, ruff, golangci-lint, clippy.toml, rubocop…) — linters give the agent instant, deterministic feedback on every edit.",
+      "severity": "error",
       "title": "Linter configured",
     },
     {
@@ -4895,6 +5381,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Enable static type checking (tsconfig.json with strict: true, mypy/pyright for Python) — typed code is dramatically more harnessable: the compiler catches agent mistakes for free.",
+      "severity": "error",
       "title": "Type checking in place",
     },
     {
@@ -4906,6 +5393,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add an auto-formatter (prettier/biome, black or ruff format, gofmt/rustfmt are built-in) — formatting noise in diffs hides real agent mistakes from review.",
+      "severity": "error",
       "title": "Formatter configured",
     },
     {
@@ -4917,6 +5405,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Write at least one real test file — a configured runner with zero tests gives the agent a green light it did not earn.",
+      "severity": "error",
       "title": "Test files actually exist",
     },
     {
@@ -4928,6 +5417,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Add a CI workflow (.github/workflows/ci.yml) — CI is the harness sensor that catches what slipped past local checks, on every push.",
+      "severity": "error",
       "title": "CI pipeline configured",
     },
     {
@@ -4939,6 +5429,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Make CI execute the test suite (npm test, pytest, go test…) so no agent-authored change can merge without the sensors firing.",
+      "severity": "error",
       "title": "CI runs the test suite",
     },
     {
@@ -4950,6 +5441,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add lint and typecheck steps to CI — cheap computational sensors belong on every push ("keep quality left").",
+      "severity": "error",
       "title": "CI runs lint / type checks",
     },
     {
@@ -4961,6 +5453,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add pre-commit tooling (husky + lint-staged, pre-commit, lefthook) so fast checks run before a commit exists — the earliest possible feedback loop.",
+      "severity": "error",
       "title": "Pre-commit checks installed",
     },
     {
@@ -4972,6 +5465,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Add a .gitignore — agents commit what they see; make sure build output and local state are invisible.",
+      "severity": "error",
       "title": ".gitignore present",
     },
     {
@@ -4983,6 +5477,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Add ".env" and ".env.*" to .gitignore so an agent can never stage credentials by accident.",
+      "severity": "error",
       "title": ".gitignore covers environment files",
     },
     {
@@ -4994,6 +5489,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Remove committed .env files (keep only .env.example) or at minimum ensure .gitignore excludes them — env files in an agent's working tree leak into context and commits.",
+      "severity": "error",
       "title": "No unprotected .env files in the tree",
     },
     {
@@ -5005,6 +5501,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 4,
       "remediation": "Never inline API keys in MCP config (.cursor/mcp.json, .mcp.json, .agents/mcp_config.json) — use \${VAR} interpolation and document required variables in .env.example.",
+      "severity": "error",
       "title": "MCP configuration free of credentials",
     },
     {
@@ -5016,6 +5513,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Add a LICENSE file — required for open-source distribution and plugin marketplaces.",
+      "severity": "error",
       "title": "License present",
     },
     {
@@ -5027,6 +5525,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 2,
       "remediation": "Remove any API keys or tokens from AGENTS.md, rules, and hooks configuration — harness files are loaded into model context on every session.",
+      "severity": "error",
       "title": "No credential signatures in harness files",
     },
     {
@@ -5038,6 +5537,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Commit the lockfile (package-lock.json, uv.lock, Cargo.lock…) — reproducible installs mean the agent's sensors run against the same dependencies everywhere.",
+      "severity": "error",
       "title": "Dependency lockfile committed",
     },
     {
@@ -5049,6 +5549,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "passed": true,
       "points": 3,
       "remediation": "Reference credential-shaped values in MCP config via \${ENV_VAR} interpolation instead of literals — this rewards deliberate, safe tool-access configuration.",
+      "severity": "error",
       "title": "MCP config uses env interpolation for credentials",
     },
   ],
@@ -5062,6 +5563,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
   ],
   "dimensions": [
     {
+      "applicable": true,
       "earned": 20,
       "id": "context",
       "max": 20,
@@ -5069,6 +5571,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Context & Guides",
     },
     {
+      "applicable": true,
       "earned": 17,
       "id": "skills",
       "max": 17,
@@ -5076,6 +5579,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Skills & Commands",
     },
     {
+      "applicable": true,
       "earned": 14,
       "id": "hooks",
       "max": 14,
@@ -5083,6 +5587,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Hooks & Guardrails",
     },
     {
+      "applicable": true,
       "earned": 20,
       "id": "sensors",
       "max": 20,
@@ -5090,6 +5595,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "Sensors & Feedback",
     },
     {
+      "applicable": true,
       "earned": 14,
       "id": "ci",
       "max": 14,
@@ -5097,6 +5603,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       "title": "CI Feedback",
     },
     {
+      "applicable": true,
       "earned": 23,
       "id": "hygiene",
       "max": 23,
@@ -5115,6 +5622,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Create an AGENTS.md at the repository root describing what the project is, how to build/test it, and the conventions agents must follow.",
+        "severity": "error",
         "title": "Agent context file present (AGENTS.md)",
       },
       {
@@ -5126,6 +5634,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Flesh out AGENTS.md: add sections for project overview, build & test commands, architecture, and conventions (aim for 20+ meaningful lines with headings).",
+        "severity": "error",
         "title": "Agent context file is substantive",
       },
       {
@@ -5137,6 +5646,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Add at least one scoped rule file for your AI tool (e.g. .cursor/rules/*.mdc, .windsurf/rules/*.md, .clinerules/*.md) or a nested AGENTS.md/CLAUDE.md in a subdirectory, stating the project non-negotiables.",
+        "severity": "error",
         "title": "Scoped rules in use",
       },
       {
@@ -5148,6 +5658,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Give every rule activation metadata in frontmatter (description, globs/trigger/paths/applyTo, or alwaysApply) so the agent knows when to load it.",
+        "severity": "error",
         "title": "Rules have valid frontmatter",
       },
       {
@@ -5159,6 +5670,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Scope rules to paths (globs, trigger glob, paths, applyTo) instead of making everything always-on — blanket rules consume context on every request.",
+        "severity": "error",
         "title": "Rules are scoped, not all always-on",
       },
       {
@@ -5170,6 +5682,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Split rules longer than 500 lines into focused, scoped rules or move procedural content into a skill — huge rules crowd out task context.",
+        "severity": "error",
         "title": "No bloated rules (≤500 lines each)",
       },
       {
@@ -5181,6 +5694,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 1,
         "remediation": "Add a README.md — agents (and humans) use it as the first orientation document.",
+        "severity": "error",
         "title": "README present",
       },
       {
@@ -5192,6 +5706,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 1,
         "remediation": "Migrate the legacy .cursorrules file to scoped rules with frontmatter (.cursor/rules/*.mdc or your tool equivalent) — .cursorrules is deprecated.",
+        "severity": "error",
         "title": "No legacy .cursorrules file",
       },
       {
@@ -5203,6 +5718,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Create a SKILL.md under your tool skills directory (.cursor/skills/, .claude/skills/, or .agents/skills/) packaging a procedural workflow the agent should follow on demand.",
+        "severity": "error",
         "title": "At least one agent skill defined",
       },
       {
@@ -5214,6 +5730,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add frontmatter with name: and description: to every SKILL.md — the agent decides whether to load a skill from those two fields alone.",
+        "severity": "error",
         "title": "Skills declare name and description",
       },
       {
@@ -5225,6 +5742,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add explicit workflow/command entry points (.cursor/commands/, .windsurf/workflows/, .claude/commands/, .continue/prompts/, …) for workflows you trigger intentionally.",
+        "severity": "error",
         "title": "Explicit workflows/commands defined",
       },
       {
@@ -5236,6 +5754,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Write skill descriptions of 40+ characters that say when to use the skill ("Use when…"), not just what it is — vague descriptions never trigger.",
+        "severity": "error",
         "title": "Skill descriptions are trigger-worthy",
       },
       {
@@ -5247,6 +5766,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Create a subagent definition (.cursor/agents/, .claude/agents/, or .opencode/agents/) for a purpose-built delegate (planning, review, release…).",
+        "severity": "error",
         "title": "Custom subagent defined",
       },
       {
@@ -5258,6 +5778,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Add frontmatter with name: and description: to every subagent definition — the parent agent decides whether to delegate from those two fields alone.",
+        "severity": "error",
         "title": "Subagents declare name and description",
       },
       {
@@ -5269,6 +5790,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Create a hooks configuration (.cursor/hooks.json or .claude/settings.json hooks key) — hooks are the harness layer that can observe and control the agent loop deterministically.",
+        "severity": "error",
         "title": "Hooks configuration present and valid JSON",
       },
       {
@@ -5280,6 +5802,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Register handlers only on documented events for your tool (Cursor: beforeShellExecution, afterFileEdit, …; Claude Code: PreToolUse, PostToolUse, …) — typos fail silently.",
+        "severity": "error",
         "title": "Hooks use known events and a version field",
       },
       {
@@ -5291,6 +5814,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Register a gate hook (Cursor: beforeShellExecution / beforeMCPExecution / preToolUse; Claude Code: PreToolUse) that returns allow/deny/ask for destructive operations.",
+        "severity": "error",
         "title": "Gate hook guards risky operations",
       },
       {
@@ -5302,6 +5826,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Register a feedback hook (Cursor: afterFileEdit / postToolUse / stop; Claude Code: PostToolUse) — e.g. auto-format edited files or run a quick lint.",
+        "severity": "error",
         "title": "Feedback hook observes agent output",
       },
       {
@@ -5313,6 +5838,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Commit the scripts referenced by your hooks config — a hook pointing at a missing script fails open on every machine but yours.",
+        "severity": "error",
         "title": "Hook scripts exist in the repository",
       },
       {
@@ -5324,6 +5850,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 6,
         "remediation": "Wire up a test runner (vitest/jest, pytest, go test, cargo test…) with a standard entry point — tests are the strongest feedback sensor an agent can run on its own work.",
+        "severity": "error",
         "title": "Test runner configured",
       },
       {
@@ -5335,6 +5862,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 5,
         "remediation": "Add a linter config (eslint/biome, ruff, golangci-lint, clippy.toml, rubocop…) — linters give the agent instant, deterministic feedback on every edit.",
+        "severity": "error",
         "title": "Linter configured",
       },
       {
@@ -5346,6 +5874,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Enable static type checking (tsconfig.json with strict: true, mypy/pyright for Python) — typed code is dramatically more harnessable: the compiler catches agent mistakes for free.",
+        "severity": "error",
         "title": "Type checking in place",
       },
       {
@@ -5357,6 +5886,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add an auto-formatter (prettier/biome, black or ruff format, gofmt/rustfmt are built-in) — formatting noise in diffs hides real agent mistakes from review.",
+        "severity": "error",
         "title": "Formatter configured",
       },
       {
@@ -5368,6 +5898,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Write at least one real test file — a configured runner with zero tests gives the agent a green light it did not earn.",
+        "severity": "error",
         "title": "Test files actually exist",
       },
       {
@@ -5379,6 +5910,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Add a CI workflow (.github/workflows/ci.yml) — CI is the harness sensor that catches what slipped past local checks, on every push.",
+        "severity": "error",
         "title": "CI pipeline configured",
       },
       {
@@ -5390,6 +5922,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Make CI execute the test suite (npm test, pytest, go test…) so no agent-authored change can merge without the sensors firing.",
+        "severity": "error",
         "title": "CI runs the test suite",
       },
       {
@@ -5401,6 +5934,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add lint and typecheck steps to CI — cheap computational sensors belong on every push ("keep quality left").",
+        "severity": "error",
         "title": "CI runs lint / type checks",
       },
       {
@@ -5412,6 +5946,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add pre-commit tooling (husky + lint-staged, pre-commit, lefthook) so fast checks run before a commit exists — the earliest possible feedback loop.",
+        "severity": "error",
         "title": "Pre-commit checks installed",
       },
       {
@@ -5423,6 +5958,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Add a .gitignore — agents commit what they see; make sure build output and local state are invisible.",
+        "severity": "error",
         "title": ".gitignore present",
       },
       {
@@ -5434,6 +5970,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Add ".env" and ".env.*" to .gitignore so an agent can never stage credentials by accident.",
+        "severity": "error",
         "title": ".gitignore covers environment files",
       },
       {
@@ -5445,6 +5982,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Remove committed .env files (keep only .env.example) or at minimum ensure .gitignore excludes them — env files in an agent's working tree leak into context and commits.",
+        "severity": "error",
         "title": "No unprotected .env files in the tree",
       },
       {
@@ -5456,6 +5994,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 4,
         "remediation": "Never inline API keys in MCP config (.cursor/mcp.json, .mcp.json, .agents/mcp_config.json) — use \${VAR} interpolation and document required variables in .env.example.",
+        "severity": "error",
         "title": "MCP configuration free of credentials",
       },
       {
@@ -5467,6 +6006,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Add a LICENSE file — required for open-source distribution and plugin marketplaces.",
+        "severity": "error",
         "title": "License present",
       },
       {
@@ -5478,6 +6018,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 2,
         "remediation": "Remove any API keys or tokens from AGENTS.md, rules, and hooks configuration — harness files are loaded into model context on every session.",
+        "severity": "error",
         "title": "No credential signatures in harness files",
       },
       {
@@ -5489,6 +6030,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Commit the lockfile (package-lock.json, uv.lock, Cargo.lock…) — reproducible installs mean the agent's sensors run against the same dependencies everywhere.",
+        "severity": "error",
         "title": "Dependency lockfile committed",
       },
       {
@@ -5500,6 +6042,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "passed": true,
         "points": 3,
         "remediation": "Reference credential-shaped values in MCP config via \${ENV_VAR} interpolation instead of literals — this rewards deliberate, safe tool-access configuration.",
+        "severity": "error",
         "title": "MCP config uses env interpolation for credentials",
       },
     ],
@@ -5513,6 +6056,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
     ],
     "dimensions": [
       {
+        "applicable": true,
         "earned": 20,
         "id": "context",
         "max": 20,
@@ -5520,6 +6064,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Context & Guides",
       },
       {
+        "applicable": true,
         "earned": 17,
         "id": "skills",
         "max": 17,
@@ -5527,6 +6072,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Skills & Commands",
       },
       {
+        "applicable": true,
         "earned": 14,
         "id": "hooks",
         "max": 14,
@@ -5534,6 +6080,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Hooks & Guardrails",
       },
       {
+        "applicable": true,
         "earned": 20,
         "id": "sensors",
         "max": 20,
@@ -5541,6 +6088,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "Sensors & Feedback",
       },
       {
+        "applicable": true,
         "earned": 14,
         "id": "ci",
         "max": 14,
@@ -5548,6 +6096,7 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
         "title": "CI Feedback",
       },
       {
+        "applicable": true,
         "earned": 23,
         "id": "hygiene",
         "max": 23,
@@ -5556,6 +6105,8 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
       },
     ],
     "level": {
+      "capReason": undefined,
+      "capped": false,
       "index": 4,
       "name": "Self-correcting",
       "nextLevelGaps": [],
@@ -5568,9 +6119,16 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
   },
   "gate": "maturity",
   "level": {
+    "capReason": undefined,
+    "capped": false,
     "index": 4,
     "name": "Self-correcting",
     "nextLevelGaps": [],
+  },
+  "preset": {
+    "extends": [],
+    "resolved": [],
+    "rules": {},
   },
   "resolvedRoots": undefined,
   "scopes": {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, test } from 'vitest';
 import {
   DEFAULT_CONFIG,
   loadConfigFile,
+  PRESET_REGISTRY,
+  PROTECTED_CHECKS,
   parseConfigObject,
   parseScopeFlagList,
   resolveScanConfig,
@@ -68,6 +70,29 @@ describe('parseConfigObject', () => {
     expect(() => parseConfigObject({ rules: { 'HKS-01': 'disabled' } }, 'test')).toThrow(
       /severity must be "off" or "error"/,
     );
+  });
+
+  test.each([...PROTECTED_CHECKS])('rejects turning off protected check %s', (checkId) => {
+    expect(() => parseConfigObject({ rules: { [checkId]: 'off' } }, 'test')).toThrow(
+      /can never be set to "off"/,
+    );
+  });
+
+  test('a protected check can still be set to "error" explicitly (a no-op, but not rejected)', () => {
+    const [checkId] = [...PROTECTED_CHECKS];
+    expect(parseConfigObject({ rules: { [checkId!]: 'error' } }, 'test').rules).toEqual({
+      [checkId!]: 'error',
+    });
+  });
+});
+
+describe('PRESET_REGISTRY never waives a protected check', () => {
+  test('no built-in preset sets a protected check to "off"', () => {
+    for (const [name, preset] of Object.entries(PRESET_REGISTRY)) {
+      for (const checkId of PROTECTED_CHECKS) {
+        expect(preset[checkId], `${name} preset must not exclude ${checkId}`).not.toBe('off');
+      }
+    }
   });
 });
 

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -8,6 +8,7 @@ import {
   parseConfigObject,
   parseScopeFlagList,
   resolveScanConfig,
+  resolveSeverities,
 } from '../src/config.js';
 
 describe('parseConfigObject', () => {
@@ -37,7 +38,58 @@ describe('parseConfigObject', () => {
       scopes: { user: true, system: false },
       extraRoots: [{ id: 'team', path: '../shared' }],
       gate: 'effective',
+      extends: [],
+      rules: {},
     });
+  });
+
+  test('accepts a known preset in extends', () => {
+    expect(parseConfigObject({ extends: ['no-hooks'] }, 'test').extends).toEqual(['no-hooks']);
+  });
+
+  test('rejects an unknown preset name', () => {
+    expect(() => parseConfigObject({ extends: ['does-not-exist'] }, 'test')).toThrow(/unknown preset/);
+  });
+
+  test('accepts off/error severities in rules', () => {
+    const parsed = parseConfigObject({ rules: { 'HKS-01': 'off', 'HYG-05': 'error' } }, 'test');
+    expect(parsed.rules).toEqual({ 'HKS-01': 'off', 'HYG-05': 'error' });
+  });
+
+  test('rejects an unknown check ID in rules', () => {
+    expect(() => parseConfigObject({ rules: { 'NOPE-01': 'off' } }, 'test')).toThrow(/unknown check ID/);
+  });
+
+  test('rejects "warn" severity with a clear "not supported yet" message', () => {
+    expect(() => parseConfigObject({ rules: { 'HKS-01': 'warn' } }, 'test')).toThrow(/not supported yet/);
+  });
+
+  test('rejects an invalid severity string', () => {
+    expect(() => parseConfigObject({ rules: { 'HKS-01': 'disabled' } }, 'test')).toThrow(
+      /severity must be "off" or "error"/,
+    );
+  });
+});
+
+describe('resolveSeverities', () => {
+  test('defaults every check to error/default', () => {
+    const resolved = resolveSeverities({ extends: [], rules: {} });
+    expect(resolved.get('HKS-01')).toEqual({ severity: 'error', source: 'default' });
+  });
+
+  test('applies a preset from extends', () => {
+    const resolved = resolveSeverities({ extends: ['no-hooks'], rules: {} });
+    expect(resolved.get('HKS-01')).toEqual({ severity: 'off', source: 'extends:no-hooks' });
+    expect(resolved.get('HKS-05')).toEqual({ severity: 'off', source: 'extends:no-hooks' });
+    // A dimension untouched by the preset stays at the default.
+    expect(resolved.get('HYG-01')).toEqual({ severity: 'error', source: 'default' });
+  });
+
+  test('local rules take precedence over extends', () => {
+    const resolved = resolveSeverities({ extends: ['no-hooks'], rules: { 'HKS-01': 'error' } });
+    expect(resolved.get('HKS-01')).toEqual({ severity: 'error', source: 'rules' });
+    // Everything else the preset touched stays overridden.
+    expect(resolved.get('HKS-02')).toEqual({ severity: 'off', source: 'extends:no-hooks' });
   });
 });
 

--- a/packages/cli/test/diff.test.ts
+++ b/packages/cli/test/diff.test.ts
@@ -40,4 +40,22 @@ describe('computeDiff', () => {
     const baseline = { ...current, score: { ...current.score, max: current.score.max - 8 } };
     expect(computeDiff(baseline, current).maturityModelChanged).toBe(true);
   });
+
+  test('flags presetChanged when the applied extends/rules differ', () => {
+    const current = score(path.join(FIXTURES, 'level-4'));
+    const baseline = { ...current, preset: { extends: ['no-hooks'], rules: {}, resolved: [] } };
+    expect(computeDiff(baseline, current).presetChanged).toBe(true);
+  });
+
+  test('presetChanged is false when both sides carry the same preset', () => {
+    const current = score(path.join(FIXTURES, 'level-4'));
+    expect(computeDiff(current, current).presetChanged).toBe(false);
+  });
+
+  test('a baseline with no preset field at all (pre-v1.5 JSON) does not throw', () => {
+    const current = score(path.join(FIXTURES, 'level-4'));
+    const { preset: _omit, ...legacyBaseline } = current;
+    expect(() => computeDiff(legacyBaseline as typeof current, current)).not.toThrow();
+    expect(computeDiff(legacyBaseline as typeof current, current).presetChanged).toBe(false);
+  });
 });

--- a/packages/cli/test/docs.test.ts
+++ b/packages/cli/test/docs.test.ts
@@ -2,12 +2,13 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
-import { ALL_CHECKS } from '../src/index.js';
+import { ALL_CHECKS, PRESET_REGISTRY } from '../src/index.js';
 
 const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
 const GUIDE = path.join(REPO, 'docs', 'guide', 'measure-and-improve.md');
 const GUIDE_DIR = path.join(REPO, 'docs', 'guide');
+const METRICS = path.join(REPO, 'docs', 'guide', 'metrics-and-codes.md');
 const LOCALES = ['pt-BR', 'es', 'zh-CN', 'hi-IN'] as const;
 
 function listGuideFiles(dir: string): string[] {
@@ -53,6 +54,17 @@ describe('translated measure-and-improve guides preserve anchors', () => {
       expect(localeAnchors).toEqual(enAnchors);
     });
   }
+});
+
+describe('built-in presets stay in sync with metrics-and-codes.md', () => {
+  const metricsContent = fs.readFileSync(METRICS, 'utf8');
+
+  test('every PRESET_REGISTRY key has a documented anchor', () => {
+    const missing = Object.keys(PRESET_REGISTRY).filter(
+      (name) => !metricsContent.includes(`{#preset-${name}}`),
+    );
+    expect(missing).toEqual([]);
+  });
 });
 
 describe('translated guides mirror English chapter set', () => {

--- a/packages/cli/test/markdown.test.ts
+++ b/packages/cli/test/markdown.test.ts
@@ -205,4 +205,9 @@ describe('renderMarkdown', () => {
     const out = renderMarkdown(makeReport(), makeDiff({ maturityModelChanged: true }));
     expect(out).toContain('Baseline is from a different tool version');
   });
+
+  test('diff warns when presetChanged is true', () => {
+    const out = renderMarkdown(makeReport(), makeDiff({ presetChanged: true }));
+    expect(out).toContain('Baseline used a different extends/rules config');
+  });
 });

--- a/packages/cli/test/markdown.test.ts
+++ b/packages/cli/test/markdown.test.ts
@@ -4,8 +4,15 @@ import { renderMarkdown } from '../src/report/markdown.js';
 import type { CheckResult, DimensionScore, Report, ScoreSnapshot } from '../src/types.js';
 import { DIMENSIONS } from '../src/types.js';
 
-function makeDimensions(): DimensionScore[] {
-  return DIMENSIONS.map((d) => ({ id: d.id, title: d.title, earned: 5, max: 20, percent: 25 }));
+function makeDimensions(applicableOverrides: Partial<Record<string, boolean>> = {}): DimensionScore[] {
+  return DIMENSIONS.map((d) => ({
+    id: d.id,
+    title: d.title,
+    earned: 5,
+    max: 20,
+    percent: 25,
+    applicable: applicableOverrides[d.id] ?? true,
+  }));
 }
 
 function makeCheck(overrides: Partial<CheckResult> = {}): CheckResult {
@@ -19,13 +26,14 @@ function makeCheck(overrides: Partial<CheckResult> = {}): CheckResult {
     evidence: 'No AGENTS.md found.',
     remediation: 'Create an AGENTS.md.',
     docsUrl: 'https://paladini.github.io/harness-score/guide/measure-and-improve#ctx-01',
+    severity: 'error',
     ...overrides,
   };
 }
 
 function makeSnapshot(overrides: Partial<ScoreSnapshot> = {}): ScoreSnapshot {
   return {
-    level: { index: 1, name: 'Documented', nextLevelGaps: [] },
+    level: { index: 1, name: 'Documented', nextLevelGaps: [], capped: false },
     score: { earned: 50, max: 108, percent: 46 },
     dimensions: makeDimensions(),
     checks: [makeCheck()],
@@ -48,6 +56,7 @@ function makeReport(overrides: Partial<Report> = {}): Report {
     dimensions: snapshot.dimensions,
     checks: snapshot.checks,
     effective: snapshot,
+    preset: { extends: [], rules: {}, resolved: [] },
     ...overrides,
   };
 }
@@ -64,6 +73,7 @@ function makeDiff(overrides: Partial<ReportDiff> = {}): ReportDiff {
     dimensions: DIMENSIONS.map((d) => ({ id: d.id, title: d.title, before: 0, after: 0, delta: 0 })),
     checksChanged: [],
     maturityModelChanged: false,
+    presetChanged: false,
     ...overrides,
   };
 }
@@ -102,14 +112,70 @@ describe('renderMarkdown', () => {
 
   test('shows the next-level-gaps line only when gaps exist', () => {
     const withGaps = renderMarkdown(
-      makeReport({ level: { index: 1, name: 'Documented', nextLevelGaps: ['context ≥ 60%'] } }),
+      makeReport({
+        level: { index: 1, name: 'Documented', nextLevelGaps: ['context ≥ 60%'], capped: false },
+      }),
     );
     expect(withGaps).toContain('**To reach L2:**');
 
     const noGaps = renderMarkdown(
-      makeReport({ level: { index: 4, name: 'Self-correcting', nextLevelGaps: [] } }),
+      makeReport({ level: { index: 4, name: 'Self-correcting', nextLevelGaps: [], capped: false } }),
     );
     expect(noGaps).not.toContain('**To reach L');
+  });
+
+  test('shows a capped note when the level is capped', () => {
+    const out = renderMarkdown(
+      makeReport({
+        level: {
+          index: 3,
+          name: 'Sensing',
+          nextLevelGaps: ['hooks ≥ 70%'],
+          capped: true,
+          capReason:
+            'L4 requires hooks ≥ 70%, which is not reachable: the "hooks" dimension has no applicable checks.',
+        },
+      }),
+    );
+    expect(out).toContain('Capped');
+    expect(out).toContain('not reachable');
+  });
+
+  test('renders N/A for a non-applicable dimension instead of a misleading 0%', () => {
+    const out = renderMarkdown(makeReport({ dimensions: makeDimensions({ hooks: false }) }));
+    expect(out).toContain('N/A (excluded by preset)');
+  });
+
+  test('shows a preset disclosure line only when preset.resolved is non-empty', () => {
+    const withPreset = renderMarkdown(
+      makeReport({
+        preset: {
+          extends: ['no-hooks'],
+          rules: {},
+          resolved: [{ id: 'HKS-01', severity: 'off', source: 'extends:no-hooks' }],
+        },
+      }),
+    );
+    expect(withPreset).toContain('**Preset:**');
+    expect(withPreset).toContain('no-hooks');
+
+    expect(renderMarkdown(makeReport())).not.toContain('**Preset:**');
+  });
+
+  test('an off-severity check gets a distinct status glyph, not ✅/❌', () => {
+    const out = renderMarkdown(
+      makeReport({ checks: [makeCheck({ id: 'HKS-01', passed: false, severity: 'off' })] }),
+    );
+    expect(out).toContain('➖');
+  });
+
+  test('an off-severity failing check is excluded from Recommended improvements', () => {
+    const out = renderMarkdown(
+      makeReport({
+        checks: [makeCheck({ id: 'HKS-01', passed: false, severity: 'off' }), makeCheck({ passed: true })],
+      }),
+    );
+    expect(out).not.toContain('## Recommended improvements');
   });
 
   test('diff table renders only changed dimensions', () => {

--- a/packages/cli/test/score.test.ts
+++ b/packages/cli/test/score.test.ts
@@ -4,13 +4,18 @@ import type { DimensionId, DimensionScore } from '../src/types.js';
 import { DIMENSIONS } from '../src/types.js';
 import { fakeContext } from './helpers.js';
 
+/** A dimension override is either a bare percent (applicable defaults true) or a full shape. */
+type DimOverride = number | { percent?: number; applicable?: boolean };
+
 /** Synthetic dimension map for exercising LEVEL_REQUIREMENTS in isolation, without a full scan. */
-function makeDims(overrides: Partial<Record<DimensionId, number>>): Map<DimensionId, DimensionScore> {
+function makeDims(overrides: Partial<Record<DimensionId, DimOverride>>): Map<DimensionId, DimensionScore> {
   return new Map(
-    DIMENSIONS.map((d) => [
-      d.id,
-      { id: d.id, title: d.title, earned: 0, max: 100, percent: overrides[d.id] ?? 0 },
-    ]),
+    DIMENSIONS.map((d) => {
+      const raw = overrides[d.id];
+      const percent = typeof raw === 'number' ? raw : (raw?.percent ?? 0);
+      const applicable = typeof raw === 'number' ? true : (raw?.applicable ?? true);
+      return [d.id, { id: d.id, title: d.title, earned: 0, max: 100, percent, applicable }];
+    }),
   );
 }
 
@@ -42,6 +47,24 @@ describe('LEVEL_REQUIREMENTS boundaries', () => {
     expect(totalReq.met(makeDims({}), 79)).toBe(false);
     expect(totalReq.met(makeDims({}), 80)).toBe(true);
     expect(totalReq.met(makeDims({}), 81)).toBe(true);
+  });
+
+  test('dimAtLeast requirements carry blockedDimension for capped-level detection', () => {
+    const contextReq = LEVEL_REQUIREMENTS[0]![0]!;
+    const hooksReq = LEVEL_REQUIREMENTS[3]![0]!;
+    expect(contextReq.blockedDimension).toBe('context');
+    expect(hooksReq.blockedDimension).toBe('hooks');
+    // The L2 OR-requirement and the L4 total-percent requirement aren't tied to a single
+    // hard-blocking dimension, so they must never be treated as "capped-capable".
+    expect(LEVEL_REQUIREMENTS[1]![1]!.blockedDimension).toBeUndefined();
+    expect(LEVEL_REQUIREMENTS[3]![1]!.blockedDimension).toBeUndefined();
+  });
+
+  test('a non-applicable dimension can never satisfy dimAtLeast, even at 100%', () => {
+    const hooksReq = LEVEL_REQUIREMENTS[3]![0]!;
+    expect(hooksReq.met(makeDims({ hooks: { percent: 100, applicable: false } }), 0)).toBe(false);
+    // Contrast: the exact same 100% is satisfied when the dimension is applicable.
+    expect(hooksReq.met(makeDims({ hooks: { percent: 100, applicable: true } }), 0)).toBe(true);
   });
 });
 

--- a/packages/cli/test/scoring-integration.test.ts
+++ b/packages/cli/test/scoring-integration.test.ts
@@ -1,9 +1,10 @@
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
+import type { ResolvedScanConfig } from '../src/config.js';
 import { score } from '../src/index.js';
 import { renderBadge } from '../src/report/badge.js';
-import { buildReportFromScanContext } from '../src/score.js';
+import { buildReport, buildReportFromScanContext } from '../src/score.js';
 import { fakeContext } from './helpers.js';
 
 const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'fixtures');
@@ -40,5 +41,53 @@ describe('badge pipeline integrates with score() across all fixture levels', () 
   ])('%s → renderBadge(score(...)) embeds L%i', (fixture, expected) => {
     const svg = renderBadge(score(path.join(FIXTURES, fixture)));
     expect(svg).toContain(`>L${expected}<`);
+  });
+});
+
+describe('no-hooks preset against fixtures/level-4', () => {
+  test('excludes hooks without penalizing other dimensions, and caps the level honestly', () => {
+    const root = path.join(FIXTURES, 'level-4');
+    const baseline = buildReport(root);
+
+    // Sanity-check the fixture still means what the rest of the suite assumes.
+    expect(baseline.level.index).toBe(4);
+    expect(baseline.level.capped).toBe(false);
+
+    const presetConfig: ResolvedScanConfig = {
+      scopes: { user: false, system: false },
+      extraRoots: [],
+      gate: 'maturity',
+      effectiveScopes: ['repo'],
+      extends: ['no-hooks'],
+      rules: {},
+    };
+    const withPreset = buildReport(root, presetConfig);
+
+    const hooksDim = withPreset.dimensions.find((d) => d.id === 'hooks')!;
+    expect(hooksDim.applicable).toBe(false);
+    expect(hooksDim.earned).toBe(0);
+    expect(hooksDim.max).toBe(0);
+
+    // Every other dimension is untouched — excluding hooks never bleeds into the rest.
+    for (const id of ['context', 'skills', 'sensors', 'ci', 'hygiene'] as const) {
+      const before = baseline.dimensions.find((d) => d.id === id)!;
+      const after = withPreset.dimensions.find((d) => d.id === id)!;
+      expect(after.earned).toBe(before.earned);
+      expect(after.max).toBe(before.max);
+    }
+
+    expect(withPreset.score.max).toBe(baseline.score.max - 14);
+
+    // The strongest proof of the mechanism: even if the reduced-pool percent clears 80%,
+    // L4 stays capped — hooks is definitional to "self-correcting", not just another gap.
+    expect(withPreset.level.index).toBeLessThanOrEqual(3);
+    expect(withPreset.level.capped).toBe(true);
+    expect(withPreset.level.capReason).toMatch(/hooks/);
+
+    expect(withPreset.preset.extends).toEqual(['no-hooks']);
+    expect(withPreset.preset.resolved).toHaveLength(5); // HKS-01..05
+    expect(
+      withPreset.preset.resolved.every((r) => r.severity === 'off' && r.source === 'extends:no-hooks'),
+    ).toBe(true);
   });
 });

--- a/packages/cli/test/terminal.test.ts
+++ b/packages/cli/test/terminal.test.ts
@@ -181,6 +181,11 @@ describe('renderTerminal', () => {
     expect(out).toContain('Baseline is from a different tool version');
   });
 
+  test('diff section warns when presetChanged is true', () => {
+    const out = renderTerminal(makeReport(), makeDiff({ presetChanged: true }));
+    expect(out).toContain('Baseline used a different extends/rules config');
+  });
+
   test('diff section renders only non-zero dimension deltas', () => {
     const diff = makeDiff({
       dimensions: DIMENSIONS.map((d, i) => ({

--- a/packages/cli/test/terminal.test.ts
+++ b/packages/cli/test/terminal.test.ts
@@ -4,13 +4,17 @@ import { renderTerminal } from '../src/report/terminal.js';
 import type { CheckResult, DimensionScore, Report, ScoreSnapshot } from '../src/types.js';
 import { DIMENSIONS } from '../src/types.js';
 
-function makeDimensions(overrides: Partial<Record<string, number>> = {}): DimensionScore[] {
+function makeDimensions(
+  overrides: Partial<Record<string, number>> = {},
+  applicableOverrides: Partial<Record<string, boolean>> = {},
+): DimensionScore[] {
   return DIMENSIONS.map((d) => ({
     id: d.id,
     title: d.title,
     earned: overrides[d.id] ?? 0,
     max: 20,
     percent: overrides[d.id] ?? 0,
+    applicable: applicableOverrides[d.id] ?? true,
   }));
 }
 
@@ -25,13 +29,14 @@ function makeCheck(overrides: Partial<CheckResult> = {}): CheckResult {
     evidence: 'No AGENTS.md found.',
     remediation: 'Create an AGENTS.md.',
     docsUrl: 'https://paladini.github.io/harness-score/guide/measure-and-improve#ctx-01',
+    severity: 'error',
     ...overrides,
   };
 }
 
 function makeSnapshot(overrides: Partial<ScoreSnapshot> = {}): ScoreSnapshot {
   return {
-    level: { index: 1, name: 'Documented', nextLevelGaps: [] },
+    level: { index: 1, name: 'Documented', nextLevelGaps: [], capped: false },
     score: { earned: 50, max: 108, percent: 46 },
     dimensions: makeDimensions(),
     checks: [makeCheck()],
@@ -54,6 +59,7 @@ function makeReport(overrides: Partial<Report> = {}): Report {
     dimensions: snapshot.dimensions,
     checks: snapshot.checks,
     effective: snapshot,
+    preset: { extends: [], rules: {}, resolved: [] },
     ...overrides,
   };
 }
@@ -70,6 +76,7 @@ function makeDiff(overrides: Partial<ReportDiff> = {}): ReportDiff {
     dimensions: DIMENSIONS.map((d) => ({ id: d.id, title: d.title, before: 0, after: 0, delta: 0 })),
     checksChanged: [],
     maturityModelChanged: false,
+    presetChanged: false,
     ...overrides,
   };
 }
@@ -110,12 +117,63 @@ describe('renderTerminal', () => {
 
   test('shows next-level gaps only when present', () => {
     const withGaps = makeReport({
-      level: { index: 1, name: 'Documented', nextLevelGaps: ['context ≥ 60%'] },
+      level: { index: 1, name: 'Documented', nextLevelGaps: ['context ≥ 60%'], capped: false },
     });
     expect(renderTerminal(withGaps)).toContain('To reach L2:');
 
-    const noGaps = makeReport({ level: { index: 4, name: 'Self-correcting', nextLevelGaps: [] } });
+    const noGaps = makeReport({
+      level: { index: 4, name: 'Self-correcting', nextLevelGaps: [], capped: false },
+    });
     expect(renderTerminal(noGaps)).not.toContain('To reach L');
+  });
+
+  test('shows a capped marker and capReason when the level is capped', () => {
+    const out = renderTerminal(
+      makeReport({
+        level: {
+          index: 3,
+          name: 'Sensing',
+          nextLevelGaps: ['hooks ≥ 70%'],
+          capped: true,
+          capReason:
+            'L4 requires hooks ≥ 70%, which is not reachable: the "hooks" dimension has no applicable checks.',
+        },
+      }),
+    );
+    expect(out).toContain('(capped)');
+    expect(out).toContain('not reachable');
+  });
+
+  test('renders an excluded-by-preset marker for a non-applicable dimension instead of a bar', () => {
+    const out = renderTerminal(
+      makeReport({
+        dimensions: makeDimensions({}, { hooks: false }),
+      }),
+    );
+    expect(out).toContain('excluded by preset');
+  });
+
+  test('shows a preset disclosure line only when preset.resolved is non-empty', () => {
+    const withPreset = makeReport({
+      preset: {
+        extends: ['no-hooks'],
+        rules: {},
+        resolved: [{ id: 'HKS-01', severity: 'off', source: 'extends:no-hooks' }],
+      },
+    });
+    expect(renderTerminal(withPreset)).toContain('Preset:');
+    expect(renderTerminal(withPreset)).toContain('no-hooks');
+
+    expect(renderTerminal(makeReport())).not.toContain('Preset:');
+  });
+
+  test('an off-severity failing check is excluded from Improvements', () => {
+    const report = makeReport({
+      checks: [makeCheck({ id: 'HKS-01', passed: false, severity: 'off' }), makeCheck({ passed: true })],
+    });
+    const out = renderTerminal(report);
+    expect(out).not.toContain('HKS-01');
+    expect(out).toContain('fully harnessed');
   });
 
   test('diff section warns when maturityModelChanged is true', () => {

--- a/packages/cli/test/types/smoke.ts
+++ b/packages/cli/test/types/smoke.ts
@@ -23,12 +23,15 @@ import {
   LEVEL_NAMES,
   LEVEL_REQUIREMENTS,
   type LevelInfo,
+  PRESET_REGISTRY,
   type Report,
   type ReportDiff,
   renderBadge,
   renderMarkdown,
   renderTerminal,
+  resolveSeverities,
   type ScanContext,
+  type Severity,
   score,
   TOOL_DISPLAY_NAMES,
   TOOL_VERSION,
@@ -55,6 +58,9 @@ const checkDelta: CheckDelta | undefined = diff.checksChanged[0];
 const dimensionDelta: DimensionDelta = diff.dimensions[0]!;
 const toolId: ToolId = 'cursor';
 const toolName: string = toolDisplayName(scored.detectedHarnesses[0] ?? 'cursor');
+const severity: Severity = scored.checks[0]!.severity;
+const severities = resolveSeverities({ extends: [], rules: {} });
+const presets = PRESET_REGISTRY;
 
 // Referenced only so the compiler treats every import as used; this file is
 // never executed, only type-checked.
@@ -77,6 +83,9 @@ void [
   dimensionDelta,
   toolId,
   toolName,
+  severity,
+  severities,
+  presets,
   DOCS_BASE_URL,
   LEVEL_NAMES,
   LEVEL_REQUIREMENTS,


### PR DESCRIPTION
## Why this exists

Harness Score's whole promise is comparability: same repo, same commit, same score, everywhere. That's great until a team has a *legitimate, structural* reason a check doesn't apply to them — e.g. an org policy that forbids executing local hook scripts. Before this PR, there was no way to say "this doesn't apply to us" without either hacking the canonical model (which breaks comparability for every other repo) or just eating a permanent, unfair penalty.

The goal here was to make the score customizable **without letting that customization quietly inflate it, hide something serious, or become untraceable**. Everything below is in service of that one constraint.

## What can now change a repo's maturity score, and why

1. **A team can exclude specific checks, or adopt a named preset, from a small config file at the repo root** (`.harness-score.json`, already existed for scope settings — this PR adds two keys to it: `rules` for one-off overrides, `extends` for adopting a shared preset). It's plain JSON, versioned with the code, reviewed like any other change.

2. **Excluding a check removes it from both sides of the fraction — never just the "failing" side.** A dimension's percentage is now computed only from the checks that still apply to that team. This means excluding a check can never be used to *buy* points (you don't get free credit for something you didn't do), but it also stops *penalizing* a team for something that was never relevant to them in the first place.

3. **If excluding checks empties out an entire dimension, the maturity level itself is affected — honestly.** L4 "Self-correcting" is *defined* by the Hooks & Guardrails dimension (runtime guardrails are what "self-correcting" means in this model). A team that excludes every hook check can climb every other dimension freely, but L4 becomes what the scanner now calls **capped**: not "0%, keep trying," but "this level cannot be reached under your current configuration, and here's exactly why." Before this PR, the scanner had no way to distinguish "structurally impossible" from "just hasn't been done yet" — it would have kept showing a fixable-looking gap forever, which is actively misleading. That's the one real bug this PR fixes, and it only became visible because this feature needed it to be correct. This is now explained in the canonical [Maturity Model](https://paladini.github.io/harness-score/guide/maturity-model#when-a-level-is-capped) chapter, not just buried in config reference docs.

4. **Three checks can never be excluded — full stop, from a rule or a preset, no exceptions, enforced at config-parse time, not just by convention.** `HYG-03`/`HYG-04`/`HYG-06` — the checks that detect actual leaked or exposed credentials (unprotected `.env` files in the tree, secrets inlined in MCP config, credential signatures in harness files) — are the one hard boundary in an otherwise flexible system. Attempting `"rules": {"HYG-04": "off"}` throws immediately with a clear error. "We customized our score" can never be allowed to mean "we hid a real credential leak from what the tool reports." Every other check leans on transparency and review for integrity; these three don't get that option.

5. **Every customization is always visible, everywhere the score is shown — never a silent asterisk.** Terminal output, the Markdown report (the one posted in PR comments), and the JSON output all state plainly which checks were excluded, which preset or rule caused it, and why. There is no way to opt out of that disclosure. This is what keeps "L3" meaning roughly the same thing across repos even when two of them got there by slightly different paths — the path is always one glance away.

6. **Comparing two scans over time (`--diff`) now also flags when the config itself changed between the baseline and the current scan — in the CLI's own output, not just the JSON.** Without this, a score drop after a team adopts a preset could misread as "the team did less work," when actually "the team changed what's being measured." This warning already existed for tool-version changes; it now also fires for config changes, everywhere that warning is shown (CLI terminal/Markdown output and the GitHub Action's PR comment).

## What stayed exactly the same

- **The canonical 36-check, 108-point catalog and the shape of the 5-level ladder are untouched.** Nobody's baseline expectations shift; a repo with no config file behaves 100% identically to before this PR (verified: this repo's own self-scan is still L4 · 108/108).
- **The public README badge is unchanged.** It only ever showed the level number (by design, before this PR too), so there's no risk of it implying more than it does — the full picture is one click away in the actual report, never squeezed into the badge.
- **Nobody can invent a new exclusion unilaterally and hide it.** Right now there's exactly one shared preset (`no-hooks`), and it's governed the same way the check catalog already is — proposing a new one goes through review, documented in CONTRIBUTING.md. `rules` (the one-off local override) is the more flexible escape hatch, which is exactly why item 4 above exists as a hard floor under it.

## Documentation

Every one of the guide's five languages explains what's possible and why — not just the mechanism:

- **[Metrics & Codes → Team customization](https://paladini.github.io/harness-score/guide/metrics-and-codes#team-customization)**: `extends`/`rules`, the `no-hooks` preset, and the protected-checks floor — in English, `pt-BR`, `es`, `zh-CN`, and `hi-IN`.
- **[Maturity Model → When a level is capped](https://paladini.github.io/harness-score/guide/maturity-model#when-a-level-is-capped)**: added to all five locales — this is the canonical L0-L4 chapter, and it was a real gap that it said nothing about capped levels before this PR.
- **README**: a new "Team customization" section right after Quick Start, so a repo's front page doesn't stay silent about a capability this significant.

## What's deliberately not in this PR

- A "soft warn" severity (tracked but non-blocking) — planned, not built yet.
- A CLI flag or GitHub Action input as a shortcut for this — today it's config-file-only (`--config <path>`).

Neither of these is a gap that slipped through — they're explicit scope decisions, and the code rejects anything outside them with a clear error rather than silently doing something unexpected (e.g. asking for `"warn"` today fails loudly with "not supported yet," it doesn't get silently treated as `"error"` or `"off"`).

## Test plan

- `npm test` (build + typecheck + 266 tests) — passing, including a real end-to-end run of `no-hooks` against the existing `fixtures/level-4` proving points 2–3 above with actual numbers, not just assertions in isolation
- Manually ran the CLI against a real fixture with `extends: ["no-hooks"]` and inspected terminal/Markdown/JSON output by eye to confirm the disclosure and capped-level messaging read the way this description says they should
- Manually confirmed `rules: { "HYG-04": "off" }` is rejected with a clear error, and that a preset-only baseline diff surfaces the new `presetChanged` warning in CLI output
- `npm run lint`, `npm run scan` (this repo stays L4/108), `npm run docs:build` (all five locales, clean) — all clean
- Not merging or releasing this myself — leaving it for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
