### PR TITLE
Fix dark mode header contrast

### DIFF
--- a/.changeset/calm-dark-header.md
+++ b/.changeset/calm-dark-header.md
@@ -1,0 +1,5 @@
+---
+"harness-score": patch
+---
+
+Improve navigation contrast and control colors in the dark theme.

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -109,25 +109,42 @@
   height: 24px;
 }
 
-.VPNavBarMenuLink {
+.VPNavBar .VPNavBarMenuLink {
   color: var(--hs-header-ink);
   font-size: 13px;
   font-weight: 600;
 }
 
-.VPNavBarMenuLink:hover,
-.VPNavBarMenuLink.active {
+.VPNavBar .VPNavBarMenuLink:hover,
+.VPNavBar .VPNavBarMenuLink.active {
   color: var(--hs-header-green);
 }
 
-.VPNavBarMenuLink.active::after {
+.VPNavBar .VPNavBarMenuLink.active::after {
   background-color: var(--hs-header-green);
 }
 
-.VPNavBarAppearance,
-.VPNavBarTranslations,
-.VPNavBarSocialLinks {
+.VPNavBar .VPFlyout .button,
+.VPNavBar .VPFlyout .text,
+.VPNavBar .VPSocialLink {
   color: var(--hs-header-ink);
+}
+
+.VPNavBar .VPFlyout:hover .text,
+.VPNavBar .VPSocialLink:hover {
+  color: var(--hs-header-green);
+}
+
+.VPNavBar .VPFlyout .icon {
+  fill: currentColor;
+}
+
+.VPNavBar .VPNavBarAppearance {
+  --vp-input-border-color: var(--hs-header-ink);
+  --vp-input-switch-bg-color: var(--hs-header-paper);
+  --vp-c-neutral-inverse: var(--hs-header-ink);
+  --vp-c-text-1: var(--hs-header-paper);
+  --vp-c-text-2: var(--hs-header-paper);
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## What changed

- increases header selector specificity so VitePress dark-theme styles no longer override navigation colors
- gives navigation links, language controls, theme switch, and GitHub icon explicit high-contrast colors
- preserves the existing light mineral header and green interaction states

## Root cause

VitePress component-scoped dark-theme selectors were more specific than the custom header rules. The header remained light while its menu text inherited the dark theme's near-white text color, making the navigation unreadable.

## Impact

The header remains visually integrated with the Showcase and is now readable in dark mode without changing the page content theme.

## Validation

- `npm run docs:build`
- `npm test` — 234 tests passed
- `npm run lint` — no errors; 18 pre-existing warnings
- `npm run scan -- --min-level 4` — L4, 108/108
- Playwright/Edge dark-mode visual check at 1904×993
- computed menu color: `rgb(13, 27, 23)` on `rgb(241, 244, 236)`