### PR TITLE
Align header with showcase

### DIFF
--- a/.changeset/warm-showcase-header.md
+++ b/.changeset/warm-showcase-header.md
@@ -1,0 +1,5 @@
+---
+"harness-score": patch
+---
+
+Align the documentation header with the Harness Maturity Showcase product shell.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -77,6 +77,7 @@ const guideItemsHi: SidebarItem[] = [
 const sharedTheme = {
   logo: '/logo.svg',
   logoLink: BASE,
+  siteTitle: '<span class="hs-product-wordmark"><b>harness</b><i>score</i></span>',
   socialLinks: [{ icon: 'github', link: 'https://github.com/paladini/harness-score' }],
   search: { provider: 'local' as const },
   outline: { level: [2, 3] as [number, number] },

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -56,6 +56,84 @@
 /* CJK + Devanagari: web fonts plus slightly taller line-height for matras and hanzi. */
 :root {
   --vp-font-family-base: "Inter", "Noto Sans SC", "Noto Sans Devanagari", system-ui, sans-serif;
+  --hs-header-paper: #f1f4ec;
+  --hs-header-ink: #0d1b17;
+  --hs-header-line: #cbd4c7;
+  --hs-header-green: #119366;
+}
+
+/* Shared product header: mirrors the Harness Maturity Showcase shell. */
+.VPNav,
+.VPNavBar {
+  background: var(--hs-header-paper);
+}
+
+.VPNavBar {
+  border-bottom: 1px solid var(--hs-header-line);
+}
+
+.VPNavBar .wrapper {
+  padding: 0 32px;
+}
+
+.VPNavBar .container {
+  max-width: none;
+}
+
+.VPNavBarTitle .title {
+  gap: 10px;
+  color: var(--hs-header-ink);
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.hs-product-wordmark {
+  display: inline-flex;
+}
+
+.hs-product-wordmark b,
+.hs-product-wordmark i {
+  font-style: normal;
+  font-weight: inherit;
+}
+
+.hs-product-wordmark i {
+  margin-left: 4px;
+  color: var(--hs-header-green);
+  font-weight: 600;
+}
+
+.VPNavBarTitle .logo {
+  width: 24px;
+  height: 24px;
+}
+
+.VPNavBarMenuLink {
+  color: var(--hs-header-ink);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.VPNavBarMenuLink:hover,
+.VPNavBarMenuLink.active {
+  color: var(--hs-header-green);
+}
+
+.VPNavBarMenuLink.active::after {
+  background-color: var(--hs-header-green);
+}
+
+.VPNavBarAppearance,
+.VPNavBarTranslations,
+.VPNavBarSocialLinks {
+  color: var(--hs-header-ink);
+}
+
+@media (max-width: 640px) {
+  .VPNavBar .wrapper {
+    padding: 0 18px;
+  }
 }
 
 html[lang="hi-IN"] .vp-doc p,


### PR DESCRIPTION
## What changed

- apply the Showcase mineral and green product shell to the VitePress header
- align header height, border, spacing, logo size, and navigation typography
- use the shared lowercase harness/score wordmark
- preserve VitePress language, theme, mobile menu, and GitHub controls
- include the required patch changeset

## Validation

- 234 tests passed
- npm run lint
- npm run scan: L4, 108/108
- npm run docs:build
- Playwright desktop and 390px mobile comparison