### PR TITLE
release: v1.5.0

### DIFF
--- a/.changeset/v1.5-config-presets.md
+++ b/.changeset/v1.5-config-presets.md
@@ -1,9 +1,0 @@
----
-"harness-score": minor
----
-
-Add ESLint-flavored team customization to `.harness-score.json`: `extends` (named, maintainer-curated presets) and `rules` (per-check severity override, `"off"` or `"error"`). Ships one built-in preset, `no-hooks`, for environments where local hook execution is disallowed by policy.
-
-Excluded checks are removed from both the numerator and denominator of their dimension's score — never penalized, never silently hidden. If a preset excludes every check in a dimension a maturity-level requirement depends on, that level is now correctly reported as `capped` (with a `capReason`) instead of showing a misleading "0%, keep trying" gap — L4 in particular is definitionally tied to the Hooks & Guardrails dimension, so a repo under `no-hooks` can climb every other dimension freely but stays capped at L3.
-
-New additive `Report` fields: `preset` (what customization was actually applied), `checks[].severity`, `dimensions[].applicable`, `level.capped`/`level.capReason`. `--diff` gains a `presetChanged` flag mirroring the existing `maturityModelChanged`.

--- a/action.yml
+++ b/action.yml
@@ -153,6 +153,10 @@ runs:
             ? '> ⚠ Baseline is from a different tool version or maturity model total — some deltas below may reflect that, not repository changes.\n\n'
             : '';
 
+          const presetWarning = diff.presetChanged
+            ? '> ⚠ Baseline used a different `.harness-score.json` extends/rules config — some deltas below may reflect that, not repository changes.\n\n'
+            : '';
+
           const movedDims = diff.dimensions.filter((d) => d.delta !== 0);
           const dimTable = movedDims.length
             ? [
@@ -169,7 +173,7 @@ runs:
             marker,
             `### ${arrow} Harness Score: L${diff.level.before} · ${diff.level.beforeName} → L${diff.level.after} · ${diff.level.afterName}`,
             '',
-            modelWarning + `**Score:** ${diff.score.before.earned}/${diff.score.before.max} (${diff.score.before.percent}%) → ` +
+            modelWarning + presetWarning + `**Score:** ${diff.score.before.earned}/${diff.score.before.max} (${diff.score.before.percent}%) → ` +
               `${diff.score.after.earned}/${diff.score.after.max} (${diff.score.after.percent}%) (${sign(diff.score.deltaPercent)}pp)`,
             '',
             dimTable,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6799,7 +6799,7 @@
     },
     "packages/cli": {
       "name": "harness-score",
-      "version": "1.2.0",
+      "version": "1.5.0",
       "license": "MIT",
       "bin": {
         "harness-score": "dist/cli.js"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # harness-score
 
+## 1.5.0
+
+### Minor Changes
+
+- cbc7b98: Add ESLint-flavored team customization to `.harness-score.json`: `extends` (named, maintainer-curated presets) and `rules` (per-check severity override, `"off"` or `"error"`). Ships one built-in preset, `no-hooks`, for environments where local hook execution is disallowed by policy.
+
+  Excluded checks are removed from both the numerator and denominator of their dimension's score — never penalized, never silently hidden. If a preset excludes every check in a dimension a maturity-level requirement depends on, that level is now correctly reported as `capped` (with a `capReason`) instead of showing a misleading "0%, keep trying" gap — L4 in particular is definitionally tied to the Hooks & Guardrails dimension, so a repo under `no-hooks` can climb every other dimension freely but stays capped at L3.
+
+  New additive `Report` fields: `preset` (what customization was actually applied), `checks[].severity`, `dimensions[].applicable`, `level.capped`/`level.capReason`. `--diff` gains a `presetChanged` flag mirroring the existing `maturityModelChanged`.
+
 ## 1.3.3
 
 ### Patch Changes

--- a/packages/cli/jsr.json
+++ b/packages/cli/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@paladini/harness-score",
-  "version": "1.3.3",
+  "version": "1.5.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-score",
-  "version": "1.3.3",
+  "version": "1.5.0",
   "description": "Deterministic AI coding harness-maturity scanner for AI-assisted repositories (Cursor-flagship, expanding to other AI-first dev tools). Zero LLM calls, zero network, zero runtime dependencies.",
   "type": "module",
   "bin": {

--- a/packages/cli/src/score.ts
+++ b/packages/cli/src/score.ts
@@ -17,7 +17,7 @@ import type {
 import { DIMENSIONS } from './types.js';
 
 export const DOCS_BASE_URL = 'https://paladini.github.io/harness-score/guide/measure-and-improve';
-export const TOOL_VERSION = '1.3.3';
+export const TOOL_VERSION = '1.5.0';
 
 export const LEVEL_NAMES = ['Unharnessed', 'Documented', 'Guided', 'Sensing', 'Self-correcting'] as const;
 


### PR DESCRIPTION
## Summary

Prepare Harness Score v1.5.0 for publication across npm, GitHub Packages, JSR, GitHub Releases, and the versioned GitHub Action.

## Changes

- consume the v1.5 customization changeset and synchronize the CLI, JSR, changelog, and lockfile at `1.5.0`
- keep `1.4.x` intentionally unpublished
- synchronize the canonical root `action.yml` with the legacy Action entrypoint so `presetChanged` warnings appear in GitHub Action PR comments

## Root cause of the CI repair

PR #35 updated `action/action.yml`, but the canonical root `action.yml` had been added to `main` by a different PR after #35's last green check. The combined post-merge state therefore failed the exact Action synchronization test. This PR applies the intended v1.5 behavior to the canonical entrypoint and restores byte-for-byte parity.

## Public impact

v1.5.0 adds repository-scoped `extends` and `rules` customization, the `no-hooks` preset, protected credential checks, applicable score denominators, capped maturity levels, additive report fields, and `presetChanged` diff reporting. Repositories without customization retain the existing scoring behavior.

## Validation

- `npm test` — 267 tests passed
- `npm run test:coverage` — 267 tests passed; 96.16% statements
- `npm run lint` — passed with 18 pre-existing warnings and no errors
- `npm run scan -- --min-level 4` — L4, 108/108
- `npm run docs:build`
- `npm run plugins:sync-check`
- `npm run typecheck:consumer -w harness-score`
- `npm run check:types -w harness-score`
- `npm audit --omit=dev` — 0 vulnerabilities
- `npm pack --dry-run -w harness-score --json` — `harness-score@1.5.0`, 11 files
- `git diff --check`
