### PR TITLE
fix: fail closed on incomplete scans

### DIFF
--- a/.changeset/incomplete-verdicts.md
+++ b/.changeset/incomplete-verdicts.md
@@ -1,5 +1,0 @@
----
-'harness-score': patch
----
-
-Fail closed when repository or effective-scope filesystem walks are incomplete, with deterministic verdict reasons, diagnostic-only provisional output, and safe CLI, badge, diff, and GitHub Action behavior.

--- a/.changeset/incomplete-verdicts.md
+++ b/.changeset/incomplete-verdicts.md
@@ -1,0 +1,5 @@
+---
+'harness-score': patch
+---
+
+Fail closed when repository or effective-scope filesystem walks are incomplete, with deterministic verdict reasons, diagnostic-only provisional output, and safe CLI, badge, diff, and GitHub Action behavior.

--- a/.changeset/native-roots-hooks.md
+++ b/.changeset/native-roots-hooks.md
@@ -1,6 +1,0 @@
----
-"harness-score": patch
----
-
-Recognize supported tool directories as scan roots, select hook configurations deterministically,
-and validate the current Claude Code event and handler contract with forward-compatible warnings.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,29 @@ on:
   pull_request:
 
 jobs:
+  compatibility:
+    name: test (${{ matrix.os }}, Node ${{ matrix.node }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            node: 18
+          - os: windows-latest
+            node: 22
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      - name: test
+        run: npm test
+
   checks:
+    name: Full checks (ubuntu-latest, Node 22)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,6 +65,45 @@ jobs:
           test "$HS_PERCENT" = "100"
           test -s "$RUNNER_TEMP/harness-action-fixture/harness-badge.svg"
           test -s "$RUNNER_TEMP/harness-action-fixture/harness-report.md"
+      - name: Prepare incomplete GitHub Action smoke fixture
+        shell: bash
+        run: |
+          ROOT="$RUNNER_TEMP/harness-action-incomplete"
+          mkdir -p "$ROOT"
+          NESTED="$ROOT"
+          for DEPTH in $(seq 0 10); do
+            NESTED="$NESTED/d$DEPTH"
+            mkdir "$NESTED"
+          done
+      - name: Reject incomplete GitHub Action scan
+        id: action-incomplete
+        continue-on-error: true
+        uses: ./
+        with:
+          version: 'file:${{ github.workspace }}/packages/cli'
+          working-directory: ${{ runner.temp }}/harness-action-incomplete
+          min-level: '0'
+          badge: 'incomplete-badge.svg'
+          report: 'incomplete-report.md'
+      - name: Verify incomplete Action publishes no authoritative outputs or artifacts
+        if: ${{ always() }}
+        shell: bash
+        env:
+          HS_OUTCOME: ${{ steps.action-incomplete.outcome }}
+          HS_LEVEL: ${{ steps.action-incomplete.outputs.level }}
+          HS_LEVEL_NAME: ${{ steps.action-incomplete.outputs.level-name }}
+          HS_PERCENT: ${{ steps.action-incomplete.outputs.percent }}
+          HS_EFFECTIVE_LEVEL: ${{ steps.action-incomplete.outputs.effective-level }}
+          HS_EFFECTIVE_PERCENT: ${{ steps.action-incomplete.outputs.effective-percent }}
+        run: |
+          test "$HS_OUTCOME" = "failure"
+          test -z "$HS_LEVEL"
+          test -z "$HS_LEVEL_NAME"
+          test -z "$HS_PERCENT"
+          test -z "$HS_EFFECTIVE_LEVEL"
+          test -z "$HS_EFFECTIVE_PERCENT"
+          test ! -e "$RUNNER_TEMP/harness-action-incomplete/incomplete-badge.svg"
+          test ! -e "$RUNNER_TEMP/harness-action-incomplete/incomplete-report.md"
       - name: Consumer-facing type packaging check (typecheck:consumer)
         run: npm run typecheck:consumer -w harness-score
       - name: Published types match runtime exports (attw)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ with a concrete definition of what counts as public API:
 - **The `Report` JSON shape** — everything `--json` emits and the typed
   programmatic API exports — only gains fields in **minor** versions;
   removing or renaming a field is **major**.
-- **CLI flags and exit codes** (`0` pass, `1` gate failure, `2` usage error)
+- **CLI flags and exit codes** (`0` pass, `1` gate failure, `2` usage error or incomplete scan)
   are stable; removals are **major**.
 - **Maturity model evolution** (new checks, point totals, level thresholds)
   ships in **minor** versions — it changes what a repository *scores*, not

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
   version:
     description: 'harness-score npm version or package spec to run.'
     required: false
-    default: '1.5.2'
+    default: '1.5.3'
   comment:
     description: >-
       Post (or update) a sticky pull-request comment showing the harness

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ branding:
 
 inputs:
   min-level:
-    description: 'Fail the job when the maturity level is below this (0–4). Use 0 to never fail.'
+    description: 'Fail below this maturity level (0–4). Incomplete scans always fail, including at 0.'
     required: false
     default: '0'
   badge:
@@ -87,13 +87,51 @@ runs:
       run: |
         set -euo pipefail
         ARGS=(--quiet --json)
-        [ -n "$HS_BADGE" ] && ARGS+=(--badge "$HS_BADGE")
-        [ -n "$HS_REPORT" ] && ARGS+=(--md "$HS_REPORT")
         [ -n "$HS_CONFIG" ] && ARGS+=(--config "$HS_CONFIG")
         [ "$HS_INCLUDE_USER_HARNESS" = "true" ] && ARGS+=(--scope user)
         [ "$HS_INCLUDE_SYSTEM_HARNESS" = "true" ] && ARGS+=(--scope system)
         [ -n "$HS_GATE" ] && ARGS+=(--gate "$HS_GATE")
+        set +e
         npx -y "harness-score@$HS_VERSION" . "${ARGS[@]}" > harness-report.json
+        SCAN_STATUS=$?
+        set -e
+        if [ "$SCAN_STATUS" -ne 0 ] && [ "$SCAN_STATUS" -ne 2 ]; then
+          exit "$SCAN_STATUS"
+        fi
+
+        node <<'NODE'
+        const fs = require('fs');
+        const r = JSON.parse(fs.readFileSync('harness-report.json', 'utf8'));
+        const fallback = () => r.truncated
+          ? { status: 'incomplete', reasons: [{ code: 'file-count-limit' }] }
+          : { status: 'complete', reasons: [] };
+        const verdict = (scope) => r.verdicts?.[scope] ?? fallback();
+        const requested = ['maturity'];
+        if (r.scopes.effective.some((scope) => scope !== 'repo')) requested.push('effective');
+        const incomplete = requested.filter((scope) => verdict(scope).status === 'incomplete');
+        if (incomplete.length > 0) {
+          for (const scope of incomplete) {
+            const reasons = verdict(scope).reasons.map((reason) => {
+              const location = reason.path ? ` at ${reason.path}` : '';
+              const limit = reason.limit === undefined ? '' : ` (limit ${reason.limit})`;
+              return `${reason.code}${location}${limit}`;
+            }).join('; ');
+            console.error(`::error::Harness ${scope} scan is incomplete; no authoritative outputs were published: ${reasons}`);
+          }
+          process.exit(2);
+        }
+        NODE
+
+        ARTIFACT_ARGS=(--quiet)
+        [ -n "$HS_BADGE" ] && ARTIFACT_ARGS+=(--badge "$HS_BADGE")
+        [ -n "$HS_REPORT" ] && ARTIFACT_ARGS+=(--md "$HS_REPORT")
+        [ -n "$HS_CONFIG" ] && ARTIFACT_ARGS+=(--config "$HS_CONFIG")
+        [ "$HS_INCLUDE_USER_HARNESS" = "true" ] && ARTIFACT_ARGS+=(--scope user)
+        [ "$HS_INCLUDE_SYSTEM_HARNESS" = "true" ] && ARTIFACT_ARGS+=(--scope system)
+        [ -n "$HS_GATE" ] && ARTIFACT_ARGS+=(--gate "$HS_GATE")
+        if [ -n "$HS_BADGE" ] || [ -n "$HS_REPORT" ]; then
+          npx -y "harness-score@$HS_VERSION" . "${ARTIFACT_ARGS[@]}"
+        fi
 
         LEVEL=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).level.index")
         NAME=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).level.name")

--- a/action/README.md
+++ b/action/README.md
@@ -85,7 +85,7 @@ concurrency:
 | `badge` | `harness-badge.svg` | SVG pill (`harness` + level); empty to skip |
 | `report` | _(empty)_ | Markdown report output path |
 | `working-directory` | `.` | Directory to scan |
-| `version` | `latest` | harness-score npm version |
+| `version` | `1.5.3` | harness-score npm version or package spec |
 | `comment` | `false` | Post/update a sticky PR comment with the score delta (`pull_request` events only; requires `pull-requests: write`) |
 
 ## Outputs

--- a/action/README.md
+++ b/action/README.md
@@ -24,6 +24,8 @@ A per-run summary (level + dimension table) appears in the job summary. To
 publish the badge, upload it as an artifact or commit it to a `badges`
 branch, then reference it from your README:
 
+The Action fails closed when a requested filesystem scan is incomplete (file-count limit, depth limit, or unreadable directory). It exits before publishing level outputs, a badge, a Markdown report, a job summary, or a pull-request comment, even when `min-level` is `0`.
+
 Pin a full commit SHA instead of `v1` for maximum supply-chain stability. The legacy
 `paladini/harness-score/action@<ref>` entrypoint remains compatible, but the
 root entrypoint is recommended because GitHub dependency-review can associate
@@ -79,7 +81,7 @@ concurrency:
 
 | Input | Default | Description |
 |---|---|---|
-| `min-level` | `0` | Fail when maturity is below this level (0–4) |
+| `min-level` | `0` | Fail when maturity is below this level (0–4); incomplete scans always fail |
 | `badge` | `harness-badge.svg` | SVG pill (`harness` + level); empty to skip |
 | `report` | _(empty)_ | Markdown report output path |
 | `working-directory` | `.` | Directory to scan |

--- a/action/action.yml
+++ b/action/action.yml
@@ -27,7 +27,7 @@ inputs:
   version:
     description: 'harness-score npm version or package spec to run.'
     required: false
-    default: '1.5.2'
+    default: '1.5.3'
   comment:
     description: >-
       Post (or update) a sticky pull-request comment showing the harness

--- a/action/action.yml
+++ b/action/action.yml
@@ -9,7 +9,7 @@ branding:
 
 inputs:
   min-level:
-    description: 'Fail the job when the maturity level is below this (0–4). Use 0 to never fail.'
+    description: 'Fail below this maturity level (0–4). Incomplete scans always fail, including at 0.'
     required: false
     default: '0'
   badge:
@@ -87,13 +87,51 @@ runs:
       run: |
         set -euo pipefail
         ARGS=(--quiet --json)
-        [ -n "$HS_BADGE" ] && ARGS+=(--badge "$HS_BADGE")
-        [ -n "$HS_REPORT" ] && ARGS+=(--md "$HS_REPORT")
         [ -n "$HS_CONFIG" ] && ARGS+=(--config "$HS_CONFIG")
         [ "$HS_INCLUDE_USER_HARNESS" = "true" ] && ARGS+=(--scope user)
         [ "$HS_INCLUDE_SYSTEM_HARNESS" = "true" ] && ARGS+=(--scope system)
         [ -n "$HS_GATE" ] && ARGS+=(--gate "$HS_GATE")
+        set +e
         npx -y "harness-score@$HS_VERSION" . "${ARGS[@]}" > harness-report.json
+        SCAN_STATUS=$?
+        set -e
+        if [ "$SCAN_STATUS" -ne 0 ] && [ "$SCAN_STATUS" -ne 2 ]; then
+          exit "$SCAN_STATUS"
+        fi
+
+        node <<'NODE'
+        const fs = require('fs');
+        const r = JSON.parse(fs.readFileSync('harness-report.json', 'utf8'));
+        const fallback = () => r.truncated
+          ? { status: 'incomplete', reasons: [{ code: 'file-count-limit' }] }
+          : { status: 'complete', reasons: [] };
+        const verdict = (scope) => r.verdicts?.[scope] ?? fallback();
+        const requested = ['maturity'];
+        if (r.scopes.effective.some((scope) => scope !== 'repo')) requested.push('effective');
+        const incomplete = requested.filter((scope) => verdict(scope).status === 'incomplete');
+        if (incomplete.length > 0) {
+          for (const scope of incomplete) {
+            const reasons = verdict(scope).reasons.map((reason) => {
+              const location = reason.path ? ` at ${reason.path}` : '';
+              const limit = reason.limit === undefined ? '' : ` (limit ${reason.limit})`;
+              return `${reason.code}${location}${limit}`;
+            }).join('; ');
+            console.error(`::error::Harness ${scope} scan is incomplete; no authoritative outputs were published: ${reasons}`);
+          }
+          process.exit(2);
+        }
+        NODE
+
+        ARTIFACT_ARGS=(--quiet)
+        [ -n "$HS_BADGE" ] && ARTIFACT_ARGS+=(--badge "$HS_BADGE")
+        [ -n "$HS_REPORT" ] && ARTIFACT_ARGS+=(--md "$HS_REPORT")
+        [ -n "$HS_CONFIG" ] && ARTIFACT_ARGS+=(--config "$HS_CONFIG")
+        [ "$HS_INCLUDE_USER_HARNESS" = "true" ] && ARTIFACT_ARGS+=(--scope user)
+        [ "$HS_INCLUDE_SYSTEM_HARNESS" = "true" ] && ARTIFACT_ARGS+=(--scope system)
+        [ -n "$HS_GATE" ] && ARTIFACT_ARGS+=(--gate "$HS_GATE")
+        if [ -n "$HS_BADGE" ] || [ -n "$HS_REPORT" ]; then
+          npx -y "harness-score@$HS_VERSION" . "${ARTIFACT_ARGS[@]}"
+        fi
 
         LEVEL=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).level.index")
         NAME=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).level.name")

--- a/docs/es/guide/metrics-and-codes.md
+++ b/docs/es/guide/metrics-and-codes.md
@@ -187,8 +187,8 @@ Excluir una dimensión entera tiene una consecuencia honesta que vale la pena sa
 | `--config <file>` | Cargar config desde ruta específica |
 | `--scope user` | Habilitar scope user (separados por coma: `user`, `system`) |
 | `--gate maturity\|effective` | Puntaje usado para `--min-level` |
-| `--min-level <0-4>` | Exit 1 cuando el puntaje gated está bajo el nivel |
-| `--json` | Reporte completo incluyendo `scopes`, `gate`, `effective` |
+| `--min-level <0-4>` | Exit 1 cuando un puntaje gated completo está bajo el nivel; scopes solicitados incompletos siempre retornan exit 2 |
+| `--json` | Reporte completo incluyendo `scopes`, `gate`, `effective` y `verdicts` |
 
 ## Inputs de GitHub Action
 
@@ -201,6 +201,7 @@ Excluir una dimensión entera tiene una consecuencia honesta que vale la pena sa
 | `min-level` | `0` | Falla cuando el puntaje gated está bajo el nivel |
 
 Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effective-percent`.
+Si un scope solicitado está incompleto, la Action falla antes de publicar estos outputs, badge, reporte Markdown, resumen del job o comentario en la PR.
 
 ## Campos JSON del reporte (estables)
 
@@ -214,11 +215,15 @@ Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effect
 | `level`, `score`, `dimensions`, `checks` | Snapshot de **maturity** |
 | `effective` | Misma forma: `{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | Herramientas vistas en el **repo** (informativo) |
-| `truncated` | El walk alcanzó límite de archivos |
+| `verdicts.maturity`, `verdicts.effective` | Estado de completitud y motivos deterministas de cada snapshot: `complete` o `incomplete` |
+| `verdicts.*.reasons[]` | `file-count-limit`, `depth-limit` o `unreadable-directory`, con `path` y `limit` opcionales |
+| `truncated` | Alias de compatibilidad; `true` cuando cualquier snapshot solicitado está incompleto por cualquier motivo |
 | `preset` | `{ extends, rules, resolved }` — personalización de equipo efectivamente aplicada; `resolved` solo lista checks cuya severidad difiere del default |
 | `level.capped`, `level.capReason` | `capped` es `true` cuando un requisito bloqueante del siguiente nivel nunca puede cumplirse bajo la config actual (ej.: dimensión excluida por preset); `capReason` explica el motivo |
 | `dimensions[].applicable` | `false` solo cuando todo check de esa dimensión resolvió a `"off"` |
 | `checks[].severity` | `"off"` \| `"warn"` \| `"error"` — la severidad resuelta que este scan usó para ese check |
 | `checks[].warnings` | Diagnósticos opcionales y no fatales `{ code, message, source? }`; terminal y Markdown los muestran sin cambiar puntos |
 
-`--diff` compara campos de **maturity** por defecto (top-level `level` / `score` / `checks`).
+`level`, `score`, dimensiones y checks siguen presentes para diagnóstico, pero son provisionales cuando su veredicto es `incomplete`. Terminal y Markdown indican que la madurez no está disponible, y el badge usa `incomplete`, nunca L0-L4. Los reportes antiguos sin `verdicts` se consideran completos cuando `truncated` es `false` e incompletos cuando es `true`.
+
+`--diff` compara campos de **maturity** por defecto (top-level `level` / `score` / `checks`) y rechaza un baseline o resultado actual incompleto.

--- a/docs/guide/metrics-and-codes.md
+++ b/docs/guide/metrics-and-codes.md
@@ -187,8 +187,8 @@ Excluding an entire dimension has one honest consequence worth knowing up front:
 | `--config <file>` | Load config from a specific path |
 | `--scope user` | Enable user scope (comma-separated: `user`, `system`) |
 | `--gate maturity\|effective` | Score used for `--min-level` |
-| `--min-level <0-4>` | Exit 1 when gated score is below level |
-| `--json` | Full report including `scopes`, `gate`, `effective` |
+| `--min-level <0-4>` | Exit 1 when a complete gated score is below level; incomplete requested scopes always exit 2 |
+| `--json` | Full report including `scopes`, `gate`, `effective`, and `verdicts` |
 
 ## GitHub Action inputs
 
@@ -201,6 +201,7 @@ Excluding an entire dimension has one honest consequence worth knowing up front:
 | `min-level` | `0` | Fail when gated score is below level |
 
 Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effective-percent`.
+If a requested scan scope is incomplete, the Action fails before publishing any of these outputs, a badge, a Markdown report, a job summary, or a PR comment.
 
 ## Report JSON fields (stable)
 
@@ -214,11 +215,15 @@ Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effect
 | `level`, `score`, `dimensions`, `checks` | **Maturity** snapshot |
 | `effective` | Same shape: `{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | Tools seen in **repo** (informational) |
-| `truncated` | Walk hit file cap |
+| `verdicts.maturity`, `verdicts.effective` | Completeness status and deterministic reasons for each snapshot: `complete` or `incomplete` |
+| `verdicts.*.reasons[]` | `file-count-limit`, `depth-limit`, or `unreadable-directory`, with optional `path` and `limit` |
+| `truncated` | Compatibility alias; `true` when either requested snapshot is incomplete for any reason |
 | `preset` | `{ extends, rules, resolved }` — team customization actually applied; `resolved` lists only checks whose severity differs from the default |
 | `level.capped`, `level.capReason` | `capped` is `true` when a blocking requirement for the next level can never be met under the current config (e.g. its dimension was excluded by a preset); `capReason` explains why |
 | `dimensions[].applicable` | `false` only when every check in that dimension resolved to `"off"` |
 | `checks[].severity` | `"off"` \| `"warn"` \| `"error"` — the resolved severity this scan used for that check |
 | `checks[].warnings` | Optional non-fatal diagnostics `{ code, message, source? }`; terminal and Markdown render them without changing points |
 
-`--diff` compares **maturity** fields by default (top-level `level` / `score` / `checks`).
+`level`, `score`, dimensions, and checks remain present for diagnosis, but are provisional when their verdict is `incomplete`. Terminal and Markdown say the maturity is unavailable, and the badge value is `incomplete`, never L0-L4. Old reports without `verdicts` are treated as complete when `truncated` is `false`, and incomplete when it is `true`.
+
+`--diff` compares **maturity** fields by default (top-level `level` / `score` / `checks`) and rejects an incomplete baseline or current result.

--- a/docs/hi-IN/guide/metrics-and-codes.md
+++ b/docs/hi-IN/guide/metrics-and-codes.md
@@ -187,8 +187,8 @@ Precedence: **CLI flags → Action inputs → config file → defaults**। `ext
 | `--config <file>` | Specific path से config load करें |
 | `--scope user` | User scope enable (comma-separated: `user`, `system`) |
 | `--gate maturity\|effective` | `--min-level` के लिए score |
-| `--min-level <0-4>` | Gated score level से नीचे हो तो exit 1 |
-| `--json` | Full report including `scopes`, `gate`, `effective` |
+| `--min-level <0-4>` | Complete gated score level से नीचे हो तो exit 1; कोई requested scope incomplete हो तो हमेशा exit 2 |
+| `--json` | Full report including `scopes`, `gate`, `effective`, और `verdicts` |
 
 ## GitHub Action इनपुट
 
@@ -201,6 +201,7 @@ Precedence: **CLI flags → Action inputs → config file → defaults**। `ext
 | `min-level` | `0` | Gated score level से नीचे हो तो fail |
 
 Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effective-percent`.
+अगर कोई requested scope incomplete है, तो Action इन outputs, badge, Markdown report, job summary, या PR comment को publish करने से पहले fail होती है।
 
 ## Report JSON फ़ील्ड (स्थिर)
 
@@ -214,11 +215,15 @@ Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effect
 | `level`, `score`, `dimensions`, `checks` | **Maturity** snapshot |
 | `effective` | Same shape: `{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | **Repo** में देखे गए tools (informational) |
-| `truncated` | Walk file cap hit |
+| `verdicts.maturity`, `verdicts.effective` | हर snapshot का completeness status और deterministic reasons: `complete` या `incomplete` |
+| `verdicts.*.reasons[]` | `file-count-limit`, `depth-limit`, या `unreadable-directory`, optional `path` और `limit` के साथ |
+| `truncated` | Compatibility alias; किसी भी requested snapshot के किसी कारण से incomplete होने पर `true` |
 | `preset` | `{ extends, rules, resolved }` — इस scan में actually apply हुई team customization; `resolved` सिर्फ वे checks list करता है जिनकी severity default से अलग है |
 | `level.capped`, `level.capReason` | जब अगले level की कोई blocking requirement वर्तमान config में कभी पूरी नहीं हो सकती (जैसे उसकी dimension preset से excluded), तो `capped` `true` होता है; `capReason` वजह बताता है |
 | `dimensions[].applicable` | `false` सिर्फ तब जब उस dimension का हर check `"off"` resolve हुआ हो |
 | `checks[].severity` | `"off"` \| `"warn"` \| `"error"` — इस scan ने उस check के लिए जो resolved severity use की |
 | `checks[].warnings` | Optional non-fatal diagnostics `{ code, message, source? }`; terminal और Markdown इन्हें points बदले बिना दिखाते हैं |
 
-`--diff` default में **maturity** fields compare करता है (top-level `level` / `score` / `checks`)।
+`level`, `score`, dimensions, और checks diagnosis के लिए मौजूद रहते हैं, लेकिन संबंधित verdict `incomplete` होने पर provisional हैं। Terminal और Markdown maturity को unavailable दिखाते हैं, और badge value `incomplete` होती है, कभी L0-L4 नहीं। `verdicts` के बिना पुराने reports में `truncated: false` complete और `truncated: true` incomplete माना जाता है।
+
+`--diff` default में **maturity** fields compare करता है (top-level `level` / `score` / `checks`) और incomplete baseline या current result को reject करता है।

--- a/docs/pt-BR/guide/metrics-and-codes.md
+++ b/docs/pt-BR/guide/metrics-and-codes.md
@@ -187,8 +187,8 @@ Excluir uma dimensão inteira tem uma consequência honesta que vale saber de an
 | `--config <file>` | Carregar config de caminho específico |
 | `--scope user` | Habilitar escopo user (separados por vírgula: `user`, `system`) |
 | `--gate maturity\|effective` | Pontuação usada para `--min-level` |
-| `--min-level <0-4>` | Exit 1 quando pontuação gated está abaixo do nível |
-| `--json` | Relatório completo incluindo `scopes`, `gate`, `effective` |
+| `--min-level <0-4>` | Exit 1 quando uma pontuação gated completa está abaixo do nível; escopos solicitados incompletos sempre retornam exit 2 |
+| `--json` | Relatório completo incluindo `scopes`, `gate`, `effective` e `verdicts` |
 
 ## Inputs da GitHub Action
 
@@ -201,6 +201,7 @@ Excluir uma dimensão inteira tem uma consequência honesta que vale saber de an
 | `min-level` | `0` | Falha quando pontuação gated está abaixo do nível |
 
 Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effective-percent`.
+Se um escopo solicitado estiver incompleto, a Action falha antes de publicar esses outputs, badge, relatório Markdown, resumo do job ou comentário na PR.
 
 ## Campos JSON do relatório (estáveis)
 
@@ -214,11 +215,15 @@ Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effect
 | `level`, `score`, `dimensions`, `checks` | Snapshot de **maturity** |
 | `effective` | Mesma forma: `{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | Ferramentas vistas no **repo** (informativo) |
-| `truncated` | Walk atingiu limite de arquivos |
+| `verdicts.maturity`, `verdicts.effective` | Status de completude e motivos determinísticos de cada snapshot: `complete` ou `incomplete` |
+| `verdicts.*.reasons[]` | `file-count-limit`, `depth-limit` ou `unreadable-directory`, com `path` e `limit` opcionais |
+| `truncated` | Alias de compatibilidade; `true` quando qualquer snapshot solicitado está incompleto por qualquer motivo |
 | `preset` | `{ extends, rules, resolved }` — personalização de equipe efetivamente aplicada; `resolved` só lista checks cuja severidade difere do padrão |
 | `level.capped`, `level.capReason` | `capped` é `true` quando um requisito bloqueante do próximo nível nunca pode ser satisfeito sob a config atual (ex.: dimensão excluída por preset); `capReason` explica o motivo |
 | `dimensions[].applicable` | `false` só quando todo check daquela dimensão resolveu para `"off"` |
 | `checks[].severity` | `"off"` \| `"warn"` \| `"error"` — a severidade resolvida usada por este scan para aquele check |
 | `checks[].warnings` | Diagnósticos opcionais e não fatais `{ code, message, source? }`; terminal e Markdown os exibem sem alterar pontos |
 
-`--diff` compara campos de **maturity** por padrão (top-level `level` / `score` / `checks`).
+`level`, `score`, dimensões e checks continuam presentes para diagnóstico, mas são provisórios quando o veredito correspondente é `incomplete`. Terminal e Markdown informam que a maturidade está indisponível, e o badge usa `incomplete`, nunca L0-L4. Relatórios antigos sem `verdicts` são completos quando `truncated` é `false` e incompletos quando é `true`.
+
+`--diff` compara campos de **maturity** por padrão (top-level `level` / `score` / `checks`) e rejeita baseline ou resultado atual incompleto.

--- a/docs/zh-CN/guide/metrics-and-codes.md
+++ b/docs/zh-CN/guide/metrics-and-codes.md
@@ -184,8 +184,8 @@
 | `--config <file>` | 从指定路径加载配置 |
 | `--scope user` | 启用 user scope（逗号分隔：`user`、`system`） |
 | `--gate maturity\|effective` | `--min-level` 使用的分数 |
-| `--min-level <0-4>` | gated 分数低于等级时 exit 1 |
-| `--json` | 完整报告，含 `scopes`、`gate`、`effective` |
+| `--min-level <0-4>` | 完整 gated 分数低于等级时 exit 1；任何请求的 scope 不完整时始终 exit 2 |
+| `--json` | 完整报告，含 `scopes`、`gate`、`effective` 与 `verdicts` |
 
 ## GitHub Action 输入
 
@@ -198,6 +198,7 @@
 | `min-level` | `0` | gated 分数低于等级时失败 |
 
 Outputs：`level`、`level-name`、`percent`（maturity）；`effective-level`、`effective-percent`。
+若请求的 scope 不完整，Action 会在发布这些 outputs、badge、Markdown 报告、job summary 或 PR comment 前失败。
 
 ## 报告 JSON 字段（稳定）
 
@@ -216,6 +217,10 @@ Outputs：`level`、`level-name`、`percent`（maturity）；`effective-level`�
 | `checks[].warnings` | 可选的非致命诊断 `{ code, message, source? }`；terminal 与 Markdown 会显示它们，但不改变分数 |
 | `effective` | 相同结构：`{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | **repo** 中看到的工具（仅供参考） |
-| `truncated` | 遍历达到文件上限 |
+| `verdicts.maturity`、`verdicts.effective` | 每个 snapshot 的完整性状态与确定性原因：`complete` 或 `incomplete` |
+| `verdicts.*.reasons[]` | `file-count-limit`、`depth-limit` 或 `unreadable-directory`，可带 `path` 与 `limit` |
+| `truncated` | 兼容别名；任一请求的 snapshot 因任何原因不完整时为 `true` |
 
-`--diff` 默认比较 **maturity** 字段（顶层 `level` / `score` / `checks`）。
+`level`、`score`、dimensions 与 checks 仍会保留用于诊断，但对应 verdict 为 `incomplete` 时仅是 provisional。Terminal 与 Markdown 会显示 maturity unavailable，badge 值为 `incomplete`，绝不显示 L0-L4。旧报告缺少 `verdicts` 时，`truncated: false` 视为完整，`truncated: true` 视为不完整。
+
+`--diff` 默认比较 **maturity** 字段（顶层 `level` / `score` / `checks`），并拒绝不完整的 baseline 或当前结果。

--- a/package-lock.json
+++ b/package-lock.json
@@ -6799,7 +6799,7 @@
     },
     "packages/cli": {
       "name": "harness-score",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "MIT",
       "bin": {
         "harness-score": "dist/cli.js"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # harness-score
 
+## 1.5.3
+
+### Patch Changes
+
+- 0007d96: Fail closed when repository or effective-scope filesystem walks are incomplete, with deterministic verdict reasons, diagnostic-only provisional output, and safe CLI, badge, diff, and GitHub Action behavior.
+- 653de57: Recognize supported tool directories as scan roots, select hook configurations deterministically,
+  and validate the current Claude Code event and handler contract with forward-compatible warnings.
+
 ## 1.5.2
 
 ### Patch Changes

--- a/packages/cli/bench/scan.bench.mjs
+++ b/packages/cli/bench/scan.bench.mjs
@@ -60,6 +60,10 @@ for (let i = 0; i < ITERATIONS; i += 1) {
 }
 
 const avg = timings.reduce((a, b) => a + b, 0) / timings.length;
+const sorted = [...timings].sort((a, b) => a - b);
+const midpoint = Math.floor(sorted.length / 2);
+const median = sorted.length % 2 === 0 ? (sorted[midpoint - 1] + sorted[midpoint]) / 2 : sorted[midpoint];
 console.log(`\nAverage over ${ITERATIONS} runs: ${avg.toFixed(1)}ms (${FILE_COUNT} files)`);
+console.log(`Median over ${ITERATIONS} runs: ${median.toFixed(1)}ms (${FILE_COUNT} files)`);
 
 fs.rmSync(root, { recursive: true, force: true });

--- a/packages/cli/jsr.json
+++ b/packages/cli/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@paladini/harness-score",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-score",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Deterministic AI coding harness-maturity scanner for AI-assisted repositories (Cursor-flagship, expanding to other AI-first dev tools). Zero LLM calls, zero network, zero runtime dependencies.",
   "type": "module",
   "bin": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,6 +14,7 @@ import { renderMarkdown } from './report/markdown.js';
 import { renderTerminal } from './report/terminal.js';
 import { buildReport, TOOL_VERSION } from './score.js';
 import type { Report } from './types.js';
+import { formatIncompleteReason, reportScopeIsComplete, reportVerdict } from './verdict.js';
 
 const HELP = `harness-score — deterministic harness-maturity scanner for AI-assisted repositories
 
@@ -32,6 +33,8 @@ Options:
   --quiet              Suppress the terminal report
   --version            Print version
   --help               Show this help
+
+Exit codes: 0 complete/pass, 1 complete scan below --min-level, 2 invalid usage or incomplete requested scan.
 
 Configuration file (optional): .harness-score.json in the scan root.
 See the guide: https://paladini.github.io/harness-score/guide/measure-and-improve
@@ -169,6 +172,16 @@ function gatedLevel(report: Report): Report['level'] {
   return report.level;
 }
 
+function requestedVerdictScopes(report: Report): Array<'maturity' | 'effective'> {
+  const scopes: Array<'maturity' | 'effective'> = ['maturity'];
+  if (report.scopes.effective.some((scope) => scope !== 'repo')) scopes.push('effective');
+  return scopes;
+}
+
+function incompleteRequestedScopes(report: Report): Array<'maturity' | 'effective'> {
+  return requestedVerdictScopes(report).filter((scope) => !reportScopeIsComplete(report, scope));
+}
+
 const args = parseArgs(process.argv.slice(2));
 const rootAbs = path.resolve(args.root);
 if (!fs.existsSync(rootAbs) || !fs.statSync(rootAbs).isDirectory()) {
@@ -204,6 +217,12 @@ if (args.diff !== null) {
     );
   }
   baseline = parsed;
+  if (!reportScopeIsComplete(baseline, 'maturity')) {
+    fail('--diff: baseline maturity report is incomplete and cannot be compared.');
+  }
+  if (!reportScopeIsComplete(report, 'maturity')) {
+    fail('--diff: current maturity report is incomplete and cannot be compared.');
+  }
   diff = computeDiff(baseline, report);
 }
 
@@ -227,6 +246,18 @@ if (args.md !== null) {
 if (args.badge !== null) {
   fs.writeFileSync(args.badge, renderBadge(report), 'utf8');
   if (!args.quiet) process.stderr.write(`badge written to ${args.badge}\n`);
+}
+
+const incompleteScopes = incompleteRequestedScopes(report);
+if (incompleteScopes.length > 0) {
+  for (const scope of incompleteScopes) {
+    const reasons = reportVerdict(report, scope).reasons.map(formatIncompleteReason).join('; ');
+    process.stderr.write(
+      `harness-score: ${scope} scan is incomplete; no authoritative verdict is available` +
+        `${reasons ? `: ${reasons}` : '.'}\n`,
+    );
+  }
+  process.exit(2);
 }
 
 if (args.minLevel !== null) {

--- a/packages/cli/src/diff.ts
+++ b/packages/cli/src/diff.ts
@@ -1,4 +1,5 @@
 import type { DimensionId, Report } from './types.js';
+import { reportScopeIsComplete } from './verdict.js';
 
 export interface DimensionDelta {
   id: DimensionId;
@@ -50,6 +51,9 @@ const EMPTY_PRESET: Report['preset'] = { extends: [], rules: {}, resolved: [] };
  * regression or improvement in the scanned repository.
  */
 export function computeDiff(baseline: Report, current: Report): ReportDiff {
+  if (!reportScopeIsComplete(baseline, 'maturity') || !reportScopeIsComplete(current, 'maturity')) {
+    throw new Error('Cannot compare incomplete maturity reports.');
+  }
   const baselineChecks = new Map(baseline.checks.map((c) => [c.id, c]));
   const checksChanged: CheckDelta[] = [];
   for (const check of current.checks) {

--- a/packages/cli/src/harness/global-paths.ts
+++ b/packages/cli/src/harness/global-paths.ts
@@ -3,10 +3,24 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ExtraRootEntry } from '../config.js';
 import type { ScanOverlay } from '../scan.js';
+import type { ScanIncompleteReason } from '../types.js';
+import { compareLexically } from '../util.js';
 import { PATH_SPECS } from './registry.js';
 
 const OVERLAY_MAX_DEPTH = 8;
 const OVERLAY_MAX_FILES = 5000;
+
+interface CollectionResult {
+  incompleteReasons: ScanIncompleteReason[];
+}
+
+function addFirstReason(reasons: ScanIncompleteReason[], reason: ScanIncompleteReason): void {
+  if (!reasons.some((entry) => entry.code === reason.code)) reasons.push(reason);
+}
+
+function mergeReasons(target: ScanIncompleteReason[], source: ScanIncompleteReason[]): void {
+  for (const reason of source) addFirstReason(target, reason);
+}
 
 /** Repo-relative paths that may appear under user/system/extra harness trees. */
 function isHarnessRelPath(relPath: string): boolean {
@@ -33,22 +47,30 @@ function collectDir(
   relPrefix: string,
   files: Map<string, string>,
   depth = 0,
-): { truncated: boolean } {
-  let truncated = false;
-  if (depth > OVERLAY_MAX_DEPTH) return { truncated };
+): CollectionResult {
+  const incompleteReasons: ScanIncompleteReason[] = [];
   const stat = safeStat(absDir);
-  if (!stat?.isDirectory()) return { truncated };
+  if (!stat?.isDirectory()) return { incompleteReasons };
 
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(absDir, { withFileTypes: true });
   } catch {
-    return { truncated };
+    addFirstReason(incompleteReasons, {
+      code: 'unreadable-directory',
+      path: relPrefix || '.',
+    });
+    return { incompleteReasons };
   }
+  entries.sort((a, b) => compareLexically(a.name, b.name));
 
   for (const entry of entries) {
     if (files.size >= OVERLAY_MAX_FILES) {
-      truncated = true;
+      addFirstReason(incompleteReasons, {
+        code: 'file-count-limit',
+        path: relPrefix === '' ? entry.name : `${relPrefix}/${entry.name}`,
+        limit: OVERLAY_MAX_FILES,
+      });
       break;
     }
     const abs = path.join(absDir, entry.name);
@@ -56,37 +78,47 @@ function collectDir(
     const relPosix = toPosixRel(rel);
 
     if (entry.isDirectory()) {
+      if (depth >= OVERLAY_MAX_DEPTH) {
+        addFirstReason(incompleteReasons, {
+          code: 'depth-limit',
+          path: relPosix,
+          limit: OVERLAY_MAX_DEPTH,
+        });
+        continue;
+      }
       const sub = collectDir(abs, relPosix, files, depth + 1);
-      if (sub.truncated) truncated = true;
+      mergeReasons(incompleteReasons, sub.incompleteReasons);
     } else if (entry.isFile()) {
       if (isHarnessRelPath(relPosix)) {
         files.set(relPosix, abs);
       }
     }
   }
-  return { truncated };
+  return { incompleteReasons };
 }
 
 /** Map flat files in a directory to a repo-relative prefix (e.g. Cline global rules). */
-function collectShallowDir(
-  absDir: string,
-  relPrefix: string,
-  files: Map<string, string>,
-): { truncated: boolean } {
-  let truncated = false;
+function collectShallowDir(absDir: string, relPrefix: string, files: Map<string, string>): CollectionResult {
+  const incompleteReasons: ScanIncompleteReason[] = [];
   const stat = safeStat(absDir);
-  if (!stat?.isDirectory()) return { truncated };
+  if (!stat?.isDirectory()) return { incompleteReasons };
 
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(absDir, { withFileTypes: true });
   } catch {
-    return { truncated };
+    addFirstReason(incompleteReasons, { code: 'unreadable-directory', path: relPrefix });
+    return { incompleteReasons };
   }
+  entries.sort((a, b) => compareLexically(a.name, b.name));
 
   for (const entry of entries) {
     if (files.size >= OVERLAY_MAX_FILES) {
-      truncated = true;
+      addFirstReason(incompleteReasons, {
+        code: 'file-count-limit',
+        path: `${relPrefix}/${entry.name}`,
+        limit: OVERLAY_MAX_FILES,
+      });
       break;
     }
     if (!entry.isFile()) continue;
@@ -95,7 +127,7 @@ function collectShallowDir(
       files.set(relPosix, path.join(absDir, entry.name));
     }
   }
-  return { truncated };
+  return { incompleteReasons };
 }
 
 function collectFile(absFile: string, relPath: string, files: Map<string, string>): void {
@@ -187,15 +219,18 @@ function clineGlobalRulesDirs(home: string): string[] {
 }
 
 /** Walk an extra root and collect harness-shaped relative paths. */
-function collectExtraRoot(absRoot: string, files: Map<string, string>): { truncated: boolean } {
-  let truncated = false;
+function collectExtraRoot(absRoot: string, files: Map<string, string>): CollectionResult {
+  const incompleteReasons: ScanIncompleteReason[] = [];
   const stat = safeStat(absRoot);
-  if (!stat) return { truncated };
+  if (!stat) {
+    addFirstReason(incompleteReasons, { code: 'unreadable-directory', path: '.' });
+    return { incompleteReasons };
+  }
 
   if (stat.isFile()) {
     const rel = toPosixRel(path.basename(absRoot));
     if (isHarnessRelPath(rel)) files.set(rel, absRoot);
-    return { truncated };
+    return { incompleteReasons };
   }
 
   if (stat.isDirectory()) {
@@ -203,29 +238,44 @@ function collectExtraRoot(absRoot: string, files: Map<string, string>): { trunca
     try {
       entries = fs.readdirSync(absRoot, { withFileTypes: true });
     } catch {
-      return { truncated };
+      addFirstReason(incompleteReasons, { code: 'unreadable-directory', path: '.' });
+      return { incompleteReasons };
     }
+    entries.sort((a, b) => compareLexically(a.name, b.name));
     for (const entry of entries) {
       if (files.size >= OVERLAY_MAX_FILES) {
-        truncated = true;
+        addFirstReason(incompleteReasons, {
+          code: 'file-count-limit',
+          path: entry.name,
+          limit: OVERLAY_MAX_FILES,
+        });
         break;
       }
       const abs = path.join(absRoot, entry.name);
       const relPosix = toPosixRel(entry.name);
       if (entry.isDirectory()) {
         const sub = collectDir(abs, relPosix, files, 1);
-        if (sub.truncated) truncated = true;
+        mergeReasons(incompleteReasons, sub.incompleteReasons);
       } else if (entry.isFile() && isHarnessRelPath(relPosix)) {
         files.set(relPosix, abs);
       }
     }
   }
-  return { truncated };
+  return { incompleteReasons };
 }
 
-function overlayFromMap(label: string, files: Map<string, string>, truncated: boolean): ScanOverlay | null {
-  if (files.size === 0) return null;
-  return { label, files, truncated };
+function overlayFromMap(
+  label: string,
+  files: Map<string, string>,
+  incompleteReasons: ScanIncompleteReason[],
+): ScanOverlay | null {
+  if (files.size === 0 && incompleteReasons.length === 0) return null;
+  return {
+    label,
+    files,
+    truncated: incompleteReasons.length > 0,
+    incompleteReasons,
+  };
 }
 
 /** User-level harness locations (OS-aware, allowlisted only). */
@@ -233,23 +283,23 @@ export function buildUserOverlay(): ScanOverlay | null {
   const home = userHome();
   const xdg = xdgConfigHome();
   const files = new Map<string, string>();
-  let truncated = false;
+  const incompleteReasons: ScanIncompleteReason[] = [];
 
   for (const [absDir, relPrefix] of userHarnessDirs(home, xdg)) {
     const result = collectDir(absDir, relPrefix, files);
-    if (result.truncated) truncated = true;
+    mergeReasons(incompleteReasons, result.incompleteReasons);
   }
 
   for (const dir of clineGlobalRulesDirs(home)) {
     const result = collectShallowDir(dir, '.clinerules', files);
-    if (result.truncated) truncated = true;
+    mergeReasons(incompleteReasons, result.incompleteReasons);
   }
 
   for (const [abs, rel] of userHarnessFileAliases(home)) {
     collectFile(abs, rel, files);
   }
 
-  return overlayFromMap('user', files, truncated);
+  return overlayFromMap('user', files, incompleteReasons);
 }
 
 /** System-level harness locations (minimal v1 — expand when paths are validated). */
@@ -261,8 +311,8 @@ export function buildSystemOverlay(): ScanOverlay | null {
 export function buildExtraRootOverlay(repoRoot: string, entry: ExtraRootEntry): ScanOverlay | null {
   const absRoot = path.resolve(repoRoot, entry.path);
   const files = new Map<string, string>();
-  const { truncated } = collectExtraRoot(absRoot, files);
-  return overlayFromMap(entry.id, files, truncated);
+  const { incompleteReasons } = collectExtraRoot(absRoot, files);
+  return overlayFromMap(entry.id, files, incompleteReasons);
 }
 
 export interface ResolvedOverlayRoots {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,6 +30,8 @@ export {
   TOOL_VERSION,
 } from './score.js';
 export type * from './types.js';
+export type { VerdictScope } from './verdict.js';
+export { formatIncompleteReason, reportScopeIsComplete, reportVerdict } from './verdict.js';
 
 import { type CliConfigOverrides, resolveScanConfig } from './config.js';
 import { buildReport } from './score.js';

--- a/packages/cli/src/report/badge.ts
+++ b/packages/cli/src/report/badge.ts
@@ -1,4 +1,5 @@
 import type { Report } from '../types.js';
+import { reportScopeIsComplete } from '../verdict.js';
 
 const H = 20;
 const R = 3;
@@ -11,6 +12,7 @@ const PAD = 7;
 const LABEL_SEG = 76;
 /** Right segment fits L4 — keep in sync with generate.mjs BADGE_VALUE_SEG. */
 const VALUE_SEG = 36;
+const INCOMPLETE_VALUE_SEG = 64;
 const BAR_X = 10;
 const LABEL_X = 28;
 const VALUE_X = LABEL_SEG + PAD;
@@ -42,8 +44,8 @@ function badgeBody(total: number, value: string): string {
  * shields.io pattern: 20px height, 11px Verdana, fixed width (level only).
  */
 export function renderBadge(report: Report): string {
-  const value = `L${report.level.index}`;
-  const total = LABEL_SEG + VALUE_SEG;
+  const value = reportScopeIsComplete(report, 'maturity') ? `L${report.level.index}` : 'incomplete';
+  const total = LABEL_SEG + (value === 'incomplete' ? INCOMPLETE_VALUE_SEG : VALUE_SEG);
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="${H}" viewBox="0 0 ${total} ${H}" role="img" aria-label="Harness Score ${value}">
   <title>Harness Score: ${value}</title>

--- a/packages/cli/src/report/markdown.ts
+++ b/packages/cli/src/report/markdown.ts
@@ -1,6 +1,7 @@
 import type { ReportDiff } from '../diff.js';
 import { toolDisplayName } from '../harness/registry.js';
 import type { Report } from '../types.js';
+import { formatIncompleteReason, reportScopeIsComplete, reportVerdict } from '../verdict.js';
 
 function signed(n: number): string {
   return n > 0 ? `+${n}` : `${n}`;
@@ -58,18 +59,35 @@ function renderDiffSection(diff: ReportDiff): string[] {
 
 export function renderMarkdown(report: Report, diff?: ReportDiff | null): string {
   const lines: string[] = [];
+  const maturityComplete = reportScopeIsComplete(report, 'maturity');
+  const effectiveComplete = reportScopeIsComplete(report, 'effective');
+  const showEffective =
+    report.scopes.effective.some((scope) => scope !== 'repo') ||
+    effectiveComplete !== maturityComplete ||
+    report.effective.level.index !== report.level.index ||
+    report.effective.score.percent !== report.score.percent;
   lines.push(`# Harness Score Report`);
   lines.push('');
-  lines.push(`**Maturity level:** L${report.level.index} · ${report.level.name}`);
-  lines.push(`**Maturity score:** ${report.score.earned}/${report.score.max} (${report.score.percent}%)`);
+  if (maturityComplete) {
+    lines.push(`**Maturity level:** L${report.level.index} · ${report.level.name}`);
+    lines.push(`**Maturity score:** ${report.score.earned}/${report.score.max} (${report.score.percent}%)`);
+  } else {
+    lines.push('**Maturity:** unavailable - incomplete scan');
+    lines.push(
+      `**Provisional maturity score:** ${report.score.earned}/${report.score.max} (${report.score.percent}%)`,
+    );
+  }
   lines.push(`**Maturity scopes:** ${report.scopes.maturity.join(', ')}`);
-  if (
-    report.effective.level.index !== report.level.index ||
-    report.effective.score.percent !== report.score.percent
-  ) {
+  if (showEffective && effectiveComplete) {
     lines.push(`**Effective level:** L${report.effective.level.index} · ${report.effective.level.name}`);
     lines.push(
       `**Effective score:** ${report.effective.score.earned}/${report.effective.score.max} (${report.effective.score.percent}%)`,
+    );
+    lines.push(`**Effective scopes:** ${report.scopes.effective.join(', ')}`);
+  } else if (showEffective) {
+    lines.push('**Effective:** unavailable - incomplete scan');
+    lines.push(
+      `**Provisional effective score:** ${report.effective.score.earned}/${report.effective.score.max} (${report.effective.score.percent}%)`,
     );
     lines.push(`**Effective scopes:** ${report.scopes.effective.join(', ')}`);
   }
@@ -85,10 +103,27 @@ export function renderMarkdown(report: Report, diff?: ReportDiff | null): string
     lines.push(`**Preset:** ${extendsLabel}${offText}`);
   }
   lines.push('');
+  if (!maturityComplete || (showEffective && !effectiveComplete)) {
+    lines.push('> ⚠ This scan is incomplete. Provisional scores and checks are not authoritative.');
+    lines.push('');
+    lines.push('## Incomplete scan reasons');
+    lines.push('');
+    if (!maturityComplete) {
+      for (const reason of reportVerdict(report, 'maturity').reasons) {
+        lines.push(`- **maturity:** ${formatIncompleteReason(reason)}`);
+      }
+    }
+    if (showEffective && !effectiveComplete) {
+      for (const reason of reportVerdict(report, 'effective').reasons) {
+        lines.push(`- **effective:** ${formatIncompleteReason(reason)}`);
+      }
+    }
+    lines.push('');
+  }
   if (diff) {
     lines.push(...renderDiffSection(diff));
   }
-  lines.push('## Dimensions');
+  lines.push(maturityComplete ? '## Dimensions' : '## Provisional dimensions');
   lines.push('');
   lines.push('| Dimension | Score | % |');
   lines.push('|---|---|---|');
@@ -99,7 +134,7 @@ export function renderMarkdown(report: Report, diff?: ReportDiff | null): string
     lines.push(`| ${dimension.title} | ${cell} |`);
   }
   lines.push('');
-  lines.push('## Checks');
+  lines.push(maturityComplete ? '## Checks' : '## Provisional checks');
   lines.push('');
   lines.push('| | Check | Points | Evidence |');
   lines.push('|---|---|---|---|');
@@ -138,7 +173,7 @@ export function renderMarkdown(report: Report, diff?: ReportDiff | null): string
       lines.push(`- **${check.id}** — ${check.remediation} ([guide](${check.docsUrl}))`);
     }
   }
-  if (report.level.nextLevelGaps.length > 0) {
+  if (maturityComplete && report.level.nextLevelGaps.length > 0) {
     lines.push('');
     lines.push(`**To reach L${report.level.index + 1}:** ${report.level.nextLevelGaps.join('; ')}`);
     if (report.level.capped && report.level.capReason) {

--- a/packages/cli/src/report/terminal.ts
+++ b/packages/cli/src/report/terminal.ts
@@ -1,6 +1,7 @@
 import type { ReportDiff } from '../diff.js';
 import { toolDisplayName } from '../harness/registry.js';
 import type { Report } from '../types.js';
+import { formatIncompleteReason, reportScopeIsComplete, reportVerdict } from '../verdict.js';
 
 const useColor = process.stdout.isTTY === true && process.env.NO_COLOR === undefined;
 
@@ -77,8 +78,19 @@ function renderDiffSection(diff: ReportDiff): string[] {
 
 function effectiveDiffers(report: Report): boolean {
   return (
+    reportVerdict(report, 'effective').status !== reportVerdict(report, 'maturity').status ||
     report.effective.level.index !== report.level.index ||
     report.effective.score.percent !== report.score.percent
+  );
+}
+
+function hasEffectiveScope(report: Report): boolean {
+  return report.scopes.effective.some((scope) => scope !== 'repo');
+}
+
+function renderIncompleteReasons(report: Report, scope: 'maturity' | 'effective'): string[] {
+  return reportVerdict(report, scope).reasons.map(
+    (reason) => `    ${yellow(WARN)} ${scope}: ${formatIncompleteReason(reason)}`,
   );
 }
 
@@ -89,28 +101,43 @@ function formatScopes(scopes: string[]): string {
 export function renderTerminal(report: Report, diff?: ReportDiff | null): string {
   const lines: string[] = [];
   const levelPaint = LEVEL_COLOR[report.level.index] ?? red;
+  const maturityComplete = reportScopeIsComplete(report, 'maturity');
+  const effectiveComplete = reportScopeIsComplete(report, 'effective');
+  const showEffective = hasEffectiveScope(report) || effectiveDiffers(report);
   lines.push('');
   lines.push(bold(`  harness-score v${report.tool.version}`) + dim(`  ${report.root}`));
   lines.push('');
-  if (report.truncated) {
-    lines.push(
-      yellow(
-        `  ${WARN} Scan stopped early after hitting the file-count cap ${MIDDOT} results below may be incomplete.`,
-      ),
-    );
+  if (!maturityComplete || (showEffective && !effectiveComplete)) {
+    lines.push(yellow(`  ${WARN} Incomplete scan ${MIDDOT} provisional results are not authoritative.`));
+    if (!maturityComplete) lines.push(...renderIncompleteReasons(report, 'maturity'));
+    if (showEffective && !effectiveComplete) lines.push(...renderIncompleteReasons(report, 'effective'));
     lines.push('');
   }
-  const cappedMarker = report.level.capped ? ` ${yellow('(capped)')}` : '';
-  lines.push(
-    `  ${bold('Maturity:')} ${levelPaint(bold(`L${report.level.index} ${MIDDOT} ${report.level.name}`))}${cappedMarker}` +
-      `   ${bold('Score:')} ${report.score.earned}/${report.score.max} (${report.score.percent}%)` +
-      dim(`   scopes: ${formatScopes(report.scopes.maturity)}`),
-  );
-  if (effectiveDiffers(report)) {
+  if (maturityComplete) {
+    const cappedMarker = report.level.capped ? ` ${yellow('(capped)')}` : '';
+    lines.push(
+      `  ${bold('Maturity:')} ${levelPaint(bold(`L${report.level.index} ${MIDDOT} ${report.level.name}`))}${cappedMarker}` +
+        `   ${bold('Score:')} ${report.score.earned}/${report.score.max} (${report.score.percent}%)` +
+        dim(`   scopes: ${formatScopes(report.scopes.maturity)}`),
+    );
+  } else {
+    lines.push(
+      `  ${bold('Maturity:')} ${yellow(bold('unavailable - incomplete scan'))}` +
+        `   ${bold('Provisional score:')} ${report.score.earned}/${report.score.max} (${report.score.percent}%)` +
+        dim(`   scopes: ${formatScopes(report.scopes.maturity)}`),
+    );
+  }
+  if (showEffective && effectiveComplete) {
     const effPaint = LEVEL_COLOR[report.effective.level.index] ?? red;
     lines.push(
       `  ${bold('Effective:')} ${effPaint(bold(`L${report.effective.level.index} ${MIDDOT} ${report.effective.level.name}`))}` +
         `   ${bold('Score:')} ${report.effective.score.earned}/${report.effective.score.max} (${report.effective.score.percent}%)` +
+        dim(`   scopes: ${formatScopes(report.scopes.effective)}`),
+    );
+  } else if (showEffective) {
+    lines.push(
+      `  ${bold('Effective:')} ${yellow(bold('unavailable - incomplete scan'))}` +
+        `   ${bold('Provisional score:')} ${report.effective.score.earned}/${report.effective.score.max} (${report.effective.score.percent}%)` +
         dim(`   scopes: ${formatScopes(report.scopes.effective)}`),
     );
   }
@@ -131,6 +158,7 @@ export function renderTerminal(report: Report, diff?: ReportDiff | null): string
   if (diff) {
     lines.push(...renderDiffSection(diff));
   }
+  if (!maturityComplete) lines.push(bold('  Provisional dimensions:'));
   for (const dimension of report.dimensions) {
     if (!dimension.applicable) {
       lines.push(`  ${dimension.title.padEnd(20)} ${dim('excluded by preset')}`);
@@ -145,9 +173,13 @@ export function renderTerminal(report: Report, diff?: ReportDiff | null): string
 
   const failed = report.checks.filter((c) => !c.passed && c.severity !== 'off');
   if (failed.length === 0) {
-    lines.push(green(`  All checks passed ${MIDDOT} this repository is fully harnessed.`));
+    lines.push(
+      maturityComplete
+        ? green(`  All checks passed ${MIDDOT} this repository is fully harnessed.`)
+        : yellow(`  All provisional checks passed ${MIDDOT} completeness is required before a verdict.`),
+    );
   } else {
-    lines.push(bold(`  Improvements (${failed.length}):`));
+    lines.push(bold(`  ${maturityComplete ? '' : 'Provisional '}Improvements (${failed.length}):`));
     for (const check of failed) {
       lines.push(`   ${red(CROSS)} ${bold(check.id)} ${check.title} ${dim(`(+${check.points} pts)`)}`);
       lines.push(`     ${check.remediation}`);
@@ -175,7 +207,7 @@ export function renderTerminal(report: Report, diff?: ReportDiff | null): string
     }
   }
   lines.push('');
-  if (report.level.nextLevelGaps.length > 0) {
+  if (maturityComplete && report.level.nextLevelGaps.length > 0) {
     lines.push(`  ${bold(`To reach L${report.level.index + 1}:`)} ${report.level.nextLevelGaps.join('; ')}`);
     if (report.level.capped && report.level.capReason) {
       lines.push(yellow(`  ${WARN} ${report.level.capReason}`));

--- a/packages/cli/src/scan.ts
+++ b/packages/cli/src/scan.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { ScanContext } from './types.js';
+import type { ScanContext, ScanIncompleteReason } from './types.js';
+import { compareLexically } from './util.js';
 
 /** Directories that never contain harness signal and can be huge. */
 const SKIP_DIRS = new Set([
@@ -47,6 +48,7 @@ export interface ScanOverlay {
   /** Repo-relative path → absolute path for reading (repo wins on conflict). */
   files: Map<string, string>;
   truncated?: boolean;
+  incompleteReasons?: ScanIncompleteReason[];
 }
 
 export interface CreateScanOptions {
@@ -61,21 +63,47 @@ function safeRealpath(p: string): string | null {
   }
 }
 
-function walk(root: string): { files: string[]; truncated: boolean } {
+interface WalkOptions {
+  maxDepth?: number;
+  maxFiles?: number;
+  readDirectory?: (directory: string) => fs.Dirent[];
+}
+
+export interface WalkResult {
+  files: string[];
+  truncated: boolean;
+  incompleteReasons: ScanIncompleteReason[];
+}
+
+function addFirstReason(reasons: ScanIncompleteReason[], reason: ScanIncompleteReason): void {
+  if (!reasons.some((existing) => existing.code === reason.code)) reasons.push(reason);
+}
+
+/** Internal/testable deterministic filesystem walker. Production callers use fixed limits. */
+export function walkDirectory(root: string, options: WalkOptions = {}): WalkResult {
+  const maxDepth = options.maxDepth ?? MAX_DEPTH;
+  const maxFiles = options.maxFiles ?? MAX_FILES;
+  const readDirectory =
+    options.readDirectory ?? ((directory: string) => fs.readdirSync(directory, { withFileTypes: true }));
   const files: string[] = [];
-  let truncated = false;
+  const incompleteReasons: ScanIncompleteReason[] = [];
   const visitedRealDirs = new Set<string>([safeRealpath(root) ?? root]);
   const stack: Array<{ abs: string; rel: string; depth: number }> = [{ abs: root, rel: '', depth: 0 }];
 
-  outer: while (stack.length > 0) {
+  while (stack.length > 0) {
     const dir = stack.pop()!;
-    if (dir.depth > MAX_DEPTH) continue;
     let entries: fs.Dirent[];
     try {
-      entries = fs.readdirSync(dir.abs, { withFileTypes: true });
+      entries = readDirectory(dir.abs);
     } catch {
+      addFirstReason(incompleteReasons, {
+        code: 'unreadable-directory',
+        path: dir.rel || '.',
+      });
       continue;
     }
+    entries.sort((a, b) => compareLexically(a.name, b.name));
+    const childDirs: Array<{ abs: string; rel: string; depth: number }> = [];
     for (const entry of entries) {
       const rel = dir.rel === '' ? entry.name : `${dir.rel}/${entry.name}`;
       if (SKIP_RELATIVE_PATHS.has(rel)) continue;
@@ -97,30 +125,52 @@ function walk(root: string): { files: string[]; truncated: boolean } {
 
       if (isDir) {
         if (SKIP_DIRS.has(entry.name)) continue;
+        if (dir.depth >= maxDepth) {
+          addFirstReason(incompleteReasons, { code: 'depth-limit', path: rel, limit: maxDepth });
+          continue;
+        }
         // Dedup by real path so symlink cycles (and hardlink-style repeats)
         // can't loop forever; readdirSync/statSync below still follow the
         // symlink transparently via its own (non-resolved) `abs` path.
         const real = safeRealpath(abs) ?? abs;
         if (visitedRealDirs.has(real)) continue;
         visitedRealDirs.add(real);
-        stack.push({ abs, rel, depth: dir.depth + 1 });
+        childDirs.push({ abs, rel, depth: dir.depth + 1 });
       } else if (isFile) {
-        if (files.length >= MAX_FILES) {
-          truncated = true;
-          break outer;
+        if (files.length >= maxFiles) {
+          addFirstReason(incompleteReasons, {
+            code: 'file-count-limit',
+            path: rel,
+            limit: maxFiles,
+          });
+          files.sort(compareLexically);
+          return { files, truncated: true, incompleteReasons };
         }
         files.push(rel);
       }
     }
+    for (let i = childDirs.length - 1; i >= 0; i -= 1) stack.push(childDirs[i]!);
   }
-  files.sort();
-  return { files, truncated };
+  files.sort(compareLexically);
+  return { files, truncated: incompleteReasons.length > 0, incompleteReasons };
+}
+
+function normalizeReasons(
+  truncated: boolean,
+  reasons: ScanIncompleteReason[] | undefined,
+): ScanIncompleteReason[] {
+  const normalized: ScanIncompleteReason[] = [];
+  for (const reason of reasons ?? []) addFirstReason(normalized, reason);
+  if (truncated && normalized.length === 0) {
+    normalized.push({ code: 'file-count-limit' });
+  }
+  return normalized;
 }
 
 function buildContext(
   root: string,
   repoFiles: string[],
-  truncated: boolean,
+  incompleteReasons: ScanIncompleteReason[],
   overlayAbsByRel: Map<string, string>,
 ): ScanContext {
   const repoSet = new Set(repoFiles);
@@ -135,7 +185,8 @@ function buildContext(
   return {
     root,
     files,
-    truncated,
+    truncated: incompleteReasons.length > 0,
+    incompleteReasons,
     has(relPath: string): boolean {
       return fileSet.has(relPath);
     },
@@ -174,15 +225,20 @@ function buildContext(
 
 export function createScanContext(rootInput: string, options: CreateScanOptions = {}): ScanContext {
   const root = path.resolve(rootInput);
-  const { files: repoFiles, truncated: repoTruncated } = walk(root);
+  const { files: repoFiles, truncated: repoTruncated, incompleteReasons: repoReasons } = walkDirectory(root);
   const overlays = options.overlays ?? [];
 
   const overlayAbsByRel = new Map<string, string>();
-  let overlayTruncated = false;
+  const effectiveReasons = normalizeReasons(repoTruncated, repoReasons);
   const repoSet = new Set(repoFiles);
 
   for (const overlay of overlays) {
-    if (overlay.truncated) overlayTruncated = true;
+    for (const reason of normalizeReasons(overlay.truncated === true, overlay.incompleteReasons)) {
+      addFirstReason(effectiveReasons, {
+        ...reason,
+        path: reason.path ? `${overlay.label}:${reason.path}` : undefined,
+      });
+    }
     for (const [rel, abs] of overlay.files) {
       if (repoSet.has(rel)) continue;
       overlayAbsByRel.set(rel, abs);
@@ -190,8 +246,8 @@ export function createScanContext(rootInput: string, options: CreateScanOptions 
   }
 
   if (overlays.length === 0) {
-    return buildContext(root, repoFiles, repoTruncated, overlayAbsByRel);
+    return buildContext(root, repoFiles, effectiveReasons, overlayAbsByRel);
   }
 
-  return buildContext(root, repoFiles, repoTruncated || overlayTruncated, overlayAbsByRel);
+  return buildContext(root, repoFiles, effectiveReasons, overlayAbsByRel);
 }

--- a/packages/cli/src/score.ts
+++ b/packages/cli/src/score.ts
@@ -19,7 +19,7 @@ import type {
 import { DIMENSIONS } from './types.js';
 
 export const DOCS_BASE_URL = 'https://paladini.github.io/harness-score/guide/measure-and-improve';
-export const TOOL_VERSION = '1.5.2';
+export const TOOL_VERSION = '1.5.3';
 
 export const LEVEL_NAMES = ['Unharnessed', 'Documented', 'Guided', 'Sensing', 'Self-correcting'] as const;
 

--- a/packages/cli/src/score.ts
+++ b/packages/cli/src/score.ts
@@ -12,6 +12,8 @@ import type {
   LevelInfo,
   Report,
   ScanContext,
+  ScanIncompleteReason,
+  ScanVerdict,
   ScoreSnapshot,
 } from './types.js';
 import { DIMENSIONS } from './types.js';
@@ -158,6 +160,16 @@ function snapshotsEqual(a: ScoreSnapshot, b: ScoreSnapshot): boolean {
   return true;
 }
 
+function contextReasons(ctx: ScanContext): ScanIncompleteReason[] {
+  if (ctx.incompleteReasons && ctx.incompleteReasons.length > 0) return ctx.incompleteReasons;
+  return ctx.truncated ? [{ code: 'file-count-limit' }] : [];
+}
+
+function contextVerdict(ctx: ScanContext): ScanVerdict {
+  const reasons = contextReasons(ctx);
+  return { status: reasons.length > 0 ? 'incomplete' : 'complete', reasons };
+}
+
 export function buildReportFromContext(
   maturityCtx: ScanContext,
   effectiveCtx: ScanContext,
@@ -165,6 +177,8 @@ export function buildReportFromContext(
   resolvedRoots: Report['resolvedRoots'],
 ): Report {
   const severities = resolveSeverities(config);
+  const maturityVerdict = contextVerdict(maturityCtx);
+  const effectiveVerdict = contextVerdict(effectiveCtx);
   const maturity = buildSnapshot(maturityCtx, severities);
   let effective = maturity;
   if (effectiveCtx !== maturityCtx) {
@@ -181,7 +195,8 @@ export function buildReportFromContext(
   return {
     tool: { name: 'harness-score', version: TOOL_VERSION },
     root: maturityCtx.root,
-    truncated: maturityCtx.truncated || effectiveCtx.truncated,
+    truncated: maturityVerdict.status === 'incomplete' || effectiveVerdict.status === 'incomplete',
+    verdicts: { maturity: maturityVerdict, effective: effectiveVerdict },
     scopes: { maturity: ['repo'], effective: config.effectiveScopes },
     gate: config.gate,
     resolvedRoots: resolvedRoots && resolvedRoots.length > 0 ? resolvedRoots : undefined,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -20,8 +20,10 @@ export interface ScanContext {
   root: string;
   /** All file paths relative to root, POSIX separators, sorted. */
   files: string[];
-  /** True if the scan hit MAX_FILES and stopped before the tree was fully walked. */
+  /** Compatibility alias: true whenever the scan is incomplete for any reason. */
   truncated: boolean;
+  /** Deterministic reasons the filesystem walk could not complete. */
+  incompleteReasons?: ScanIncompleteReason[];
   /** True when the relative path exists as a file. */
   has(relPath: string): boolean;
   /** File content as UTF-8, or null when missing/unreadable. Cached. */
@@ -35,6 +37,21 @@ export interface ScanDiagnostic {
   code: string;
   message: string;
   source?: string;
+}
+
+export type ScanIncompleteReasonCode = 'file-count-limit' | 'depth-limit' | 'unreadable-directory';
+
+export interface ScanIncompleteReason {
+  code: ScanIncompleteReasonCode;
+  path?: string;
+  limit?: number;
+}
+
+export type ScanVerdictStatus = 'complete' | 'incomplete';
+
+export interface ScanVerdict {
+  status: ScanVerdictStatus;
+  reasons: ScanIncompleteReason[];
 }
 
 export interface CheckOutcome {
@@ -119,8 +136,10 @@ export interface PresetInfo {
 export interface Report {
   tool: { name: string; version: string };
   root: string;
-  /** True if the scan hit its file-count cap before fully walking the tree — results may be incomplete. */
+  /** Compatibility alias: true whenever either requested scan scope is incomplete. */
   truncated: boolean;
+  /** Authoritative completeness for repository-only and effective snapshots. */
+  verdicts?: { maturity: ScanVerdict; effective: ScanVerdict };
   /** Scopes included in each score. */
   scopes: { maturity: ['repo']; effective: Array<'repo' | 'user' | 'system' | string> };
   /** Which score `--min-level` and CI gates use. */

--- a/packages/cli/src/verdict.ts
+++ b/packages/cli/src/verdict.ts
@@ -1,0 +1,24 @@
+import type { Report, ScanIncompleteReason, ScanVerdict } from './types.js';
+
+export type VerdictScope = 'maturity' | 'effective';
+
+const LEGACY_FILE_LIMIT: ScanIncompleteReason = { code: 'file-count-limit' };
+
+/** Resolve additive verdicts while preserving fail-closed behavior for legacy reports. */
+export function reportVerdict(report: Report, scope: VerdictScope): ScanVerdict {
+  const explicit = report.verdicts?.[scope];
+  if (explicit) return explicit;
+  return report.truncated
+    ? { status: 'incomplete', reasons: [LEGACY_FILE_LIMIT] }
+    : { status: 'complete', reasons: [] };
+}
+
+export function reportScopeIsComplete(report: Report, scope: VerdictScope): boolean {
+  return reportVerdict(report, scope).status === 'complete';
+}
+
+export function formatIncompleteReason(reason: ScanIncompleteReason): string {
+  const location = reason.path ? ` at ${reason.path}` : '';
+  const limit = reason.limit === undefined ? '' : ` (limit ${reason.limit})`;
+  return `${reason.code}${location}${limit}`;
+}

--- a/packages/cli/test/__snapshots__/golden-output.test.ts.snap
+++ b/packages/cli/test/__snapshots__/golden-output.test.ts.snap
@@ -1018,6 +1018,16 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
     "percent": 13,
   },
   "truncated": false,
+  "verdicts": {
+    "effective": {
+      "reasons": [],
+      "status": "complete",
+    },
+    "maturity": {
+      "reasons": [],
+      "status": "complete",
+    },
+  },
 }
 `;
 
@@ -2041,6 +2051,16 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
     "percent": 20,
   },
   "truncated": false,
+  "verdicts": {
+    "effective": {
+      "reasons": [],
+      "status": "complete",
+    },
+    "maturity": {
+      "reasons": [],
+      "status": "complete",
+    },
+  },
 }
 `;
 
@@ -3068,6 +3088,16 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
     "percent": 48,
   },
   "truncated": false,
+  "verdicts": {
+    "effective": {
+      "reasons": [],
+      "status": "complete",
+    },
+    "maturity": {
+      "reasons": [],
+      "status": "complete",
+    },
+  },
 }
 `;
 
@@ -4093,6 +4123,16 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
     "percent": 81,
   },
   "truncated": false,
+  "verdicts": {
+    "effective": {
+      "reasons": [],
+      "status": "complete",
+    },
+    "maturity": {
+      "reasons": [],
+      "status": "complete",
+    },
+  },
 }
 `;
 
@@ -5118,6 +5158,16 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
     "percent": 100,
   },
   "truncated": false,
+  "verdicts": {
+    "effective": {
+      "reasons": [],
+      "status": "complete",
+    },
+    "maturity": {
+      "reasons": [],
+      "status": "complete",
+    },
+  },
 }
 `;
 
@@ -6175,5 +6225,15 @@ exports[`golden output — regression baseline for build/packaging/scan changes 
     "percent": 100,
   },
   "truncated": false,
+  "verdicts": {
+    "effective": {
+      "reasons": [],
+      "status": "complete",
+    },
+    "maturity": {
+      "reasons": [],
+      "status": "complete",
+    },
+  },
 }
 `;

--- a/packages/cli/test/badge.test.ts
+++ b/packages/cli/test/badge.test.ts
@@ -28,4 +28,21 @@ describe('renderBadge', () => {
     expect(svg).toContain('viewBox="0 0 112 20"');
     expect(svg).toContain('width="112"');
   });
+
+  test('renders incomplete instead of L0-L4 for explicit and legacy incomplete reports', () => {
+    const explicit = makeReport(4);
+    explicit.verdicts = {
+      maturity: { status: 'incomplete', reasons: [{ code: 'depth-limit' }] },
+      effective: { status: 'incomplete', reasons: [{ code: 'depth-limit' }] },
+    };
+    const explicitSvg = renderBadge(explicit);
+    expect(explicitSvg).toContain('>incomplete<');
+    expect(explicitSvg).toContain('aria-label="Harness Score incomplete"');
+    expect(explicitSvg).toContain('width="140"');
+    expect(explicitSvg).not.toContain('>L4<');
+
+    const legacy = makeReport(2);
+    legacy.truncated = true;
+    expect(renderBadge(legacy)).toContain('>incomplete<');
+  });
 });

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -14,6 +14,16 @@ function run(args: string[]) {
   return spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8' });
 }
 
+function makeIncompleteRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-incomplete-'));
+  let nested = root;
+  for (let depth = 0; depth < 11; depth += 1) {
+    nested = path.join(nested, `d${depth}`);
+    fs.mkdirSync(nested);
+  }
+  return root;
+}
+
 describe('cli', () => {
   test('--json emits a parseable report', () => {
     const result = run([path.join(FIXTURES, 'level-2'), '--json']);
@@ -42,6 +52,59 @@ describe('cli', () => {
     expect(svg).toContain('Harness Score');
     expect(svg).toContain('L3');
     fs.unlinkSync(badgePath);
+  });
+
+  test('emits diagnostic JSON and exits 2 for an incomplete scan even with --min-level 0', () => {
+    const root = makeIncompleteRoot();
+    try {
+      const result = run([root, '--json', '--quiet', '--min-level', '0']);
+      expect(result.status).toBe(2);
+      const report = JSON.parse(result.stdout);
+      expect(report.verdicts.maturity.status).toBe('incomplete');
+      expect(report.verdicts.maturity.reasons[0]).toMatchObject({
+        code: 'depth-limit',
+        limit: 10,
+      });
+      expect(result.stderr).toContain('no authoritative verdict is available');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('writes an incomplete badge instead of L0-L4 and exits 2', () => {
+    const root = makeIncompleteRoot();
+    const badgePath = path.join(os.tmpdir(), `hs-incomplete-badge-${process.pid}.svg`);
+    try {
+      const result = run([root, '--badge', badgePath, '--quiet']);
+      expect(result.status).toBe(2);
+      const svg = fs.readFileSync(badgePath, 'utf8');
+      expect(svg).toContain('>incomplete<');
+      expect(svg).not.toMatch(/>L[0-4]</);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+      fs.rmSync(badgePath, { force: true });
+    }
+  });
+
+  test('exits 2 when only a requested effective scope is incomplete', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-effective-root-'));
+    const shared = makeIncompleteRoot();
+    fs.writeFileSync(
+      path.join(root, '.harness-score.json'),
+      JSON.stringify({ extraRoots: [{ id: 'team', path: shared }], gate: 'maturity' }),
+      'utf8',
+    );
+    try {
+      const result = run([root, '--json', '--quiet', '--min-level', '0']);
+      expect(result.status).toBe(2);
+      const report = JSON.parse(result.stdout);
+      expect(report.verdicts.maturity.status).toBe('complete');
+      expect(report.verdicts.effective.status).toBe('incomplete');
+      expect(result.stderr).toContain('effective scan is incomplete');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+      fs.rmSync(shared, { recursive: true, force: true });
+    }
   });
 
   test('rejects a nonexistent directory', () => {
@@ -92,5 +155,34 @@ describe('cli', () => {
     expect(result.status).toBe(2);
     expect(result.stderr).toContain('does not look like a harness-score report');
     fs.unlinkSync(badPath);
+  });
+
+  test('--diff rejects legacy incomplete baselines', () => {
+    const baselinePath = path.join(os.tmpdir(), `hs-incomplete-baseline-${process.pid}.json`);
+    const baseline = JSON.parse(run([path.join(FIXTURES, 'level-2'), '--json', '--quiet']).stdout);
+    baseline.truncated = true;
+    delete baseline.verdicts;
+    fs.writeFileSync(baselinePath, JSON.stringify(baseline), 'utf8');
+    try {
+      const result = run([path.join(FIXTURES, 'level-4'), '--diff', baselinePath, '--quiet']);
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('baseline maturity report is incomplete');
+    } finally {
+      fs.rmSync(baselinePath, { force: true });
+    }
+  });
+
+  test('--diff rejects an incomplete current scan', () => {
+    const baselinePath = path.join(os.tmpdir(), `hs-complete-baseline-${process.pid}.json`);
+    const root = makeIncompleteRoot();
+    fs.writeFileSync(baselinePath, run([path.join(FIXTURES, 'level-2'), '--json', '--quiet']).stdout, 'utf8');
+    try {
+      const result = run([root, '--diff', baselinePath, '--quiet']);
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('current maturity report is incomplete');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+      fs.rmSync(baselinePath, { force: true });
+    }
   });
 });

--- a/packages/cli/test/diff.test.ts
+++ b/packages/cli/test/diff.test.ts
@@ -58,4 +58,22 @@ describe('computeDiff', () => {
     expect(() => computeDiff(legacyBaseline as typeof current, current)).not.toThrow();
     expect(computeDiff(legacyBaseline as typeof current, current).presetChanged).toBe(false);
   });
+
+  test('rejects incomplete current and legacy baseline reports', () => {
+    const complete = score(path.join(FIXTURES, 'level-4'));
+    const incomplete = {
+      ...complete,
+      truncated: true,
+      verdicts: {
+        maturity: { status: 'incomplete' as const, reasons: [{ code: 'depth-limit' as const }] },
+        effective: { status: 'incomplete' as const, reasons: [{ code: 'depth-limit' as const }] },
+      },
+    };
+    expect(() => computeDiff(complete, incomplete)).toThrow('incomplete maturity reports');
+
+    const { verdicts: _verdicts, ...legacyIncomplete } = incomplete;
+    expect(() => computeDiff(legacyIncomplete as typeof complete, complete)).toThrow(
+      'incomplete maturity reports',
+    );
+  });
 });

--- a/packages/cli/test/global-paths.test.ts
+++ b/packages/cli/test/global-paths.test.ts
@@ -152,10 +152,38 @@ describe('buildExtraRootOverlay', () => {
     }
   });
 
-  test('returns null for a missing extra root path', () => {
+  test('reports a deterministic depth-limit reason for an incomplete extra root', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-extra-'));
+    let nested = dir;
+    for (let depth = 0; depth < 10; depth += 1) {
+      nested = path.join(nested, `d${depth}`);
+      fs.mkdirSync(nested);
+    }
+    fs.writeFileSync(path.join(nested, 'AGENTS.md'), '# Too deep\n', 'utf8');
+
+    try {
+      const overlay = buildExtraRootOverlay(dir, { id: 'deep', path: '.' });
+      expect(overlay?.truncated).toBe(true);
+      expect(overlay?.incompleteReasons).toEqual([
+        {
+          code: 'depth-limit',
+          path: 'd0/d1/d2/d3/d4/d5/d6/d7/d8',
+          limit: 8,
+        },
+      ]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('fails closed for a missing configured extra root path', () => {
     const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-repo-'));
     try {
-      expect(buildExtraRootOverlay(repo, { id: 'missing', path: './definitely-not-here' })).toBeNull();
+      expect(buildExtraRootOverlay(repo, { id: 'missing', path: './definitely-not-here' })).toMatchObject({
+        label: 'missing',
+        truncated: true,
+        incompleteReasons: [{ code: 'unreadable-directory', path: '.' }],
+      });
     } finally {
       fs.rmSync(repo, { recursive: true, force: true });
     }

--- a/packages/cli/test/markdown.test.ts
+++ b/packages/cli/test/markdown.test.ts
@@ -89,6 +89,36 @@ describe('renderMarkdown', () => {
     expect(out).toContain('❌');
   });
 
+  test('renders explicit incomplete verdicts as provisional and hides the level', () => {
+    const out = renderMarkdown(
+      makeReport({
+        truncated: true,
+        verdicts: {
+          maturity: {
+            status: 'incomplete',
+            reasons: [{ code: 'unreadable-directory', path: 'private' }],
+          },
+          effective: {
+            status: 'incomplete',
+            reasons: [{ code: 'unreadable-directory', path: 'private' }],
+          },
+        },
+      }),
+    );
+    expect(out).toContain('**Maturity:** unavailable - incomplete scan');
+    expect(out).toContain('**Provisional maturity score:**');
+    expect(out).toContain('## Provisional dimensions');
+    expect(out).toContain('## Provisional checks');
+    expect(out).toContain('unreadable-directory at private');
+    expect(out).not.toContain('**Maturity level:** L1');
+  });
+
+  test('uses truncated as the fail-closed fallback for old reports', () => {
+    const out = renderMarkdown(makeReport({ truncated: true }));
+    expect(out).toContain('**Maturity:** unavailable - incomplete scan');
+    expect(out).toContain('file-count-limit');
+  });
+
   test('shows detected harnesses with display names, only when non-empty', () => {
     const detected = renderMarkdown(makeReport({ detectedHarnesses: ['cursor', 'claude-code'] }));
     expect(detected).toContain('**Detected harnesses:** Cursor, Claude Code');

--- a/packages/cli/test/scan.test.ts
+++ b/packages/cli/test/scan.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, test } from 'vitest';
-import { createScanContext } from '../src/scan.js';
+import { createScanContext, walkDirectory } from '../src/scan.js';
 
 const tmpDirs: string[] = [];
 
@@ -56,5 +56,53 @@ describe('createScanContext — symlinks', () => {
     // (thousands of copies) is the bug this test guards against.
     expect(occurrences.length).toBeLessThan(20);
     expect(ctx.truncated).toBe(false);
+  });
+});
+
+describe('deterministic incomplete scan reasons', () => {
+  test('sorts directory entries before applying the file-count limit', () => {
+    const root = mkTmpDir();
+    for (const name of ['z.txt', 'a.txt', 'm.txt']) fs.writeFileSync(path.join(root, name), name);
+    const reverseRead = (directory: string) => fs.readdirSync(directory, { withFileTypes: true }).reverse();
+
+    const result = walkDirectory(root, { maxFiles: 2, readDirectory: reverseRead });
+    expect(result.files).toEqual(['a.txt', 'm.txt']);
+    expect(result.incompleteReasons).toEqual([{ code: 'file-count-limit', path: 'z.txt', limit: 2 }]);
+    expect(result.truncated).toBe(true);
+  });
+
+  test('records the first deterministic directory skipped by the depth limit', () => {
+    const root = mkTmpDir();
+    fs.mkdirSync(path.join(root, 'a', 'b'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'z', 'b'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'a', 'b', 'deep.txt'), 'deep');
+
+    const result = walkDirectory(root, { maxDepth: 1 });
+    expect(result.files).toEqual([]);
+    expect(result.incompleteReasons).toEqual([{ code: 'depth-limit', path: 'a/b', limit: 1 }]);
+  });
+
+  test('records an unreadable directory and continues scanning deterministic siblings', () => {
+    const root = mkTmpDir();
+    fs.mkdirSync(path.join(root, 'a-blocked'));
+    fs.mkdirSync(path.join(root, 'b-readable'));
+    fs.writeFileSync(path.join(root, 'b-readable', 'visible.txt'), 'visible');
+    const injectedRead = (directory: string): fs.Dirent[] => {
+      if (path.basename(directory) === 'a-blocked') throw new Error('permission denied');
+      return fs.readdirSync(directory, { withFileTypes: true });
+    };
+
+    const result = walkDirectory(root, { readDirectory: injectedRead });
+    expect(result.files).toEqual(['b-readable/visible.txt']);
+    expect(result.incompleteReasons).toEqual([{ code: 'unreadable-directory', path: 'a-blocked' }]);
+  });
+
+  test('converts a legacy truncated overlay to a file-count reason', () => {
+    const root = mkTmpDir();
+    const ctx = createScanContext(root, {
+      overlays: [{ label: 'legacy', files: new Map(), truncated: true }],
+    });
+    expect(ctx.truncated).toBe(true);
+    expect(ctx.incompleteReasons).toEqual([{ code: 'file-count-limit' }]);
   });
 });

--- a/packages/cli/test/scope.test.ts
+++ b/packages/cli/test/scope.test.ts
@@ -3,7 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
-import { score } from '../src/index.js';
+import { buildReport, score } from '../src/index.js';
 
 const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'fixtures');
 
@@ -74,5 +74,42 @@ describe('harness scopes and dual score', () => {
         fs.rmSync(repoDir, { recursive: true, force: true });
       }
     });
+  });
+
+  test('keeps maturity complete when only an effective extra scope is incomplete', () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-repo-'));
+    const sharedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-shared-'));
+    let nested = sharedDir;
+    for (let depth = 0; depth < 10; depth += 1) {
+      nested = path.join(nested, `d${depth}`);
+      fs.mkdirSync(nested, { recursive: true });
+    }
+    fs.writeFileSync(path.join(nested, 'AGENTS.md'), '# Too deep\n', 'utf8');
+
+    try {
+      const report = buildReport(repoDir, {
+        scopes: { user: false, system: false },
+        extraRoots: [{ id: 'team', path: sharedDir }],
+        gate: 'maturity',
+        effectiveScopes: ['repo', 'team'],
+        extends: [],
+        rules: {},
+      });
+      expect(report.verdicts?.maturity).toEqual({ status: 'complete', reasons: [] });
+      expect(report.verdicts?.effective).toEqual({
+        status: 'incomplete',
+        reasons: [
+          {
+            code: 'depth-limit',
+            path: 'team:d0/d1/d2/d3/d4/d5/d6/d7/d8',
+            limit: 8,
+          },
+        ],
+      });
+      expect(report.truncated).toBe(true);
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+      fs.rmSync(sharedDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/test/score.test.ts
+++ b/packages/cli/test/score.test.ts
@@ -88,5 +88,33 @@ describe('buildReport shape', () => {
     expect(report.tool.version).toBe(TOOL_VERSION);
     expect(report.root).toBe(ctx.root);
     expect(report.truncated).toBe(ctx.truncated);
+    expect(report.verdicts).toEqual({
+      maturity: { status: 'complete', reasons: [] },
+      effective: { status: 'complete', reasons: [] },
+    });
+  });
+
+  test('converts a legacy truncated context to a fail-closed file-count verdict', () => {
+    const ctx = { ...fakeContext({}), truncated: true };
+    const report = buildReportFromScanContext(ctx);
+    expect(report.truncated).toBe(true);
+    expect(report.verdicts?.maturity).toEqual({
+      status: 'incomplete',
+      reasons: [{ code: 'file-count-limit' }],
+    });
+  });
+
+  test('preserves explicit incomplete reasons even when legacy truncated is false', () => {
+    const ctx = {
+      ...fakeContext({}),
+      truncated: false,
+      incompleteReasons: [{ code: 'depth-limit' as const, path: 'a/b', limit: 10 }],
+    };
+    const report = buildReportFromScanContext(ctx);
+    expect(report.truncated).toBe(true);
+    expect(report.verdicts?.effective).toEqual({
+      status: 'incomplete',
+      reasons: [{ code: 'depth-limit', path: 'a/b', limit: 10 }],
+    });
   });
 });

--- a/packages/cli/test/terminal.test.ts
+++ b/packages/cli/test/terminal.test.ts
@@ -82,9 +82,33 @@ function makeDiff(overrides: Partial<ReportDiff> = {}): ReportDiff {
 }
 
 describe('renderTerminal', () => {
-  test('shows the truncated-scan banner only when report.truncated is true', () => {
-    expect(renderTerminal(makeReport({ truncated: true }))).toContain('Scan stopped early');
-    expect(renderTerminal(makeReport({ truncated: false }))).not.toContain('Scan stopped early');
+  test('renders legacy truncated reports as incomplete without an authoritative level', () => {
+    const incomplete = renderTerminal(makeReport({ truncated: true }));
+    expect(incomplete).toContain('Maturity: unavailable - incomplete scan');
+    expect(incomplete).toContain('maturity: file-count-limit');
+    expect(incomplete).toContain('Provisional dimensions:');
+    expect(incomplete).not.toContain('Maturity: L1');
+    expect(renderTerminal(makeReport({ truncated: false }))).not.toContain('Incomplete scan');
+  });
+
+  test('keeps maturity authoritative when only the requested effective scope is incomplete', () => {
+    const out = renderTerminal(
+      makeReport({
+        truncated: true,
+        scopes: { maturity: ['repo'], effective: ['repo', 'team'] },
+        verdicts: {
+          maturity: { status: 'complete', reasons: [] },
+          effective: {
+            status: 'incomplete',
+            reasons: [{ code: 'depth-limit', path: 'team:deep', limit: 8 }],
+          },
+        },
+      }),
+    );
+    expect(out).toContain('Maturity: L1');
+    expect(out).toContain('Effective: unavailable - incomplete scan');
+    expect(out).toContain('effective: depth-limit at team:deep (limit 8)');
+    expect(out).not.toContain('Provisional dimensions:');
   });
 
   test('shows "fully harnessed" when every check passed', () => {

--- a/packages/cli/test/types/smoke.ts
+++ b/packages/cli/test/types/smoke.ts
@@ -20,6 +20,7 @@ import {
   type DimensionInfo,
   type DimensionScore,
   DOCS_BASE_URL,
+  formatIncompleteReason,
   LEVEL_NAMES,
   LEVEL_REQUIREMENTS,
   type LevelInfo,
@@ -29,9 +30,14 @@ import {
   renderBadge,
   renderMarkdown,
   renderTerminal,
+  reportScopeIsComplete,
+  reportVerdict,
   resolveSeverities,
   type ScanContext,
   type ScanDiagnostic,
+  type ScanIncompleteReason,
+  type ScanVerdict,
+  type ScanVerdictStatus,
   type Severity,
   score,
   TOOL_DISPLAY_NAMES,
@@ -56,6 +62,11 @@ const levelInfo: LevelInfo = scored.level;
 const checkOutcome: CheckOutcome = { passed: true, evidence: 'x' };
 const checkResult: CheckResult = scored.checks[0]!;
 const diagnostic: ScanDiagnostic = { code: 'future-event', message: 'x', source: '.claude/settings.json' };
+const incompleteReason: ScanIncompleteReason = { code: 'depth-limit', path: 'deep', limit: 10 };
+const verdict: ScanVerdict = reportVerdict(scored, 'maturity');
+const verdictStatus: ScanVerdictStatus = verdict.status;
+const complete: boolean = reportScopeIsComplete(scored, 'maturity');
+const formattedReason: string = formatIncompleteReason(incompleteReason);
 const checkDelta: CheckDelta | undefined = diff.checksChanged[0];
 const dimensionDelta: DimensionDelta = diff.dimensions[0]!;
 const toolId: ToolId = 'cursor';
@@ -82,6 +93,11 @@ void [
   checkOutcome,
   checkResult,
   diagnostic,
+  incompleteReason,
+  verdict,
+  verdictStatus,
+  complete,
+  formattedReason,
   checkDelta,
   dimensionDelta,
   toolId,


### PR DESCRIPTION
## Summary

Part 2 of #46. Part 1 was merged in #48.

- make repository and effective-scope walks deterministic
- report additive maturity/effective completeness verdicts and deterministic reasons
- treat legacy `truncated: true` reports and contexts as incomplete
- render incomplete results as provisional, use an `incomplete` badge, and reject incomplete diffs
- return exit code 2 for any requested incomplete scope, including with `--min-level 0`
- prevent the Action from publishing authoritative outputs, badges, reports, summaries, or comments after an incomplete scan
- test Ubuntu Node 18/22 and Windows Node 22
- document the contract in all five locales
- consume both patch changesets into release `v1.5.3`

## Validation

- `npm test`: 330 tests passed
- `npm run lint`: passed (18 pre-existing CSS warnings)
- `npm run plugins:sync-check`: passed
- `npm run scan`: L4, 108/108, tool version 1.5.3
- `npm run docs:build`: passed
- `npm run check:types -w harness-score`: passed
- clean `harness-score-1.5.3.tgz` install: typed API passed, zero runtime dependencies

## Benchmark

Ten iterations on the same Windows environment:

| Files | Before median | After median | Change |
|---|---:|---:|---:|
| 5,000 | 44.1 ms | 41.9 ms | -4.9% |
| 20,000 | 153.1 ms | 158.1 ms | +3.3% |

The 20,000-file regression is below the 15% merge block.

## Merge and release

After final CI passes, squash merge this PR, verify `main`, create `v1.5.3`, verify npm/GitHub Packages/JSR/Action/docs, and only then move `v1` and close #46.