### PR TITLE
Fix sticky dark header contrast

### DIFF
--- a/.changeset/warm-dingos-smile.md
+++ b/.changeset/warm-dingos-smile.md
@@ -1,0 +1,5 @@
+---
+"harness-score": patch
+---
+
+Keep the navigation header legible after scrolling in dark mode.

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -60,6 +60,7 @@
   --hs-header-ink: #0d1b17;
   --hs-header-line: #cbd4c7;
   --hs-header-green: #119366;
+  --vp-nav-bg-color: var(--hs-header-paper);
 }
 
 /* Shared product header: mirrors the Harness Maturity Showcase shell. */


### PR DESCRIPTION
## Summary

- keep the shared product header on its light paper background after scrolling in dark mode
- reuse the existing `--hs-header-paper` token through VitePress's `--vp-nav-bg-color`
- add a patch changeset for the user-facing docs fix

## Root cause

VitePress removes the `.top` class from the home navigation after scrolling. Its more-specific sticky navigation selector then reapplies the dark `--vp-nav-bg-color`, while the Harness Score wordmark, navigation links, and controls retain their dark ink colors.

By setting VitePress's navigation background token to the existing Harness Score paper color, the built-in top, sticky, sidebar, and mobile states all resolve to the intended header background without new specificity overrides or `!important` declarations.

## Browser verification

Verified locally with Playwright:

- dark mode at 1904x993, both at the top and at `scrollY=600`
- internal guide page with sidebar
- light mode
- mobile 390x844 with navigation closed and open

In the reported desktop dark-mode scenario, the sticky header now remains `rgb(241, 244, 236)` with the wordmark and main links at `rgb(13, 27, 23)`.

## Validation

- `npm run docs:build`
- `npm test` — 268 tests passed
- `npm run lint` — passed with 18 pre-existing warnings and no errors
- `npm run scan -- --min-level 4` — L4, 108/108
- `git diff --check`