### PR TITLE
Ship the MIT license with the legacy Action entrypoint

### DIFF
--- a/.changeset/quiet-action-license.md
+++ b/.changeset/quiet-action-license.md
@@ -1,0 +1,5 @@
+---
+"harness-score": patch
+---
+
+Ship the MIT license inside the legacy `action/` entrypoint for GitHub dependency-review compatibility.

--- a/.github/workflows/dependency-review-validation.yml
+++ b/.github/workflows/dependency-review-validation.yml
@@ -1,0 +1,17 @@
+name: Dependency Review validation
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          comment-summary-in-pr: always

--- a/.github/workflows/legacy-action-license-fixture.yml
+++ b/.github/workflows/legacy-action-license-fixture.yml
@@ -1,0 +1,17 @@
+name: Legacy Action license fixture
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  harness:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: paladini/harness-score/action@e0ba97e1ecdb5e48ee8c6142c36e84b4c5c30755
+        with:
+          min-level: '0'

--- a/.github/workflows/legacy-action-license-fixture.yml
+++ b/.github/workflows/legacy-action-license-fixture.yml
@@ -1,4 +1,4 @@
-name: Legacy Action license fixture
+name: Root Action license fixture
 
 on:
   workflow_dispatch:
@@ -12,6 +12,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: paladini/harness-score/action@e0ba97e1ecdb5e48ee8c6142c36e84b4c5c30755
+      - uses: paladini/harness-score@6d4aace760e315554db49f6d6c244e24e6671b4c
         with:
           min-level: '0'

--- a/action/LICENSE
+++ b/action/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Fernando Paladini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/test/plugins-sync.test.ts
+++ b/packages/cli/test/plugins-sync.test.ts
@@ -14,6 +14,14 @@ describe('plugins/shared path config sync', () => {
     expect(legacy).toBe(canonical);
   });
 
+  test('the legacy GitHub Action ships the repository license', () => {
+    const repoRoot = path.resolve(import.meta.dirname, '../../..');
+    const canonical = fs.readFileSync(path.join(repoRoot, 'LICENSE'), 'utf8');
+    const legacy = fs.readFileSync(path.join(repoRoot, 'action/LICENSE'), 'utf8');
+
+    expect(legacy).toBe(canonical);
+  });
+
   test('generated TOOL_PATHS matches PLUGIN_TOOL_PATHS from the CLI harness registry exactly', () => {
     for (const [toolId, paths] of Object.entries(PLUGIN_TOOL_PATHS)) {
       const tool = TOOL_PATHS[toolId as keyof typeof TOOL_PATHS];


### PR DESCRIPTION
## Outcome: publisher-side license files do not fix the report

This PR tested the proposed direct fix for #29 by placing the repository's MIT license inside `action/` and referencing that exact commit through `paladini/harness-score/action@<SHA>`.

The real Dependency Review run still reported the legacy Action dependency as having an unknown license:

- subdirectory entrypoint with `action/LICENSE`: https://github.com/paladini/harness-score/actions/runs/30170660005
- root entrypoint from released `v1.3.3`: https://github.com/paladini/harness-score/actions/runs/30170681992

The root test also reported `actions/checkout@v4` as unknown. This indicates that the license result is coming from GitHub's Dependency Graph/Dependency Review metadata and is not changed by adding a license alongside the Action manifest.

The local implementation itself was healthy (236 tests, lint, docs build, L4 108/108), but the proposed change did not meet its acceptance criterion. The PR is therefore closed without merge or release. Temporary validation workflows remain only in the closed branch history and were never merged into `main`.