### PR TITLE
release: prepare v1.5.1 GitHub Marketplace launch

### DIFF
--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -11,12 +11,12 @@ description: Use when the user asks to release, publish, or version-bump harness
    `npm run version-packages` (runs `changeset version`, which bumps
    `packages/cli/package.json` and writes `packages/cli/CHANGELOG.md` from
    accumulated `.changeset/*.md` files, then `scripts/sync-version.mjs`,
-   which mirrors the new version into `TOOL_VERSION` and `jsr.json` —
-   changesets doesn't know about either file on its own). Review the diff.
-   If no changesets were added since the last release, bump all three by
-   hand instead:
-   - `packages/cli/package.json`, `TOOL_VERSION` in
-     `packages/cli/src/score.ts`, and `version` in `packages/cli/jsr.json`
+    which mirrors the new version into `TOOL_VERSION`, `jsr.json`,
+    `package-lock.json`, and both GitHub Action entrypoints — changesets
+    doesn't know about those project-specific files). Review the diff.
+    If no changesets were added since the last release, bump
+    `packages/cli/package.json` by hand and run
+    `node scripts/sync-version.mjs`.
    - `plugins/cursor/.cursor-plugin/plugin.json` (+ entry in
      `plugins/cursor/CHANGELOG.md`) — only if Cursor plugin content
      changed, it has its own release track
@@ -38,15 +38,22 @@ description: Use when the user asks to release, publish, or version-bump harness
    - **GitHub Packages** as `@paladini/harness-score` (automatic, uses the
      built-in `GITHUB_TOKEN`, no secret needed — the repo's Actions
      "Workflow permissions" must be set to Read and write).
-   - **JSR** as `@paladini/harness-score` (automatic via OIDC — but the
-     scope must be claimed once by the user at jsr.io/new before the first
-     publish succeeds).
-5. If npm Trusted Publishing isn't configured yet, `npm publish` in CI will
+    - **JSR** as `@paladini/harness-score` (automatic via OIDC — but the
+      scope must be claimed once by the user at jsr.io/new before the first
+      publish succeeds).
+   If the GitHub Action changed, select **Publish this Action to the GitHub
+   Marketplace**. Use **Code quality** as the primary category and
+   **Continuous integration** as the secondary category.
+5. After the release workflow succeeds, move the matching stable Action major
+   tag (`v1` for a `v1.x.y` release):
+   `git tag -f vN vX.Y.Z && git push origin vN --force`. Never move the major
+   tag before the released Action and registry jobs pass.
+6. If npm Trusted Publishing isn't configured yet, `npm publish` in CI will
    fail with a clear error; the user completes the one-time npmjs.com setup
    and the next run succeeds — no manual local publish needed once it's on.
-6. Cursor Marketplace: the listing updates from the repo — remind the user
+7. Cursor Marketplace: the listing updates from the repo — remind the user
    to resubmit at https://cursor.com/marketplace/publish only if
    `plugins/cursor/` metadata changed. Claude Code has no separate
    marketplace to resubmit to — see step 2.
-7. Docs deploy automatically via `.github/workflows/pages.yml` on push to
+8. Docs deploy automatically via `.github/workflows/pages.yml` on push to
    main.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,30 @@ jobs:
         run: npm run lint
       - name: Build, test & coverage gate
         run: npm run test:coverage
+      - name: Prepare GitHub Action smoke fixture
+        shell: bash
+        run: cp -R fixtures/level-4 "$RUNNER_TEMP/harness-action-fixture"
+      - name: Smoke test the packaged GitHub Action
+        id: action-smoke
+        uses: ./
+        with:
+          version: 'file:${{ github.workspace }}/packages/cli'
+          working-directory: ${{ runner.temp }}/harness-action-fixture
+          min-level: '4'
+          badge: 'harness-badge.svg'
+          report: 'harness-report.md'
+      - name: Verify GitHub Action outputs and artifacts
+        shell: bash
+        env:
+          HS_LEVEL: ${{ steps.action-smoke.outputs.level }}
+          HS_LEVEL_NAME: ${{ steps.action-smoke.outputs.level-name }}
+          HS_PERCENT: ${{ steps.action-smoke.outputs.percent }}
+        run: |
+          test "$HS_LEVEL" = "4"
+          test "$HS_LEVEL_NAME" = "Self-correcting"
+          test "$HS_PERCENT" = "100"
+          test -s "$RUNNER_TEMP/harness-action-fixture/harness-badge.svg"
+          test -s "$RUNNER_TEMP/harness-action-fixture/harness-report.md"
       - name: Consumer-facing type packaging check (typecheck:consumer)
         run: npm run typecheck:consumer -w harness-score
       - name: Published types match runtime exports (attw)

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The pill looks the same whether CI regenerates it or you pin a static file.
 
 ```yaml
 # .github/workflows/harness.yml
-- uses: paladini/harness-score@main
+- uses: paladini/harness-score@v1
   with: { badge: 'harness-badge.svg' }
 # publish harness-badge.svg to a badges branch or GitHub Pages, then:
 ```
@@ -249,7 +249,7 @@ harness-score --min-level 3
 Or in CI:
 
 ```yaml
-- uses: paladini/harness-score@main
+- uses: paladini/harness-score@v1
   with:
     min-level: '3'
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,10 +5,12 @@ no npm token, no long-lived secret stored anywhere in this repo.
 
 1. **Verify green:** `npm test`, `npm run lint`, `npm run scan` (must report
    L4), `npm run docs:build`.
-2. **Bump versions together** — these three must always match:
+2. **Bump versions together** — these release surfaces must always match:
    - `packages/cli/package.json` (`version`)
    - `TOOL_VERSION` in `packages/cli/src/score.ts`
    - `version` in `packages/cli/jsr.json`
+   - the `packages/cli` workspace version in `package-lock.json`
+   - the `version` input default in `action.yml` and `action/action.yml`
    - If Cursor plugin content changed: `plugins/cursor/.cursor-plugin/plugin.json` +
      an entry in `plugins/cursor/CHANGELOG.md` (it has its own release
      track and version number).
@@ -22,10 +24,11 @@ no npm token, no long-lived secret stored anywhere in this repo.
    `npm run version-packages` — this runs `changeset version` (bumps
    `packages/cli/package.json` and writes `packages/cli/CHANGELOG.md` from
    the accumulated changesets) followed by `scripts/sync-version.mjs`,
-   which mirrors the new version into `TOOL_VERSION` and `jsr.json` (changesets
-   has no notion of either file, so this closes that gap). Review the diff,
-   then continue at step 3. If no changesets were added for a release,
-   bump all three by hand as before.
+   which mirrors the new version into every release surface listed above
+   (changesets has no notion of those project-specific files). Review the
+   diff, then continue at step 3. If no changesets were added for a release,
+   bump `packages/cli/package.json` by hand and run
+   `node scripts/sync-version.mjs`.
 3. Commit `release: vX.Y.Z`, tag `vX.Y.Z`, push with tags.
 4. Create a GitHub Release from that tag. If `packages/cli/CHANGELOG.md`
    gained an entry for this version (via changesets), copy that section
@@ -35,6 +38,11 @@ no npm token, no long-lived secret stored anywhere in this repo.
    # or, with no CHANGELOG.md entry for this release:
    gh release create vX.Y.Z --generate-notes
    ```
+   When the GitHub Action changed, select **Publish this Action to the GitHub
+   Marketplace** while drafting the release. Use **Code quality** as the
+   primary category and **Continuous integration** as the secondary category.
+   For the initial Marketplace release, use the title
+   `v1.5.1 — GitHub Marketplace launch`.
    This fires [`release.yml`](.github/workflows/release.yml), which
    publishes to all three registries automatically:
    - **npm** as [`harness-score`](https://www.npmjs.com/package/harness-score),
@@ -57,10 +65,20 @@ no npm token, no long-lived secret stored anywhere in this repo.
      release; all three still expose the same public API (checked by
      `packages/cli/test/golden-output.test.ts` and the `attw`/type-smoke
      checks against the npm-published shape).
-5. If npm Trusted Publishing isn't configured yet, `npm publish` in CI fails
+5. After the release workflow succeeds, move the matching stable Action major
+   tag (`v1` for a `v1.x.y` release) to the released commit and push it:
+   ```bash
+   git tag -f vN vX.Y.Z
+   git push origin vN --force
+   ```
+   For the Marketplace launch, `vN` is `v1` and `vX.Y.Z` is `v1.5.1`.
+   Do not move the major tag before the registry jobs and the released Action
+   have passed. Pushing this tag does not trigger the registry publication
+   workflow; only a published GitHub Release does.
+6. If npm Trusted Publishing isn't configured yet, `npm publish` in CI fails
    with a clear error; complete the one-time npmjs.com setup and re-run —
    no manual local publish is ever needed once it's wired up.
-6. **Cursor Marketplace:** the listing points at the repo, so most changes
+7. **Cursor Marketplace:** the listing points at the repo, so most changes
    need nothing further. Resubmit at
    [cursor.com/marketplace/publish](https://cursor.com/marketplace/publish)
    only if `plugins/cursor/.cursor-plugin/plugin.json` metadata (name,
@@ -69,7 +87,7 @@ no npm token, no long-lived secret stored anywhere in this repo.
    this git repo (`.claude-plugin/marketplace.json`). A `plugins/claude-code/.claude-plugin/plugin.json`
    version bump and a push to `main` is the entire release; users already
    on the marketplace pick it up via `/plugin marketplace update`.
-7. **Docs:** deploy automatically via
+8. **Docs:** deploy automatically via
    [`pages.yml`](.github/workflows/pages.yml) on every push to `main` — no
    manual step.
 

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,7 @@
 name: 'Harness Score'
 description: >-
-  Deterministic AI-harness maturity audit (Cursor-first): scans the repository,
-  reports a maturity level (L0–L4), optionally fails the build below a minimum
-  level, and emits an SVG badge and markdown report.
+  Deterministic AI-harness maturity audit with CI gates, reports, badges, and
+  pull-request score deltas.
 author: 'Fernando Paladini'
 branding:
   icon: 'shield'
@@ -26,9 +25,9 @@ inputs:
     required: false
     default: '.'
   version:
-    description: 'harness-score npm version to run.'
+    description: 'harness-score npm version or package spec to run.'
     required: false
-    default: 'latest'
+    default: '1.5.1'
   comment:
     description: >-
       Post (or update) a sticky pull-request comment showing the harness
@@ -76,16 +75,25 @@ runs:
     - id: scan
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        HS_BADGE: ${{ inputs.badge }}
+        HS_CONFIG: ${{ inputs.config }}
+        HS_GATE: ${{ inputs.gate }}
+        HS_INCLUDE_SYSTEM_HARNESS: ${{ inputs.include-system-harness }}
+        HS_INCLUDE_USER_HARNESS: ${{ inputs.include-user-harness }}
+        HS_MIN_LEVEL: ${{ inputs.min-level }}
+        HS_REPORT: ${{ inputs.report }}
+        HS_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
         ARGS=(--quiet --json)
-        [ -n "${{ inputs.badge }}" ] && ARGS+=(--badge "${{ inputs.badge }}")
-        [ -n "${{ inputs.report }}" ] && ARGS+=(--md "${{ inputs.report }}")
-        [ -n "${{ inputs.config }}" ] && ARGS+=(--config "${{ inputs.config }}")
-        [ "${{ inputs.include-user-harness }}" = "true" ] && ARGS+=(--scope user)
-        [ "${{ inputs.include-system-harness }}" = "true" ] && ARGS+=(--scope system)
-        [ -n "${{ inputs.gate }}" ] && ARGS+=(--gate "${{ inputs.gate }}")
-        npx -y "harness-score@${{ inputs.version }}" . "${ARGS[@]}" > harness-report.json
+        [ -n "$HS_BADGE" ] && ARGS+=(--badge "$HS_BADGE")
+        [ -n "$HS_REPORT" ] && ARGS+=(--md "$HS_REPORT")
+        [ -n "$HS_CONFIG" ] && ARGS+=(--config "$HS_CONFIG")
+        [ "$HS_INCLUDE_USER_HARNESS" = "true" ] && ARGS+=(--scope user)
+        [ "$HS_INCLUDE_SYSTEM_HARNESS" = "true" ] && ARGS+=(--scope system)
+        [ -n "$HS_GATE" ] && ARGS+=(--gate "$HS_GATE")
+        npx -y "harness-score@$HS_VERSION" . "${ARGS[@]}" > harness-report.json
 
         LEVEL=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).level.index")
         NAME=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).level.name")
@@ -110,8 +118,8 @@ runs:
           require('fs').appendFileSync(process.env.GITHUB_STEP_SUMMARY, '\n| Dimension | Score | % |\n|---|---|---|\n' + rows + '\n');
         "
 
-        if [ "$GATE_LEVEL" -lt "${{ inputs.min-level }}" ]; then
-          echo "::error::Harness ${GATE} L${GATE_LEVEL} is below required L${{ inputs.min-level }}."
+        if [ "$GATE_LEVEL" -lt "$HS_MIN_LEVEL" ]; then
+          echo "::error::Harness ${GATE} L${GATE_LEVEL} is below required L${HS_MIN_LEVEL}."
           echo "$GATE_GAPS"
           exit 1
         fi
@@ -120,12 +128,16 @@ runs:
       if: ${{ inputs.comment == 'true' && github.event_name == 'pull_request' }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        HS_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        HS_VERSION: ${{ inputs.version }}
+        HS_WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
         set -euo pipefail
-        git fetch origin "${{ github.event.pull_request.base.ref }}"
+        git fetch origin "$HS_BASE_REF"
         git worktree remove /tmp/harness-score-base --force 2>/dev/null || true
         git worktree add /tmp/harness-score-base FETCH_HEAD
-        npx -y "harness-score@${{ inputs.version }}" "/tmp/harness-score-base/${{ inputs.working-directory }}" \
+        npx -y "harness-score@$HS_VERSION" "/tmp/harness-score-base/$HS_WORKING_DIRECTORY" \
           --quiet --json > /tmp/harness-score-base.json
         git worktree remove /tmp/harness-score-base --force
 
@@ -133,9 +145,11 @@ runs:
       if: ${{ inputs.comment == 'true' && github.event_name == 'pull_request' }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        HS_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
-        npx -y "harness-score@${{ inputs.version }}" . --quiet --json \
+        npx -y "harness-score@$HS_VERSION" . --quiet --json \
           --diff /tmp/harness-score-base.json > /tmp/harness-score-diff.json
 
     - id: comment

--- a/action/README.md
+++ b/action/README.md
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: paladini/harness-score@main
+      - uses: paladini/harness-score@v1
         with:
           min-level: '3'          # fail below L3 (0 = report only)
           badge: 'harness-badge.svg'
@@ -24,7 +24,7 @@ A per-run summary (level + dimension table) appears in the job summary. To
 publish the badge, upload it as an artifact or commit it to a `badges`
 branch, then reference it from your README:
 
-Pin a full commit SHA instead of `main` in production workflows. The legacy
+Pin a full commit SHA instead of `v1` for maximum supply-chain stability. The legacy
 `paladini/harness-score/action@<ref>` entrypoint remains compatible, but the
 root entrypoint is recommended because GitHub dependency-review can associate
 it with this repository's MIT license.
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: paladini/harness-score@main
+      - uses: paladini/harness-score@v1
         with:
           comment: 'true'
 ```

--- a/action/action.yml
+++ b/action/action.yml
@@ -1,8 +1,7 @@
 name: 'Harness Score'
 description: >-
-  Deterministic AI-harness maturity audit (Cursor-first): scans the repository,
-  reports a maturity level (L0–L4), optionally fails the build below a minimum
-  level, and emits an SVG badge and markdown report.
+  Deterministic AI-harness maturity audit with CI gates, reports, badges, and
+  pull-request score deltas.
 author: 'Fernando Paladini'
 branding:
   icon: 'shield'
@@ -26,9 +25,9 @@ inputs:
     required: false
     default: '.'
   version:
-    description: 'harness-score npm version to run.'
+    description: 'harness-score npm version or package spec to run.'
     required: false
-    default: 'latest'
+    default: '1.5.1'
   comment:
     description: >-
       Post (or update) a sticky pull-request comment showing the harness
@@ -76,16 +75,25 @@ runs:
     - id: scan
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        HS_BADGE: ${{ inputs.badge }}
+        HS_CONFIG: ${{ inputs.config }}
+        HS_GATE: ${{ inputs.gate }}
+        HS_INCLUDE_SYSTEM_HARNESS: ${{ inputs.include-system-harness }}
+        HS_INCLUDE_USER_HARNESS: ${{ inputs.include-user-harness }}
+        HS_MIN_LEVEL: ${{ inputs.min-level }}
+        HS_REPORT: ${{ inputs.report }}
+        HS_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
         ARGS=(--quiet --json)
-        [ -n "${{ inputs.badge }}" ] && ARGS+=(--badge "${{ inputs.badge }}")
-        [ -n "${{ inputs.report }}" ] && ARGS+=(--md "${{ inputs.report }}")
-        [ -n "${{ inputs.config }}" ] && ARGS+=(--config "${{ inputs.config }}")
-        [ "${{ inputs.include-user-harness }}" = "true" ] && ARGS+=(--scope user)
-        [ "${{ inputs.include-system-harness }}" = "true" ] && ARGS+=(--scope system)
-        [ -n "${{ inputs.gate }}" ] && ARGS+=(--gate "${{ inputs.gate }}")
-        npx -y "harness-score@${{ inputs.version }}" . "${ARGS[@]}" > harness-report.json
+        [ -n "$HS_BADGE" ] && ARGS+=(--badge "$HS_BADGE")
+        [ -n "$HS_REPORT" ] && ARGS+=(--md "$HS_REPORT")
+        [ -n "$HS_CONFIG" ] && ARGS+=(--config "$HS_CONFIG")
+        [ "$HS_INCLUDE_USER_HARNESS" = "true" ] && ARGS+=(--scope user)
+        [ "$HS_INCLUDE_SYSTEM_HARNESS" = "true" ] && ARGS+=(--scope system)
+        [ -n "$HS_GATE" ] && ARGS+=(--gate "$HS_GATE")
+        npx -y "harness-score@$HS_VERSION" . "${ARGS[@]}" > harness-report.json
 
         LEVEL=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).level.index")
         NAME=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).level.name")
@@ -110,8 +118,8 @@ runs:
           require('fs').appendFileSync(process.env.GITHUB_STEP_SUMMARY, '\n| Dimension | Score | % |\n|---|---|---|\n' + rows + '\n');
         "
 
-        if [ "$GATE_LEVEL" -lt "${{ inputs.min-level }}" ]; then
-          echo "::error::Harness ${GATE} L${GATE_LEVEL} is below required L${{ inputs.min-level }}."
+        if [ "$GATE_LEVEL" -lt "$HS_MIN_LEVEL" ]; then
+          echo "::error::Harness ${GATE} L${GATE_LEVEL} is below required L${HS_MIN_LEVEL}."
           echo "$GATE_GAPS"
           exit 1
         fi
@@ -120,12 +128,16 @@ runs:
       if: ${{ inputs.comment == 'true' && github.event_name == 'pull_request' }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        HS_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        HS_VERSION: ${{ inputs.version }}
+        HS_WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
         set -euo pipefail
-        git fetch origin "${{ github.event.pull_request.base.ref }}"
+        git fetch origin "$HS_BASE_REF"
         git worktree remove /tmp/harness-score-base --force 2>/dev/null || true
         git worktree add /tmp/harness-score-base FETCH_HEAD
-        npx -y "harness-score@${{ inputs.version }}" "/tmp/harness-score-base/${{ inputs.working-directory }}" \
+        npx -y "harness-score@$HS_VERSION" "/tmp/harness-score-base/$HS_WORKING_DIRECTORY" \
           --quiet --json > /tmp/harness-score-base.json
         git worktree remove /tmp/harness-score-base --force
 
@@ -133,9 +145,11 @@ runs:
       if: ${{ inputs.comment == 'true' && github.event_name == 'pull_request' }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        HS_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
-        npx -y "harness-score@${{ inputs.version }}" . --quiet --json \
+        npx -y "harness-score@$HS_VERSION" . --quiet --json \
           --diff /tmp/harness-score-base.json > /tmp/harness-score-diff.json
 
     - id: comment

--- a/docs/es/guide/measure-and-improve.md
+++ b/docs/es/guide/measure-and-improve.md
@@ -161,7 +161,7 @@ una rule se pudre. Traba tu nivel en CI:
 O usa la action empaquetada, que también emite el badge:
 
 ```yaml
-- uses: paladini/harness-score@main
+- uses: paladini/harness-score@v1
   with:
     min-level: '3'
     badge: 'harness-badge.svg'
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: paladini/harness-score@main
+      - uses: paladini/harness-score@v1
         with: { badge: 'harness-badge.svg' }
       - uses: JamesIves/github-pages-deploy-action@v4
         with: { branch: badges, folder: ., clean: false }

--- a/docs/guide/measure-and-improve.md
+++ b/docs/guide/measure-and-improve.md
@@ -163,7 +163,7 @@ rules file rots. Ratchet your level in CI:
 Or use the packaged action, which also emits the badge:
 
 ```yaml
-- uses: paladini/harness-score@main
+- uses: paladini/harness-score@v1
   with:
     min-level: '3'
     badge: 'harness-badge.svg'
@@ -203,7 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: paladini/harness-score@main
+      - uses: paladini/harness-score@v1
         with: { badge: 'harness-badge.svg' }
       - uses: JamesIves/github-pages-deploy-action@v4
         with: { branch: badges, folder: ., clean: false }

--- a/docs/hi-IN/guide/measure-and-improve.md
+++ b/docs/hi-IN/guide/measure-and-improve.md
@@ -141,7 +141,7 @@ Harness चुपचाप पीछे हट जाता है — किस
 या packaged action का उपयोग करें, जो बैज भी emit करता है:
 
 ```yaml
-- uses: paladini/harness-score@main
+- uses: paladini/harness-score@v1
   with:
     min-level: '3'
     badge: 'harness-badge.svg'
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: paladini/harness-score@main
+      - uses: paladini/harness-score@v1
         with: { badge: 'harness-badge.svg' }
       - uses: JamesIves/github-pages-deploy-action@v4
         with: { branch: badges, folder: ., clean: false }

--- a/docs/pt-BR/guide/measure-and-improve.md
+++ b/docs/pt-BR/guide/measure-and-improve.md
@@ -161,7 +161,7 @@ rule apodrece. Trave seu nível no CI:
 Ou use a action empacotada, que também emite o badge:
 
 ```yaml
-- uses: paladini/harness-score@main
+- uses: paladini/harness-score@v1
   with:
     min-level: '3'
     badge: 'harness-badge.svg'
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: paladini/harness-score@main
+      - uses: paladini/harness-score@v1
         with: { badge: 'harness-badge.svg' }
       - uses: JamesIves/github-pages-deploy-action@v4
         with: { branch: badges, folder: ., clean: false }

--- a/docs/zh-CN/guide/measure-and-improve.md
+++ b/docs/zh-CN/guide/measure-and-improve.md
@@ -136,7 +136,7 @@ Harness 会静默退化 — 有人在清理时删掉 `hooks.json`，规则文件
 或使用打包 action，同时生成徽章：
 
 ```yaml
-- uses: paladini/harness-score@main
+- uses: paladini/harness-score@v1
   with:
     min-level: '3'
     badge: 'harness-badge.svg'
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: paladini/harness-score@main
+      - uses: paladini/harness-score@v1
         with: { badge: 'harness-badge.svg' }
       - uses: JamesIves/github-pages-deploy-action@v4
         with: { branch: badges, folder: ., clean: false }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6799,7 +6799,7 @@
     },
     "packages/cli": {
       "name": "harness-score",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "bin": {
         "harness-score": "dist/cli.js"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # harness-score
 
+## 1.5.1
+
+### Patch Changes
+
+- Prepare the GitHub Action for its Marketplace launch with concise metadata,
+  version-aligned execution, hardened input handling, stable `v1` usage, and an
+  end-to-end CI smoke test.
+- Keep the CLI, JSR manifest, lockfile, and both GitHub Action entrypoints
+  version-aligned automatically during future releases.
+
 ## 1.5.0
 
 ### Minor Changes

--- a/packages/cli/jsr.json
+++ b/packages/cli/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@paladini/harness-score",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-score",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Deterministic AI coding harness-maturity scanner for AI-assisted repositories (Cursor-flagship, expanding to other AI-first dev tools). Zero LLM calls, zero network, zero runtime dependencies.",
   "type": "module",
   "bin": {

--- a/packages/cli/src/score.ts
+++ b/packages/cli/src/score.ts
@@ -17,7 +17,7 @@ import type {
 import { DIMENSIONS } from './types.js';
 
 export const DOCS_BASE_URL = 'https://paladini.github.io/harness-score/guide/measure-and-improve';
-export const TOOL_VERSION = '1.5.0';
+export const TOOL_VERSION = '1.5.1';
 
 export const LEVEL_NAMES = ['Unharnessed', 'Documented', 'Guided', 'Sensing', 'Self-correcting'] as const;
 

--- a/packages/cli/test/plugins-sync.test.ts
+++ b/packages/cli/test/plugins-sync.test.ts
@@ -14,6 +14,26 @@ describe('plugins/shared path config sync', () => {
     expect(legacy).toBe(canonical);
   });
 
+  test('the GitHub Action metadata stays Marketplace-ready and version-aligned', () => {
+    const repoRoot = path.resolve(import.meta.dirname, '../../..');
+    const metadata = fs.readFileSync(path.join(repoRoot, 'action.yml'), 'utf8');
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, 'packages/cli/package.json'), 'utf8'),
+    ) as { version: string };
+
+    const descriptionBlock = metadata.match(/^description: >-\r?\n(?<lines>(?: {2}.+\r?\n)+)author:/m);
+    const description = descriptionBlock?.groups?.lines
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .join(' ');
+    const actionVersion = metadata.match(/^ {2}version:\r?\n(?: {4}.+\r?\n)+? {4}default: '([^']+)'/m)?.[1];
+
+    expect(description).toBeDefined();
+    expect(description!.length).toBeLessThan(125);
+    expect(actionVersion).toBe(packageJson.version);
+  });
+
   test('generated TOOL_PATHS matches PLUGIN_TOOL_PATHS from the CLI harness registry exactly', () => {
     for (const [toolId, paths] of Object.entries(PLUGIN_TOOL_PATHS)) {
       const tool = TOOL_PATHS[toolId as keyof typeof TOOL_PATHS];

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -1,12 +1,9 @@
 #!/usr/bin/env node
 /**
- * Mirrors packages/cli/package.json's version into the two other places
- * RELEASING.md requires it to match: TOOL_VERSION in score.ts and the
- * version field in jsr.json. Run by hand after `npx changeset version`
- * (which only bumps package.json + CHANGELOG.md) and before committing a
- * release — changesets doesn't know about either of these project-specific
- * files, so this closes that gap rather than asking a maintainer to keep
- * three files in sync by memory.
+ * Mirrors packages/cli/package.json's version into every release surface:
+ * TOOL_VERSION in score.ts, jsr.json, package-lock.json, and both GitHub
+ * Action entrypoints. Run after `npx changeset version` (which only bumps
+ * package.json + CHANGELOG.md) and before committing a release.
  */
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
@@ -19,6 +16,8 @@ const CLI_DIR = path.join(ROOT, 'packages', 'cli');
 const pkgPath = path.join(CLI_DIR, 'package.json');
 const scorePath = path.join(CLI_DIR, 'src', 'score.ts');
 const jsrPath = path.join(CLI_DIR, 'jsr.json');
+const lockPath = path.join(ROOT, 'package-lock.json');
+const actionPaths = [path.join(ROOT, 'action.yml'), path.join(ROOT, 'action', 'action.yml')];
 
 const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
 const version = pkg.version;
@@ -39,17 +38,35 @@ const jsr = JSON.parse(fs.readFileSync(jsrPath, 'utf8'));
 jsr.version = version;
 fs.writeFileSync(jsrPath, `${JSON.stringify(jsr, null, 2)}\n`);
 
-// JSON.stringify expands short arrays onto multiple lines; biome's formatter
-// collapses them. Without this pass, `version-packages` leaves main CI red
-// (exactly what broke the v1.3.1 release commit).
-const format = spawnSync('npx', ['biome', 'format', '--write', jsrPath], {
+const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+const cliLockEntry = lock.packages?.['packages/cli'];
+if (!cliLockEntry) {
+  console.error('Could not find packages["packages/cli"] in package-lock.json.');
+  process.exit(1);
+}
+cliLockEntry.version = version;
+fs.writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
+
+const actionVersionRe = /(^ {2}version:\r?\n(?: {4}.+\r?\n)+? {4}default: ')[^']+(')/m;
+for (const actionPath of actionPaths) {
+  const metadata = fs.readFileSync(actionPath, 'utf8');
+  if (!actionVersionRe.test(metadata)) {
+    console.error(`Could not find the version input default in ${path.relative(ROOT, actionPath)}.`);
+    process.exit(1);
+  }
+  fs.writeFileSync(actionPath, metadata.replace(actionVersionRe, `$1${version}$2`));
+}
+
+// JSON.stringify expands short arrays onto multiple lines; Biome restores the
+// repository's canonical JSON formatting.
+const format = spawnSync('npx', ['biome', 'format', '--write', jsrPath, lockPath], {
   cwd: ROOT,
   stdio: 'inherit',
   shell: process.platform === 'win32',
 });
 if (format.status !== 0) {
-  console.error('Failed to biome-format packages/cli/jsr.json after version sync.');
+  console.error('Failed to format versioned JSON files after version sync.');
   process.exit(format.status ?? 1);
 }
 
-console.log(`Synced TOOL_VERSION and jsr.json to ${version}.`);
+console.log(`Synced CLI, JSR, lockfile, and GitHub Action versions to ${version}.`);


### PR DESCRIPTION
## Summary

Prepare Harness Score v1.5.1 for its initial GitHub Marketplace Action release.

- shorten the Marketplace description to 102 characters
- pin the Action's default CLI version to `1.5.1` instead of `latest`
- pass Action inputs through intermediate environment variables before Bash uses them
- add an end-to-end CI smoke test for the packaged root Action, including outputs, badge, and Markdown report
- enforce Marketplace description length, root/legacy Action parity, and Action/package version alignment in tests
- replace documented `@main` usage with the stable `@v1` reference across the root README, Action README, and all localized guides
- synchronize the CLI, JSR manifest, lockfile, and both Action entrypoints during version bumps
- document Marketplace categories, release title, and the safe major-tag update sequence

## Why

GitHub's Marketplace release form rejected the existing 205-character Action description. The audit also found that consumers were directed to a mutable branch, the Action executed the mutable npm `latest` tag by default, Action inputs were interpolated directly into Bash, and CI did not exercise the packaged Action itself. The release workflow also publishes npm, GitHub Packages, and JSR for every GitHub Release, so all version surfaces need to stay aligned for the Marketplace release.

## User impact

After the release is published and the `v1` tag is created, users can consume `paladini/harness-score@v1` with reproducible default scanner behavior, safer input handling, and CI-backed Action packaging. Existing `action/` consumers remain compatible because the legacy metadata stays byte-for-byte aligned with the root entrypoint.

## Marketplace fields

- Primary category: **Code quality**
- Secondary category: **Continuous integration**
- Release title: **v1.5.1 — GitHub Marketplace launch**

## Validation

- `npm test` — 20 files, 268 tests passed
- `npm run lint` — passed; 18 pre-existing CSS warnings, no errors
- `npm run docs:build` — passed
- `npm run scan -- --min-level 4` — L4, 108/108
- `npm run plugins:sync-check` — passed
- `actionlint` v1.7.12 — passed
- local Action package-spec smoke — L4, 100%, badge and Markdown report generated
- `npm audit --omit=dev` — 0 vulnerabilities
- `npm pack -w harness-score --dry-run --json` — `harness-score@1.5.1`, 11 files
- `git diff --check` — passed

## Release boundary

This PR does not publish a GitHub Release, list the Action in Marketplace, or create/move the `v1` tag. Those steps remain gated on merge and a successful release workflow.