### PR TITLE
fix: scan complete repository trees and gate by authority

### DIFF
--- a/.changeset/calm-scanners-walk.md
+++ b/.changeset/calm-scanners-walk.md
@@ -1,0 +1,7 @@
+---
+"harness-score": minor
+---
+
+Scan the complete repository tree without a production depth cap, raise the
+file-count fuse to 1,000,000, and decide incomplete-scan failures from the
+selected gate while preserving authoritative maturity outputs.

--- a/.changeset/calm-scanners-walk.md
+++ b/.changeset/calm-scanners-walk.md
@@ -4,4 +4,6 @@
 
 Scan the complete repository tree without a production depth cap, raise the
 file-count fuse to 1,000,000, and decide incomplete-scan failures from the
-selected gate while preserving authoritative maturity outputs.
+selected gate while preserving authoritative maturity outputs. Discovered
+paths that cannot be inspected and symlinks that escape the scan root now also
+make the affected snapshot incomplete.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,51 +59,140 @@ jobs:
           HS_LEVEL: ${{ steps.action-smoke.outputs.level }}
           HS_LEVEL_NAME: ${{ steps.action-smoke.outputs.level-name }}
           HS_PERCENT: ${{ steps.action-smoke.outputs.percent }}
+          HS_EFFECTIVE_LEVEL: ${{ steps.action-smoke.outputs.effective-level }}
+          HS_EFFECTIVE_PERCENT: ${{ steps.action-smoke.outputs.effective-percent }}
         run: |
           test "$HS_LEVEL" = "4"
           test "$HS_LEVEL_NAME" = "Self-correcting"
           test "$HS_PERCENT" = "100"
+          test "$HS_EFFECTIVE_LEVEL" = "4"
+          test "$HS_EFFECTIVE_PERCENT" = "100"
           test -s "$RUNNER_TEMP/harness-action-fixture/harness-badge.svg"
           test -s "$RUNNER_TEMP/harness-action-fixture/harness-report.md"
-      - name: Prepare incomplete GitHub Action smoke fixture
+      - name: Prepare effective-incomplete GitHub Action smoke fixtures
         shell: bash
         run: |
-          ROOT="$RUNNER_TEMP/harness-action-incomplete"
-          mkdir -p "$ROOT"
-          NESTED="$ROOT"
-          for DEPTH in $(seq 0 10); do
+          MATURITY_ROOT="$RUNNER_TEMP/harness-action-effective-maturity"
+          EFFECTIVE_ROOT="$RUNNER_TEMP/harness-action-effective-gate"
+          SHARED_ROOT="$RUNNER_TEMP/harness-action-effective-shared"
+          cp -R fixtures/level-4 "$MATURITY_ROOT"
+          cp -R fixtures/level-4 "$EFFECTIVE_ROOT"
+          mkdir -p "$SHARED_ROOT"
+          NESTED="$SHARED_ROOT"
+          for DEPTH in $(seq 0 9); do
             NESTED="$NESTED/d$DEPTH"
             mkdir "$NESTED"
           done
-      - name: Reject incomplete GitHub Action scan
-        id: action-incomplete
+          printf '# Too deep\n' > "$NESTED/AGENTS.md"
+          HS_MATURITY_ROOT="$MATURITY_ROOT" \
+          HS_EFFECTIVE_ROOT="$EFFECTIVE_ROOT" \
+          HS_SHARED_ROOT="$SHARED_ROOT" \
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const config = JSON.stringify({
+            extraRoots: [{ id: 'team', path: process.env.HS_SHARED_ROOT }],
+          });
+          for (const root of [process.env.HS_MATURITY_ROOT, process.env.HS_EFFECTIVE_ROOT]) {
+            fs.writeFileSync(path.join(root, '.harness-score.json'), config);
+          }
+          NODE
+      - name: Keep maturity authoritative when effective is incomplete
+        id: action-effective-incomplete-maturity
+        uses: ./
+        with:
+          version: 'file:${{ github.workspace }}/packages/cli'
+          working-directory: ${{ runner.temp }}/harness-action-effective-maturity
+          gate: maturity
+          min-level: '4'
+          badge: 'maturity-badge.svg'
+          report: 'maturity-report.md'
+      - name: Verify maturity-gated effective-incomplete result
+        shell: bash
+        env:
+          HS_LEVEL: ${{ steps.action-effective-incomplete-maturity.outputs.level }}
+          HS_LEVEL_NAME: ${{ steps.action-effective-incomplete-maturity.outputs.level-name }}
+          HS_PERCENT: ${{ steps.action-effective-incomplete-maturity.outputs.percent }}
+          HS_EFFECTIVE_LEVEL: ${{ steps.action-effective-incomplete-maturity.outputs.effective-level }}
+          HS_EFFECTIVE_PERCENT: ${{ steps.action-effective-incomplete-maturity.outputs.effective-percent }}
+        run: |
+          test "$HS_LEVEL" = "4"
+          test "$HS_LEVEL_NAME" = "Self-correcting"
+          test "$HS_PERCENT" = "100"
+          test -z "$HS_EFFECTIVE_LEVEL"
+          test -z "$HS_EFFECTIVE_PERCENT"
+          test -s "$RUNNER_TEMP/harness-action-effective-maturity/maturity-badge.svg"
+          test -s "$RUNNER_TEMP/harness-action-effective-maturity/maturity-report.md"
+      - name: Reject effective gate when effective is incomplete
+        id: action-effective-incomplete-gate
         continue-on-error: true
         uses: ./
         with:
           version: 'file:${{ github.workspace }}/packages/cli'
-          working-directory: ${{ runner.temp }}/harness-action-incomplete
-          min-level: '0'
-          badge: 'incomplete-badge.svg'
-          report: 'incomplete-report.md'
-      - name: Verify incomplete Action publishes no authoritative outputs or artifacts
+          working-directory: ${{ runner.temp }}/harness-action-effective-gate
+          gate: effective
+          min-level: '4'
+          badge: 'maturity-badge.svg'
+          report: 'maturity-report.md'
+      - name: Verify failed effective gate keeps only maturity authoritative
         if: ${{ always() }}
         shell: bash
         env:
-          HS_OUTCOME: ${{ steps.action-incomplete.outcome }}
-          HS_LEVEL: ${{ steps.action-incomplete.outputs.level }}
-          HS_LEVEL_NAME: ${{ steps.action-incomplete.outputs.level-name }}
-          HS_PERCENT: ${{ steps.action-incomplete.outputs.percent }}
-          HS_EFFECTIVE_LEVEL: ${{ steps.action-incomplete.outputs.effective-level }}
-          HS_EFFECTIVE_PERCENT: ${{ steps.action-incomplete.outputs.effective-percent }}
+          HS_OUTCOME: ${{ steps.action-effective-incomplete-gate.outcome }}
+          HS_LEVEL: ${{ steps.action-effective-incomplete-gate.outputs.level }}
+          HS_LEVEL_NAME: ${{ steps.action-effective-incomplete-gate.outputs.level-name }}
+          HS_PERCENT: ${{ steps.action-effective-incomplete-gate.outputs.percent }}
+          HS_EFFECTIVE_LEVEL: ${{ steps.action-effective-incomplete-gate.outputs.effective-level }}
+          HS_EFFECTIVE_PERCENT: ${{ steps.action-effective-incomplete-gate.outputs.effective-percent }}
         run: |
+          test "$HS_OUTCOME" = "failure"
+          test "$HS_LEVEL" = "4"
+          test "$HS_LEVEL_NAME" = "Self-correcting"
+          test "$HS_PERCENT" = "100"
+          test -z "$HS_EFFECTIVE_LEVEL"
+          test -z "$HS_EFFECTIVE_PERCENT"
+          test -s "$RUNNER_TEMP/harness-action-effective-gate/maturity-badge.svg"
+          test -s "$RUNNER_TEMP/harness-action-effective-gate/maturity-report.md"
+      - name: Prepare unreadable maturity smoke fixture
+        shell: bash
+        run: |
+          ROOT="$RUNNER_TEMP/harness-action-maturity-incomplete"
+          mkdir -p "$ROOT/blocked"
+          printf 'unreadable\n' > "$ROOT/blocked/evidence.txt"
+          chmod 000 "$ROOT/blocked"
+      - name: Reject incomplete maturity scan
+        id: action-maturity-incomplete
+        continue-on-error: true
+        uses: ./
+        with:
+          version: 'file:${{ github.workspace }}/packages/cli'
+          working-directory: ${{ runner.temp }}/harness-action-maturity-incomplete
+          min-level: '0'
+          badge: 'incomplete-badge.svg'
+          report: 'incomplete-report.md'
+      - name: Verify incomplete maturity publishes no authoritative outputs or artifacts
+        if: ${{ always() }}
+        shell: bash
+        env:
+          HS_OUTCOME: ${{ steps.action-maturity-incomplete.outcome }}
+          HS_LEVEL: ${{ steps.action-maturity-incomplete.outputs.level }}
+          HS_LEVEL_NAME: ${{ steps.action-maturity-incomplete.outputs.level-name }}
+          HS_PERCENT: ${{ steps.action-maturity-incomplete.outputs.percent }}
+          HS_EFFECTIVE_LEVEL: ${{ steps.action-maturity-incomplete.outputs.effective-level }}
+          HS_EFFECTIVE_PERCENT: ${{ steps.action-maturity-incomplete.outputs.effective-percent }}
+        run: |
+          ROOT="$RUNNER_TEMP/harness-action-maturity-incomplete"
+          trap 'chmod 700 "$ROOT/blocked"' EXIT
           test "$HS_OUTCOME" = "failure"
           test -z "$HS_LEVEL"
           test -z "$HS_LEVEL_NAME"
           test -z "$HS_PERCENT"
           test -z "$HS_EFFECTIVE_LEVEL"
           test -z "$HS_EFFECTIVE_PERCENT"
-          test ! -e "$RUNNER_TEMP/harness-action-incomplete/incomplete-badge.svg"
-          test ! -e "$RUNNER_TEMP/harness-action-incomplete/incomplete-report.md"
+          test ! -e "$ROOT/incomplete-badge.svg"
+          test ! -e "$ROOT/incomplete-report.md"
+          test "$(node -p "require('$ROOT/harness-report.json').verdicts.maturity.status")" = "incomplete"
+          test "$(node -p "require('$ROOT/harness-report.json').verdicts.maturity.reasons[0].code")" = "unreadable-directory"
       - name: Consumer-facing type packaging check (typecheck:consumer)
         run: npm run typecheck:consumer -w harness-score
       - name: Published types match runtime exports (attw)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ A high score means the *infrastructure* for reliable agent work exists. It's
 necessary, not sufficient — and that's the honest ceiling of what any
 deterministic scanner can claim.
 
+The repository scan walks the complete relevant filesystem tree, including
+tracked, untracked, and ignored files. It skips known dependency and generated
+directories, and it never reads file bodies larger than 512 KiB. An emergency
+fuse stops pathological trees above 1,000,000 files; hitting that fuse or an
+unreadable directory marks the affected snapshot as incomplete instead of
+publishing its score as authoritative.
+
 ## Stability & versioning
 
 As of **v1.0.0**, Harness Score follows [semantic versioning](https://semver.org/)

--- a/README.md
+++ b/README.md
@@ -127,10 +127,11 @@ deterministic scanner can claim.
 
 The repository scan walks the complete relevant filesystem tree, including
 tracked, untracked, and ignored files. It skips known dependency and generated
-directories, and it never reads file bodies larger than 512 KiB. An emergency
-fuse stops pathological trees above 1,000,000 files; hitting that fuse or an
-unreadable directory marks the affected snapshot as incomplete instead of
-publishing its score as authoritative.
+directories, keeps followed symlink targets inside the scan root, and never
+reads file bodies larger than 512 KiB. An emergency fuse stops pathological
+trees above 1,000,000 files; hitting that fuse, finding an out-of-root symlink,
+or encountering an unreadable relevant path marks the affected snapshot as
+incomplete instead of publishing its score as authoritative.
 
 ## Stability & versioning
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,6 +11,7 @@ no npm token, no long-lived secret stored anywhere in this repo.
    - `version` in `packages/cli/jsr.json`
    - the `packages/cli` workspace version in `package-lock.json`
    - the `version` input default in `action.yml` and `action/action.yml`
+   - the `version` input row in `action/README.md`
    - If Cursor plugin content changed: `plugins/cursor/.cursor-plugin/plugin.json` +
      an entry in `plugins/cursor/CHANGELOG.md` (it has its own release
      track and version number).

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ branding:
 
 inputs:
   min-level:
-    description: 'Fail below this maturity level (0–4). Incomplete scans always fail, including at 0.'
+    description: 'Fail below this level (0–4). An incomplete gated snapshot exits 2, including at 0.'
     required: false
     default: '0'
   badge:
@@ -63,10 +63,10 @@ outputs:
     description: 'Maturity score percentage.'
     value: ${{ steps.scan.outputs.percent }}
   effective-level:
-    description: 'Effective level index when global scopes are enabled.'
+    description: 'Effective level index when the effective snapshot is complete.'
     value: ${{ steps.scan.outputs.effective-level }}
   effective-percent:
-    description: 'Effective score percentage when global scopes are enabled.'
+    description: 'Effective score percentage when the effective snapshot is complete.'
     value: ${{ steps.scan.outputs.effective-percent }}
 
 runs:
@@ -214,15 +214,18 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       env:
         HS_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        HS_CONFIG: ${{ inputs.config }}
         HS_VERSION: ${{ inputs.version }}
         HS_WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
         set -euo pipefail
+        BASELINE_ARGS=(--quiet --json)
+        [ -n "$HS_CONFIG" ] && BASELINE_ARGS+=(--config "$HS_CONFIG")
         git fetch origin "$HS_BASE_REF"
         git worktree remove /tmp/harness-score-base --force 2>/dev/null || true
         git worktree add /tmp/harness-score-base FETCH_HEAD
         npx -y "harness-score@$HS_VERSION" "/tmp/harness-score-base/$HS_WORKING_DIRECTORY" \
-          --quiet --json > /tmp/harness-score-base.json
+          "${BASELINE_ARGS[@]}" > /tmp/harness-score-base.json
         git worktree remove /tmp/harness-score-base --force
 
     - id: diff
@@ -230,10 +233,13 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
+        HS_CONFIG: ${{ inputs.config }}
         HS_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
-        npx -y "harness-score@$HS_VERSION" . --quiet --json \
+        DIFF_ARGS=(--quiet --json)
+        [ -n "$HS_CONFIG" ] && DIFF_ARGS+=(--config "$HS_CONFIG")
+        npx -y "harness-score@$HS_VERSION" . "${DIFF_ARGS[@]}" \
           --diff /tmp/harness-score-base.json > /tmp/harness-score-diff.json
 
     - id: comment

--- a/action.yml
+++ b/action.yml
@@ -95,32 +95,74 @@ runs:
         npx -y "harness-score@$HS_VERSION" . "${ARGS[@]}" > harness-report.json
         SCAN_STATUS=$?
         set -e
-        if [ "$SCAN_STATUS" -ne 0 ] && [ "$SCAN_STATUS" -ne 2 ]; then
-          exit "$SCAN_STATUS"
-        fi
 
-        node <<'NODE'
+        if ! SCAN_STATE=$(node <<'NODE'
         const fs = require('fs');
         const r = JSON.parse(fs.readFileSync('harness-report.json', 'utf8'));
+        if (!r.level || !r.score || !r.effective || !Array.isArray(r.dimensions)) {
+          throw new Error('harness-report.json is not a Harness Score report');
+        }
+
         const fallback = () => r.truncated
           ? { status: 'incomplete', reasons: [{ code: 'file-count-limit' }] }
           : { status: 'complete', reasons: [] };
-        const verdict = (scope) => r.verdicts?.[scope] ?? fallback();
-        const requested = ['maturity'];
-        if (r.scopes.effective.some((scope) => scope !== 'repo')) requested.push('effective');
-        const incomplete = requested.filter((scope) => verdict(scope).status === 'incomplete');
-        if (incomplete.length > 0) {
-          for (const scope of incomplete) {
-            const reasons = verdict(scope).reasons.map((reason) => {
-              const location = reason.path ? ` at ${reason.path}` : '';
-              const limit = reason.limit === undefined ? '' : ` (limit ${reason.limit})`;
-              return `${reason.code}${location}${limit}`;
-            }).join('; ');
-            console.error(`::error::Harness ${scope} scan is incomplete; no authoritative outputs were published: ${reasons}`);
-          }
-          process.exit(2);
+        const maturity = r.verdicts?.maturity ?? fallback();
+        const effective = r.verdicts?.effective ?? fallback();
+        const outputs = [];
+        const summary = [];
+
+        if (maturity.status === 'complete') {
+          outputs.push(`level=${r.level.index}`);
+          outputs.push(`level-name=${r.level.name}`);
+          outputs.push(`percent=${r.score.percent}`);
+          summary.push(`## Harness Score: L${r.level.index} - ${r.level.name} (${r.score.percent}% maturity)`);
+          summary.push('');
+          summary.push('| Dimension | Score | % |');
+          summary.push('|---|---|---|');
+          summary.push(...r.dimensions.map((d) => `| ${d.title} | ${d.earned}/${d.max} | ${d.percent}% |`));
+        } else {
+          console.error('::error::Harness maturity scan is incomplete; maturity outputs and artifacts were not published.');
+          summary.push('## Harness Score: maturity unavailable');
+          summary.push('');
+          summary.push('> Error: The maturity scan is incomplete. No maturity outputs or artifacts were published.');
         }
+
+        if (effective.status === 'complete') {
+          outputs.push(`effective-level=${r.effective.level.index}`);
+          outputs.push(`effective-percent=${r.effective.score.percent}`);
+          if (
+            maturity.status === 'complete' &&
+            (r.effective.level.index !== r.level.index || r.effective.score.percent !== r.score.percent)
+          ) {
+            summary.splice(1, 0, `Effective: L${r.effective.level.index} (${r.effective.score.percent}%) - gate: ${r.gate}`, '');
+          }
+        } else {
+          console.error('::warning::Harness effective scan is incomplete; effective outputs were not published.');
+          summary.push('');
+          summary.push('> Warning: Effective score unavailable because the effective scan is incomplete.');
+        }
+
+        if (outputs.length > 0) {
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `${outputs.join('\n')}\n`);
+        }
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary.join('\n')}\n`);
+        process.stdout.write([
+          maturity.status,
+          effective.status,
+          r.gate,
+          r.level.index,
+          r.effective.level.index,
+        ].join('\t'));
         NODE
+        ); then
+          echo "::error::Harness Score did not produce a valid JSON report."
+          if [ "$SCAN_STATUS" -ne 0 ]; then
+            exit "$SCAN_STATUS"
+          fi
+          exit 2
+        fi
+
+        IFS=$'\t' read -r MATURITY_STATUS EFFECTIVE_STATUS GATE LEVEL EFF_LEVEL <<< "$SCAN_STATE"
 
         ARTIFACT_ARGS=(--quiet)
         [ -n "$HS_BADGE" ] && ARTIFACT_ARGS+=(--badge "$HS_BADGE")
@@ -129,36 +171,40 @@ runs:
         [ "$HS_INCLUDE_USER_HARNESS" = "true" ] && ARTIFACT_ARGS+=(--scope user)
         [ "$HS_INCLUDE_SYSTEM_HARNESS" = "true" ] && ARTIFACT_ARGS+=(--scope system)
         [ -n "$HS_GATE" ] && ARTIFACT_ARGS+=(--gate "$HS_GATE")
-        if [ -n "$HS_BADGE" ] || [ -n "$HS_REPORT" ]; then
+        if [ "$MATURITY_STATUS" = "complete" ] && { [ -n "$HS_BADGE" ] || [ -n "$HS_REPORT" ]; }; then
+          set +e
           npx -y "harness-score@$HS_VERSION" . "${ARTIFACT_ARGS[@]}"
+          ARTIFACT_STATUS=$?
+          set -e
+          if [ "$ARTIFACT_STATUS" -ne 0 ] && ! { [ "$ARTIFACT_STATUS" -eq 2 ] && [ "$EFFECTIVE_STATUS" = "incomplete" ]; }; then
+            exit "$ARTIFACT_STATUS"
+          fi
         fi
 
-        LEVEL=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).level.index")
-        NAME=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).level.name")
-        PERCENT=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).score.percent")
-        EFF_LEVEL=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).effective.level.index")
-        EFF_PERCENT=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).effective.score.percent")
-        GATE=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).gate")
-        GATE_LEVEL=$(node -p "const r=JSON.parse(require('fs').readFileSync('harness-report.json','utf8')); (r.gate==='effective'?r.effective:r).level.index")
-        GATE_GAPS=$(node -p "const r=JSON.parse(require('fs').readFileSync('harness-report.json','utf8')); (r.gate==='effective'?r.effective:r).level.nextLevelGaps.join('; ')")
-        echo "level=$LEVEL" >> "$GITHUB_OUTPUT"
-        echo "level-name=$NAME" >> "$GITHUB_OUTPUT"
-        echo "percent=$PERCENT" >> "$GITHUB_OUTPUT"
-        echo "effective-level=$EFF_LEVEL" >> "$GITHUB_OUTPUT"
-        echo "effective-percent=$EFF_PERCENT" >> "$GITHUB_OUTPUT"
-        echo "## Harness Score: L$LEVEL · $NAME ($PERCENT% maturity)" >> "$GITHUB_STEP_SUMMARY"
-        if [ "$EFF_LEVEL" != "$LEVEL" ] || [ "$EFF_PERCENT" != "$PERCENT" ]; then
-          echo "Effective: L$EFF_LEVEL ($EFF_PERCENT%) · gate: $GATE" >> "$GITHUB_STEP_SUMMARY"
+        if [ "$SCAN_STATUS" -ne 0 ] && [ "$SCAN_STATUS" -ne 2 ]; then
+          exit "$SCAN_STATUS"
         fi
-        node -e "
-          const r = JSON.parse(require('fs').readFileSync('harness-report.json','utf8'));
-          const rows = r.dimensions.map(d => '| ' + d.title + ' | ' + d.earned + '/' + d.max + ' | ' + d.percent + '% |').join('\n');
-          require('fs').appendFileSync(process.env.GITHUB_STEP_SUMMARY, '\n| Dimension | Score | % |\n|---|---|---|\n' + rows + '\n');
-        "
+
+        if [ "$MATURITY_STATUS" != "complete" ]; then
+          [ "$SCAN_STATUS" -ne 0 ] && exit "$SCAN_STATUS"
+          exit 2
+        fi
+
+        if [ "$GATE" = "effective" ] && [ "$EFFECTIVE_STATUS" != "complete" ]; then
+          [ "$SCAN_STATUS" -ne 0 ] && exit "$SCAN_STATUS"
+          exit 2
+        fi
+
+        if [ "$SCAN_STATUS" -ne 0 ] && ! { [ "$SCAN_STATUS" -eq 2 ] && [ "$EFFECTIVE_STATUS" = "incomplete" ] && [ "$GATE" = "maturity" ]; }; then
+          exit "$SCAN_STATUS"
+        fi
+
+        GATE_LEVEL="$LEVEL"
+        [ "$GATE" = "effective" ] && GATE_LEVEL="$EFF_LEVEL"
 
         if [ "$GATE_LEVEL" -lt "$HS_MIN_LEVEL" ]; then
           echo "::error::Harness ${GATE} L${GATE_LEVEL} is below required L${HS_MIN_LEVEL}."
-          echo "$GATE_GAPS"
+          node -e "const r=require('./harness-report.json'); console.log((r.gate==='effective'?r.effective:r).level.nextLevelGaps.join('; '))"
           exit 1
         fi
 

--- a/action/README.md
+++ b/action/README.md
@@ -25,7 +25,9 @@ publish the badge, upload it as an artifact or commit it to a `badges`
 branch, then reference it from your README:
 
 The Action fails closed when the snapshot selected by `gate` is incomplete
-(file-count limit, depth limit, or unreadable directory). Complete maturity
+(file-count limit, depth limit, or unreadable relevant path such as an
+`unreadable-path` or `unreadable-directory`, plus out-of-root symlinks).
+Complete maturity
 outputs, badges, and reports remain authoritative when only an additional
 effective scope is incomplete. In that case, `gate: maturity` can pass with a
 warning, while `gate: effective` exits 2. Effective outputs remain empty until
@@ -50,6 +52,10 @@ new one each time.
 
 This is opt-in and requires the calling workflow to grant
 `pull-requests: write` — the action cannot request that permission for you:
+
+When `config` is set, the main scan, base-branch baseline, and current diff all
+use that same explicit configuration. Leave `config` empty to preserve config
+autodiscovery in each scanned tree.
 
 ```yaml
 on:

--- a/action/README.md
+++ b/action/README.md
@@ -24,7 +24,12 @@ A per-run summary (level + dimension table) appears in the job summary. To
 publish the badge, upload it as an artifact or commit it to a `badges`
 branch, then reference it from your README:
 
-The Action fails closed when a requested filesystem scan is incomplete (file-count limit, depth limit, or unreadable directory). It exits before publishing level outputs, a badge, a Markdown report, a job summary, or a pull-request comment, even when `min-level` is `0`.
+The Action fails closed when the snapshot selected by `gate` is incomplete
+(file-count limit, depth limit, or unreadable directory). Complete maturity
+outputs, badges, and reports remain authoritative when only an additional
+effective scope is incomplete. In that case, `gate: maturity` can pass with a
+warning, while `gate: effective` exits 2. Effective outputs remain empty until
+the effective snapshot is complete.
 
 Pin a full commit SHA instead of `v1` for maximum supply-chain stability. The legacy
 `paladini/harness-score/action@<ref>` entrypoint remains compatible, but the
@@ -81,13 +86,19 @@ concurrency:
 
 | Input | Default | Description |
 |---|---|---|
-| `min-level` | `0` | Fail when maturity is below this level (0–4); incomplete scans always fail |
+| `min-level` | `0` | Fail when the complete gated score is below this level (0–4); an incomplete gated snapshot exits 2 |
 | `badge` | `harness-badge.svg` | SVG pill (`harness` + level); empty to skip |
 | `report` | _(empty)_ | Markdown report output path |
 | `working-directory` | `.` | Directory to scan |
 | `version` | `1.5.3` | harness-score npm version or package spec |
 | `comment` | `false` | Post/update a sticky PR comment with the score delta (`pull_request` events only; requires `pull-requests: write`) |
+| `include-user-harness` | `false` | Include the user-level harness in the effective snapshot |
+| `include-system-harness` | `false` | Include the system-level harness in the effective snapshot |
+| `gate` | `maturity` | Select which snapshot `min-level` and incomplete-scan failures use |
+| `config` | _(empty)_ | Pass a specific scanner configuration file |
 
 ## Outputs
 
-`level` (0–4), `level-name`, `percent`.
+`level` (0–4), `level-name`, and `percent` describe maturity and are published
+only when maturity is complete. `effective-level` and `effective-percent` are
+published only when the effective snapshot is complete.

--- a/action/action.yml
+++ b/action/action.yml
@@ -9,7 +9,7 @@ branding:
 
 inputs:
   min-level:
-    description: 'Fail below this maturity level (0–4). Incomplete scans always fail, including at 0.'
+    description: 'Fail below this level (0–4). An incomplete gated snapshot exits 2, including at 0.'
     required: false
     default: '0'
   badge:
@@ -63,10 +63,10 @@ outputs:
     description: 'Maturity score percentage.'
     value: ${{ steps.scan.outputs.percent }}
   effective-level:
-    description: 'Effective level index when global scopes are enabled.'
+    description: 'Effective level index when the effective snapshot is complete.'
     value: ${{ steps.scan.outputs.effective-level }}
   effective-percent:
-    description: 'Effective score percentage when global scopes are enabled.'
+    description: 'Effective score percentage when the effective snapshot is complete.'
     value: ${{ steps.scan.outputs.effective-percent }}
 
 runs:
@@ -214,15 +214,18 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       env:
         HS_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        HS_CONFIG: ${{ inputs.config }}
         HS_VERSION: ${{ inputs.version }}
         HS_WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
         set -euo pipefail
+        BASELINE_ARGS=(--quiet --json)
+        [ -n "$HS_CONFIG" ] && BASELINE_ARGS+=(--config "$HS_CONFIG")
         git fetch origin "$HS_BASE_REF"
         git worktree remove /tmp/harness-score-base --force 2>/dev/null || true
         git worktree add /tmp/harness-score-base FETCH_HEAD
         npx -y "harness-score@$HS_VERSION" "/tmp/harness-score-base/$HS_WORKING_DIRECTORY" \
-          --quiet --json > /tmp/harness-score-base.json
+          "${BASELINE_ARGS[@]}" > /tmp/harness-score-base.json
         git worktree remove /tmp/harness-score-base --force
 
     - id: diff
@@ -230,10 +233,13 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
+        HS_CONFIG: ${{ inputs.config }}
         HS_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
-        npx -y "harness-score@$HS_VERSION" . --quiet --json \
+        DIFF_ARGS=(--quiet --json)
+        [ -n "$HS_CONFIG" ] && DIFF_ARGS+=(--config "$HS_CONFIG")
+        npx -y "harness-score@$HS_VERSION" . "${DIFF_ARGS[@]}" \
           --diff /tmp/harness-score-base.json > /tmp/harness-score-diff.json
 
     - id: comment

--- a/action/action.yml
+++ b/action/action.yml
@@ -95,32 +95,74 @@ runs:
         npx -y "harness-score@$HS_VERSION" . "${ARGS[@]}" > harness-report.json
         SCAN_STATUS=$?
         set -e
-        if [ "$SCAN_STATUS" -ne 0 ] && [ "$SCAN_STATUS" -ne 2 ]; then
-          exit "$SCAN_STATUS"
-        fi
 
-        node <<'NODE'
+        if ! SCAN_STATE=$(node <<'NODE'
         const fs = require('fs');
         const r = JSON.parse(fs.readFileSync('harness-report.json', 'utf8'));
+        if (!r.level || !r.score || !r.effective || !Array.isArray(r.dimensions)) {
+          throw new Error('harness-report.json is not a Harness Score report');
+        }
+
         const fallback = () => r.truncated
           ? { status: 'incomplete', reasons: [{ code: 'file-count-limit' }] }
           : { status: 'complete', reasons: [] };
-        const verdict = (scope) => r.verdicts?.[scope] ?? fallback();
-        const requested = ['maturity'];
-        if (r.scopes.effective.some((scope) => scope !== 'repo')) requested.push('effective');
-        const incomplete = requested.filter((scope) => verdict(scope).status === 'incomplete');
-        if (incomplete.length > 0) {
-          for (const scope of incomplete) {
-            const reasons = verdict(scope).reasons.map((reason) => {
-              const location = reason.path ? ` at ${reason.path}` : '';
-              const limit = reason.limit === undefined ? '' : ` (limit ${reason.limit})`;
-              return `${reason.code}${location}${limit}`;
-            }).join('; ');
-            console.error(`::error::Harness ${scope} scan is incomplete; no authoritative outputs were published: ${reasons}`);
-          }
-          process.exit(2);
+        const maturity = r.verdicts?.maturity ?? fallback();
+        const effective = r.verdicts?.effective ?? fallback();
+        const outputs = [];
+        const summary = [];
+
+        if (maturity.status === 'complete') {
+          outputs.push(`level=${r.level.index}`);
+          outputs.push(`level-name=${r.level.name}`);
+          outputs.push(`percent=${r.score.percent}`);
+          summary.push(`## Harness Score: L${r.level.index} - ${r.level.name} (${r.score.percent}% maturity)`);
+          summary.push('');
+          summary.push('| Dimension | Score | % |');
+          summary.push('|---|---|---|');
+          summary.push(...r.dimensions.map((d) => `| ${d.title} | ${d.earned}/${d.max} | ${d.percent}% |`));
+        } else {
+          console.error('::error::Harness maturity scan is incomplete; maturity outputs and artifacts were not published.');
+          summary.push('## Harness Score: maturity unavailable');
+          summary.push('');
+          summary.push('> Error: The maturity scan is incomplete. No maturity outputs or artifacts were published.');
         }
+
+        if (effective.status === 'complete') {
+          outputs.push(`effective-level=${r.effective.level.index}`);
+          outputs.push(`effective-percent=${r.effective.score.percent}`);
+          if (
+            maturity.status === 'complete' &&
+            (r.effective.level.index !== r.level.index || r.effective.score.percent !== r.score.percent)
+          ) {
+            summary.splice(1, 0, `Effective: L${r.effective.level.index} (${r.effective.score.percent}%) - gate: ${r.gate}`, '');
+          }
+        } else {
+          console.error('::warning::Harness effective scan is incomplete; effective outputs were not published.');
+          summary.push('');
+          summary.push('> Warning: Effective score unavailable because the effective scan is incomplete.');
+        }
+
+        if (outputs.length > 0) {
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `${outputs.join('\n')}\n`);
+        }
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary.join('\n')}\n`);
+        process.stdout.write([
+          maturity.status,
+          effective.status,
+          r.gate,
+          r.level.index,
+          r.effective.level.index,
+        ].join('\t'));
         NODE
+        ); then
+          echo "::error::Harness Score did not produce a valid JSON report."
+          if [ "$SCAN_STATUS" -ne 0 ]; then
+            exit "$SCAN_STATUS"
+          fi
+          exit 2
+        fi
+
+        IFS=$'\t' read -r MATURITY_STATUS EFFECTIVE_STATUS GATE LEVEL EFF_LEVEL <<< "$SCAN_STATE"
 
         ARTIFACT_ARGS=(--quiet)
         [ -n "$HS_BADGE" ] && ARTIFACT_ARGS+=(--badge "$HS_BADGE")
@@ -129,36 +171,40 @@ runs:
         [ "$HS_INCLUDE_USER_HARNESS" = "true" ] && ARTIFACT_ARGS+=(--scope user)
         [ "$HS_INCLUDE_SYSTEM_HARNESS" = "true" ] && ARTIFACT_ARGS+=(--scope system)
         [ -n "$HS_GATE" ] && ARTIFACT_ARGS+=(--gate "$HS_GATE")
-        if [ -n "$HS_BADGE" ] || [ -n "$HS_REPORT" ]; then
+        if [ "$MATURITY_STATUS" = "complete" ] && { [ -n "$HS_BADGE" ] || [ -n "$HS_REPORT" ]; }; then
+          set +e
           npx -y "harness-score@$HS_VERSION" . "${ARTIFACT_ARGS[@]}"
+          ARTIFACT_STATUS=$?
+          set -e
+          if [ "$ARTIFACT_STATUS" -ne 0 ] && ! { [ "$ARTIFACT_STATUS" -eq 2 ] && [ "$EFFECTIVE_STATUS" = "incomplete" ]; }; then
+            exit "$ARTIFACT_STATUS"
+          fi
         fi
 
-        LEVEL=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).level.index")
-        NAME=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).level.name")
-        PERCENT=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).score.percent")
-        EFF_LEVEL=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).effective.level.index")
-        EFF_PERCENT=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).effective.score.percent")
-        GATE=$(node -p "JSON.parse(require('fs').readFileSync('harness-report.json','utf8')).gate")
-        GATE_LEVEL=$(node -p "const r=JSON.parse(require('fs').readFileSync('harness-report.json','utf8')); (r.gate==='effective'?r.effective:r).level.index")
-        GATE_GAPS=$(node -p "const r=JSON.parse(require('fs').readFileSync('harness-report.json','utf8')); (r.gate==='effective'?r.effective:r).level.nextLevelGaps.join('; ')")
-        echo "level=$LEVEL" >> "$GITHUB_OUTPUT"
-        echo "level-name=$NAME" >> "$GITHUB_OUTPUT"
-        echo "percent=$PERCENT" >> "$GITHUB_OUTPUT"
-        echo "effective-level=$EFF_LEVEL" >> "$GITHUB_OUTPUT"
-        echo "effective-percent=$EFF_PERCENT" >> "$GITHUB_OUTPUT"
-        echo "## Harness Score: L$LEVEL · $NAME ($PERCENT% maturity)" >> "$GITHUB_STEP_SUMMARY"
-        if [ "$EFF_LEVEL" != "$LEVEL" ] || [ "$EFF_PERCENT" != "$PERCENT" ]; then
-          echo "Effective: L$EFF_LEVEL ($EFF_PERCENT%) · gate: $GATE" >> "$GITHUB_STEP_SUMMARY"
+        if [ "$SCAN_STATUS" -ne 0 ] && [ "$SCAN_STATUS" -ne 2 ]; then
+          exit "$SCAN_STATUS"
         fi
-        node -e "
-          const r = JSON.parse(require('fs').readFileSync('harness-report.json','utf8'));
-          const rows = r.dimensions.map(d => '| ' + d.title + ' | ' + d.earned + '/' + d.max + ' | ' + d.percent + '% |').join('\n');
-          require('fs').appendFileSync(process.env.GITHUB_STEP_SUMMARY, '\n| Dimension | Score | % |\n|---|---|---|\n' + rows + '\n');
-        "
+
+        if [ "$MATURITY_STATUS" != "complete" ]; then
+          [ "$SCAN_STATUS" -ne 0 ] && exit "$SCAN_STATUS"
+          exit 2
+        fi
+
+        if [ "$GATE" = "effective" ] && [ "$EFFECTIVE_STATUS" != "complete" ]; then
+          [ "$SCAN_STATUS" -ne 0 ] && exit "$SCAN_STATUS"
+          exit 2
+        fi
+
+        if [ "$SCAN_STATUS" -ne 0 ] && ! { [ "$SCAN_STATUS" -eq 2 ] && [ "$EFFECTIVE_STATUS" = "incomplete" ] && [ "$GATE" = "maturity" ]; }; then
+          exit "$SCAN_STATUS"
+        fi
+
+        GATE_LEVEL="$LEVEL"
+        [ "$GATE" = "effective" ] && GATE_LEVEL="$EFF_LEVEL"
 
         if [ "$GATE_LEVEL" -lt "$HS_MIN_LEVEL" ]; then
           echo "::error::Harness ${GATE} L${GATE_LEVEL} is below required L${HS_MIN_LEVEL}."
-          echo "$GATE_GAPS"
+          node -e "const r=require('./harness-report.json'); console.log((r.gate==='effective'?r.effective:r).level.nextLevelGaps.join('; '))"
           exit 1
         fi
 

--- a/docs/es/guide/metrics-and-codes.md
+++ b/docs/es/guide/metrics-and-codes.md
@@ -182,12 +182,19 @@ Excluir una dimensión entera tiene una consecuencia honesta que vale la pena sa
 
 ## Flags de CLI (configuración del scan)
 
+El descubrimiento de maturity del repositorio no tiene límite de profundidad
+en producción. Incluye archivos tracked, untracked e ignored después de omitir
+directorios conocidos de dependencias y artefactos generados.
+`file-count-limit` representa un fusible de emergencia de 1.000.000 de archivos
+para el repositorio; los overlays limitados de user y extra roots aún pueden
+reportar `depth-limit`.
+
 | Flag | Significado |
 |---|---|
 | `--config <file>` | Cargar config desde ruta específica |
 | `--scope user` | Habilitar scope user (separados por coma: `user`, `system`) |
 | `--gate maturity\|effective` | Puntaje usado para `--min-level` |
-| `--min-level <0-4>` | Exit 1 cuando un puntaje gated completo está bajo el nivel; scopes solicitados incompletos siempre retornan exit 2 |
+| `--min-level <0-4>` | Exit 1 cuando el puntaje gated completo está bajo el nivel; un snapshot seleccionado por el gate incompleto retorna exit 2 |
 | `--json` | Reporte completo incluyendo `scopes`, `gate`, `effective` y `verdicts` |
 
 ## Inputs de GitHub Action
@@ -201,7 +208,7 @@ Excluir una dimensión entera tiene una consecuencia honesta que vale la pena sa
 | `min-level` | `0` | Falla cuando el puntaje gated está bajo el nivel |
 
 Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effective-percent`.
-Si un scope solicitado está incompleto, la Action falla antes de publicar estos outputs, badge, reporte Markdown, resumen del job o comentario en la PR.
+La Action publica outputs, badge y reporte de maturity solo cuando maturity está completo, y outputs de effective solo cuando effective está completo. Si solo effective está incompleto, `gate: maturity` puede pasar con una advertencia; `gate: effective` retorna exit 2. Maturity incompleto no publica outputs de maturity, badge, reporte o comentario en la PR.
 
 ## Campos JSON del reporte (estables)
 
@@ -224,6 +231,6 @@ Si un scope solicitado está incompleto, la Action falla antes de publicar estos
 | `checks[].severity` | `"off"` \| `"warn"` \| `"error"` — la severidad resuelta que este scan usó para ese check |
 | `checks[].warnings` | Diagnósticos opcionales y no fatales `{ code, message, source? }`; terminal y Markdown los muestran sin cambiar puntos |
 
-`level`, `score`, dimensiones y checks siguen presentes para diagnóstico, pero son provisionales cuando su veredicto es `incomplete`. Terminal y Markdown indican que la madurez no está disponible, y el badge usa `incomplete`, nunca L0-L4. Los reportes antiguos sin `verdicts` se consideran completos cuando `truncated` es `false` e incompletos cuando es `true`.
+`level`, `score`, dimensiones y checks siguen presentes para diagnóstico, pero son provisionales cuando su veredicto es `incomplete`. Terminal y Markdown identifican el snapshot no disponible. El badge siempre representa maturity y usa `incomplete`, nunca L0-L4, cuando maturity está incompleto. Los reportes antiguos sin `verdicts` se consideran completos cuando `truncated` es `false` e incompletos cuando es `true`.
 
-`--diff` compara campos de **maturity** por defecto (top-level `level` / `score` / `checks`) y rechaza un baseline o resultado actual incompleto.
+`--diff` compara campos de **maturity** por defecto (top-level `level` / `score` / `checks`) y rechaza un baseline o resultado actual con maturity incompleto. Effective incompleto no bloquea un diff de maturity.

--- a/docs/es/guide/metrics-and-codes.md
+++ b/docs/es/guide/metrics-and-codes.md
@@ -187,7 +187,11 @@ en producción. Incluye archivos tracked, untracked e ignored después de omitir
 directorios conocidos de dependencias y artefactos generados.
 `file-count-limit` representa un fusible de emergencia de 1.000.000 de archivos
 para el repositorio; los overlays limitados de user y extra roots aún pueden
-reportar `depth-limit`.
+reportar `depth-limit`. Una ruta descubierta que no puede inspeccionarse cuando
+un check la solicita reporta `unreadable-path`; los contenidos de más de 512 KiB
+omitidos intencionalmente no reportan ese motivo. Los symlinks internos se siguen
+y deduplican; un destino fuera de la raíz reporta `outside-root-symlink` y no se
+recorre ni se lee.
 
 | Flag | Significado |
 |---|---|
@@ -223,8 +227,8 @@ La Action publica outputs, badge y reporte de maturity solo cuando maturity est�
 | `effective` | Misma forma: `{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | Herramientas vistas en el **repo** (informativo) |
 | `verdicts.maturity`, `verdicts.effective` | Estado de completitud y motivos deterministas de cada snapshot: `complete` o `incomplete` |
-| `verdicts.*.reasons[]` | `file-count-limit`, `depth-limit` o `unreadable-directory`, con `path` y `limit` opcionales |
-| `truncated` | Alias de compatibilidad; `true` cuando cualquier snapshot solicitado está incompleto por cualquier motivo |
+| `verdicts.*.reasons[]` | `file-count-limit`, `depth-limit`, `unreadable-directory`, `unreadable-path` o `outside-root-symlink`, con `path` y `limit` opcionales |
+| `truncated` | Alias de compatibilidad; `true` cuando el snapshot de maturity o effective está incompleto por cualquier motivo |
 | `preset` | `{ extends, rules, resolved }` — personalización de equipo efectivamente aplicada; `resolved` solo lista checks cuya severidad difiere del default |
 | `level.capped`, `level.capReason` | `capped` es `true` cuando un requisito bloqueante del siguiente nivel nunca puede cumplirse bajo la config actual (ej.: dimensión excluida por preset); `capReason` explica el motivo |
 | `dimensions[].applicable` | `false` solo cuando todo check de esa dimensión resolvió a `"off"` |

--- a/docs/guide/metrics-and-codes.md
+++ b/docs/guide/metrics-and-codes.md
@@ -186,7 +186,10 @@ Repository maturity discovery has no production depth cap. It includes tracked,
 untracked, and ignored files after skipping known dependency and generated
 directories. `file-count-limit` represents an emergency 1,000,000-file fuse for
 the repository scan; bounded user and extra-root overlays can still report
-`depth-limit`.
+`depth-limit`. A discovered path that cannot be inspected when a check requests
+it reports `unreadable-path`; intentionally skipped bodies above 512 KiB do not.
+Internal symlinks are followed and deduplicated, while a target outside the scan
+root reports `outside-root-symlink` and is not traversed or read.
 
 | Flag | Meaning |
 |---|---|
@@ -222,8 +225,8 @@ The Action publishes maturity outputs, badges, and reports only when maturity is
 | `effective` | Same shape: `{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | Tools seen in **repo** (informational) |
 | `verdicts.maturity`, `verdicts.effective` | Completeness status and deterministic reasons for each snapshot: `complete` or `incomplete` |
-| `verdicts.*.reasons[]` | `file-count-limit`, `depth-limit`, or `unreadable-directory`, with optional `path` and `limit` |
-| `truncated` | Compatibility alias; `true` when either requested snapshot is incomplete for any reason |
+| `verdicts.*.reasons[]` | `file-count-limit`, `depth-limit`, `unreadable-directory`, `unreadable-path`, or `outside-root-symlink`, with optional `path` and `limit` |
+| `truncated` | Compatibility alias; `true` when the maturity or effective snapshot is incomplete for any reason |
 | `preset` | `{ extends, rules, resolved }` — team customization actually applied; `resolved` lists only checks whose severity differs from the default |
 | `level.capped`, `level.capReason` | `capped` is `true` when a blocking requirement for the next level can never be met under the current config (e.g. its dimension was excluded by a preset); `capReason` explains why |
 | `dimensions[].applicable` | `false` only when every check in that dimension resolved to `"off"` |

--- a/docs/guide/metrics-and-codes.md
+++ b/docs/guide/metrics-and-codes.md
@@ -182,12 +182,18 @@ Excluding an entire dimension has one honest consequence worth knowing up front:
 
 ## CLI flags (scan configuration)
 
+Repository maturity discovery has no production depth cap. It includes tracked,
+untracked, and ignored files after skipping known dependency and generated
+directories. `file-count-limit` represents an emergency 1,000,000-file fuse for
+the repository scan; bounded user and extra-root overlays can still report
+`depth-limit`.
+
 | Flag | Meaning |
 |---|---|
 | `--config <file>` | Load config from a specific path |
 | `--scope user` | Enable user scope (comma-separated: `user`, `system`) |
 | `--gate maturity\|effective` | Score used for `--min-level` |
-| `--min-level <0-4>` | Exit 1 when a complete gated score is below level; incomplete requested scopes always exit 2 |
+| `--min-level <0-4>` | Exit 1 when a complete gated score is below level; an incomplete gated snapshot exits 2 |
 | `--json` | Full report including `scopes`, `gate`, `effective`, and `verdicts` |
 
 ## GitHub Action inputs
@@ -201,7 +207,7 @@ Excluding an entire dimension has one honest consequence worth knowing up front:
 | `min-level` | `0` | Fail when gated score is below level |
 
 Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effective-percent`.
-If a requested scan scope is incomplete, the Action fails before publishing any of these outputs, a badge, a Markdown report, a job summary, or a PR comment.
+The Action publishes maturity outputs, badges, and reports only when maturity is complete, and effective outputs only when effective is complete. If only effective is incomplete, `gate: maturity` can pass with a warning; `gate: effective` exits 2. An incomplete maturity snapshot publishes no maturity outputs, badge, report, or PR comment.
 
 ## Report JSON fields (stable)
 
@@ -224,6 +230,6 @@ If a requested scan scope is incomplete, the Action fails before publishing any 
 | `checks[].severity` | `"off"` \| `"warn"` \| `"error"` — the resolved severity this scan used for that check |
 | `checks[].warnings` | Optional non-fatal diagnostics `{ code, message, source? }`; terminal and Markdown render them without changing points |
 
-`level`, `score`, dimensions, and checks remain present for diagnosis, but are provisional when their verdict is `incomplete`. Terminal and Markdown say the maturity is unavailable, and the badge value is `incomplete`, never L0-L4. Old reports without `verdicts` are treated as complete when `truncated` is `false`, and incomplete when it is `true`.
+`level`, `score`, dimensions, and checks remain present for diagnosis, but are provisional when their verdict is `incomplete`. Terminal and Markdown identify the unavailable snapshot. The badge always represents maturity and uses `incomplete`, never L0-L4, when maturity is incomplete. Old reports without `verdicts` are treated as complete when `truncated` is `false`, and incomplete when it is `true`.
 
-`--diff` compares **maturity** fields by default (top-level `level` / `score` / `checks`) and rejects an incomplete baseline or current result.
+`--diff` compares **maturity** fields by default (top-level `level` / `score` / `checks`) and rejects an incomplete maturity baseline or current result. An incomplete effective snapshot does not block a maturity diff.

--- a/docs/hi-IN/guide/metrics-and-codes.md
+++ b/docs/hi-IN/guide/metrics-and-codes.md
@@ -186,7 +186,11 @@ Repository maturity discovery पर production depth cap नहीं है।
 और generated directories को छोड़ने के बाद इसमें tracked, untracked, और ignored
 files शामिल होते हैं। Repository scan में `file-count-limit` emergency
 1,000,000-file fuse को दर्शाता है; bounded user और extra-root overlays अभी भी
-`depth-limit` report कर सकते हैं।
+`depth-limit` report कर सकते हैं। Check के request करने पर inspect न हो पाने वाला
+discovered path `unreadable-path` report करता है; जानबूझकर skip किए गए 512 KiB से
+बड़े bodies यह reason report नहीं करते। Internal symlinks follow और deduplicate
+होते हैं; scan root के बाहर का target `outside-root-symlink` report करता है और
+उसे traverse या read नहीं किया जाता।
 
 | Flag | Meaning |
 |---|---|
@@ -222,8 +226,8 @@ Action maturity complete होने पर ही maturity outputs, badge, औ
 | `effective` | Same shape: `{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | **Repo** में देखे गए tools (informational) |
 | `verdicts.maturity`, `verdicts.effective` | हर snapshot का completeness status और deterministic reasons: `complete` या `incomplete` |
-| `verdicts.*.reasons[]` | `file-count-limit`, `depth-limit`, या `unreadable-directory`, optional `path` और `limit` के साथ |
-| `truncated` | Compatibility alias; किसी भी requested snapshot के किसी कारण से incomplete होने पर `true` |
+| `verdicts.*.reasons[]` | `file-count-limit`, `depth-limit`, `unreadable-directory`, `unreadable-path`, या `outside-root-symlink`, optional `path` और `limit` के साथ |
+| `truncated` | Compatibility alias; maturity या effective snapshot के किसी कारण से incomplete होने पर `true` |
 | `preset` | `{ extends, rules, resolved }` — इस scan में actually apply हुई team customization; `resolved` सिर्फ वे checks list करता है जिनकी severity default से अलग है |
 | `level.capped`, `level.capReason` | जब अगले level की कोई blocking requirement वर्तमान config में कभी पूरी नहीं हो सकती (जैसे उसकी dimension preset से excluded), तो `capped` `true` होता है; `capReason` वजह बताता है |
 | `dimensions[].applicable` | `false` सिर्फ तब जब उस dimension का हर check `"off"` resolve हुआ हो |

--- a/docs/hi-IN/guide/metrics-and-codes.md
+++ b/docs/hi-IN/guide/metrics-and-codes.md
@@ -182,12 +182,18 @@ Precedence: **CLI flags → Action inputs → config file → defaults**। `ext
 
 ## CLI flags (स्कैन कॉन्फ़िगरेशन)
 
+Repository maturity discovery पर production depth cap नहीं है। Known dependency
+और generated directories को छोड़ने के बाद इसमें tracked, untracked, और ignored
+files शामिल होते हैं। Repository scan में `file-count-limit` emergency
+1,000,000-file fuse को दर्शाता है; bounded user और extra-root overlays अभी भी
+`depth-limit` report कर सकते हैं।
+
 | Flag | Meaning |
 |---|---|
 | `--config <file>` | Specific path से config load करें |
 | `--scope user` | User scope enable (comma-separated: `user`, `system`) |
 | `--gate maturity\|effective` | `--min-level` के लिए score |
-| `--min-level <0-4>` | Complete gated score level से नीचे हो तो exit 1; कोई requested scope incomplete हो तो हमेशा exit 2 |
+| `--min-level <0-4>` | Complete gated score level से नीचे हो तो exit 1; gate द्वारा चुना गया snapshot incomplete हो तो exit 2 |
 | `--json` | Full report including `scopes`, `gate`, `effective`, और `verdicts` |
 
 ## GitHub Action इनपुट
@@ -201,7 +207,7 @@ Precedence: **CLI flags → Action inputs → config file → defaults**। `ext
 | `min-level` | `0` | Gated score level से नीचे हो तो fail |
 
 Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effective-percent`.
-अगर कोई requested scope incomplete है, तो Action इन outputs, badge, Markdown report, job summary, या PR comment को publish करने से पहले fail होती है।
+Action maturity complete होने पर ही maturity outputs, badge, और report publish करती है, और effective complete होने पर ही effective outputs publish करती है। अगर केवल effective incomplete है, तो `gate: maturity` warning के साथ pass हो सकता है; `gate: effective` exit 2 देता है। Maturity incomplete होने पर maturity outputs, badge, report, या PR comment publish नहीं होते।
 
 ## Report JSON फ़ील्ड (स्थिर)
 
@@ -224,6 +230,6 @@ Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effect
 | `checks[].severity` | `"off"` \| `"warn"` \| `"error"` — इस scan ने उस check के लिए जो resolved severity use की |
 | `checks[].warnings` | Optional non-fatal diagnostics `{ code, message, source? }`; terminal और Markdown इन्हें points बदले बिना दिखाते हैं |
 
-`level`, `score`, dimensions, और checks diagnosis के लिए मौजूद रहते हैं, लेकिन संबंधित verdict `incomplete` होने पर provisional हैं। Terminal और Markdown maturity को unavailable दिखाते हैं, और badge value `incomplete` होती है, कभी L0-L4 नहीं। `verdicts` के बिना पुराने reports में `truncated: false` complete और `truncated: true` incomplete माना जाता है।
+`level`, `score`, dimensions, और checks diagnosis के लिए मौजूद रहते हैं, लेकिन संबंधित verdict `incomplete` होने पर provisional हैं। Terminal और Markdown unavailable snapshot को पहचानते हैं। Badge हमेशा maturity को दिखाता है और maturity incomplete होने पर `incomplete` value इस्तेमाल करता है, कभी L0-L4 नहीं। `verdicts` के बिना पुराने reports में `truncated: false` complete और `truncated: true` incomplete माना जाता है।
 
-`--diff` default में **maturity** fields compare करता है (top-level `level` / `score` / `checks`) और incomplete baseline या current result को reject करता है।
+`--diff` default में **maturity** fields compare करता है (top-level `level` / `score` / `checks`) और incomplete maturity baseline या current result को reject करता है। Incomplete effective snapshot maturity diff को block नहीं करता।

--- a/docs/pt-BR/guide/metrics-and-codes.md
+++ b/docs/pt-BR/guide/metrics-and-codes.md
@@ -187,7 +187,11 @@ produção. Ela inclui arquivos rastreados, não rastreados e ignorados depois d
 pular diretórios conhecidos de dependências e artefatos gerados.
 `file-count-limit` representa um fusível emergencial de 1.000.000 de arquivos
 para o repositório; overlays limitados de user e extra roots ainda podem
-reportar `depth-limit`.
+reportar `depth-limit`. Um caminho descoberto que não possa ser inspecionado
+quando solicitado por um check reporta `unreadable-path`; conteúdos acima de
+512 KiB, ignorados intencionalmente, não reportam esse motivo. Symlinks internos
+são seguidos e deduplicados, enquanto um alvo fora da raiz reporta
+`outside-root-symlink` e não é percorrido nem lido.
 
 | Flag | Significado |
 |---|---|
@@ -223,8 +227,8 @@ A Action publica outputs, badge e relatório de maturity somente quando maturity
 | `effective` | Mesma forma: `{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | Ferramentas vistas no **repo** (informativo) |
 | `verdicts.maturity`, `verdicts.effective` | Status de completude e motivos determinísticos de cada snapshot: `complete` ou `incomplete` |
-| `verdicts.*.reasons[]` | `file-count-limit`, `depth-limit` ou `unreadable-directory`, com `path` e `limit` opcionais |
-| `truncated` | Alias de compatibilidade; `true` quando qualquer snapshot solicitado está incompleto por qualquer motivo |
+| `verdicts.*.reasons[]` | `file-count-limit`, `depth-limit`, `unreadable-directory`, `unreadable-path` ou `outside-root-symlink`, com `path` e `limit` opcionais |
+| `truncated` | Alias de compatibilidade; `true` quando o snapshot de maturity ou effective está incompleto por qualquer motivo |
 | `preset` | `{ extends, rules, resolved }` — personalização de equipe efetivamente aplicada; `resolved` só lista checks cuja severidade difere do padrão |
 | `level.capped`, `level.capReason` | `capped` é `true` quando um requisito bloqueante do próximo nível nunca pode ser satisfeito sob a config atual (ex.: dimensão excluída por preset); `capReason` explica o motivo |
 | `dimensions[].applicable` | `false` só quando todo check daquela dimensão resolveu para `"off"` |

--- a/docs/pt-BR/guide/metrics-and-codes.md
+++ b/docs/pt-BR/guide/metrics-and-codes.md
@@ -182,12 +182,19 @@ Excluir uma dimensão inteira tem uma consequência honesta que vale saber de an
 
 ## Flags da CLI (configuração do scan)
 
+A descoberta de maturity no repositório não possui limite de profundidade em
+produção. Ela inclui arquivos rastreados, não rastreados e ignorados depois de
+pular diretórios conhecidos de dependências e artefatos gerados.
+`file-count-limit` representa um fusível emergencial de 1.000.000 de arquivos
+para o repositório; overlays limitados de user e extra roots ainda podem
+reportar `depth-limit`.
+
 | Flag | Significado |
 |---|---|
 | `--config <file>` | Carregar config de caminho específico |
 | `--scope user` | Habilitar escopo user (separados por vírgula: `user`, `system`) |
 | `--gate maturity\|effective` | Pontuação usada para `--min-level` |
-| `--min-level <0-4>` | Exit 1 quando uma pontuação gated completa está abaixo do nível; escopos solicitados incompletos sempre retornam exit 2 |
+| `--min-level <0-4>` | Exit 1 quando a pontuação gated completa está abaixo do nível; snapshot selecionado pelo gate incompleto retorna exit 2 |
 | `--json` | Relatório completo incluindo `scopes`, `gate`, `effective` e `verdicts` |
 
 ## Inputs da GitHub Action
@@ -201,7 +208,7 @@ Excluir uma dimensão inteira tem uma consequência honesta que vale saber de an
 | `min-level` | `0` | Falha quando pontuação gated está abaixo do nível |
 
 Outputs: `level`, `level-name`, `percent` (maturity); `effective-level`, `effective-percent`.
-Se um escopo solicitado estiver incompleto, a Action falha antes de publicar esses outputs, badge, relatório Markdown, resumo do job ou comentário na PR.
+A Action publica outputs, badge e relatório de maturity somente quando maturity está completo, e outputs de effective somente quando effective está completo. Se apenas effective estiver incompleto, `gate: maturity` pode passar com um aviso; `gate: effective` retorna exit 2. Maturity incompleto não publica outputs de maturity, badge, relatório ou comentário na PR.
 
 ## Campos JSON do relatório (estáveis)
 
@@ -224,6 +231,6 @@ Se um escopo solicitado estiver incompleto, a Action falha antes de publicar ess
 | `checks[].severity` | `"off"` \| `"warn"` \| `"error"` — a severidade resolvida usada por este scan para aquele check |
 | `checks[].warnings` | Diagnósticos opcionais e não fatais `{ code, message, source? }`; terminal e Markdown os exibem sem alterar pontos |
 
-`level`, `score`, dimensões e checks continuam presentes para diagnóstico, mas são provisórios quando o veredito correspondente é `incomplete`. Terminal e Markdown informam que a maturidade está indisponível, e o badge usa `incomplete`, nunca L0-L4. Relatórios antigos sem `verdicts` são completos quando `truncated` é `false` e incompletos quando é `true`.
+`level`, `score`, dimensões e checks continuam presentes para diagnóstico, mas são provisórios quando o veredito correspondente é `incomplete`. Terminal e Markdown identificam o snapshot indisponível. O badge sempre representa maturity e usa `incomplete`, nunca L0-L4, quando maturity está incompleto. Relatórios antigos sem `verdicts` são completos quando `truncated` é `false` e incompletos quando é `true`.
 
-`--diff` compara campos de **maturity** por padrão (top-level `level` / `score` / `checks`) e rejeita baseline ou resultado atual incompleto.
+`--diff` compara campos de **maturity** por padrão (top-level `level` / `score` / `checks`) e rejeita baseline ou resultado atual com maturity incompleto. Effective incompleto não bloqueia um diff de maturity.

--- a/docs/zh-CN/guide/metrics-and-codes.md
+++ b/docs/zh-CN/guide/metrics-and-codes.md
@@ -181,7 +181,10 @@
 
 仓库 maturity 发现没有生产环境深度上限。跳过已知依赖和生成目录后，它会包含 tracked、
 untracked 和 ignored 文件。仓库扫描中的 `file-count-limit` 表示 1,000,000 个文件的
-紧急保险丝；有界的 user 和 extra-root overlay 仍可能报告 `depth-limit`。
+紧急保险丝；有界的 user 和 extra-root overlay 仍可能报告 `depth-limit`。如果 check
+请求检查一个已发现但无法读取的路径，则报告 `unreadable-path`；有意跳过的 512 KiB
+以上文件内容不会报告该原因。内部 symlink 会被跟随并去重；指向扫描根目录之外的目标会
+报告 `outside-root-symlink`，且不会被遍历或读取。
 
 | 标志 | 含义 |
 |---|---|
@@ -222,8 +225,8 @@ Action 仅在 maturity 完整时发布 maturity outputs、badge 和报告，仅�
 | `effective` | 相同结构：`{ level, score, dimensions, checks, detectedHarnesses }` |
 | `detectedHarnesses` | **repo** 中看到的工具（仅供参考） |
 | `verdicts.maturity`、`verdicts.effective` | 每个 snapshot 的完整性状态与确定性原因：`complete` 或 `incomplete` |
-| `verdicts.*.reasons[]` | `file-count-limit`、`depth-limit` 或 `unreadable-directory`，可带 `path` 与 `limit` |
-| `truncated` | 兼容别名；任一请求的 snapshot 因任何原因不完整时为 `true` |
+| `verdicts.*.reasons[]` | `file-count-limit`、`depth-limit`、`unreadable-directory`、`unreadable-path` 或 `outside-root-symlink`，可带 `path` 与 `limit` |
+| `truncated` | 兼容别名；maturity 或 effective snapshot 因任何原因不完整时为 `true` |
 
 `level`、`score`、dimensions 与 checks 仍会保留用于诊断，但对应 verdict 为 `incomplete` 时仅是 provisional。Terminal 与 Markdown 会明确指出不可用的 snapshot。Badge 始终表示 maturity；当 maturity 不完整时值为 `incomplete`，绝不显示 L0-L4。旧报告缺少 `verdicts` 时，`truncated: false` 视为完整，`truncated: true` 视为不完整。
 

--- a/docs/zh-CN/guide/metrics-and-codes.md
+++ b/docs/zh-CN/guide/metrics-and-codes.md
@@ -179,12 +179,16 @@
 
 ## CLI 标志（扫描配置）
 
+仓库 maturity 发现没有生产环境深度上限。跳过已知依赖和生成目录后，它会包含 tracked、
+untracked 和 ignored 文件。仓库扫描中的 `file-count-limit` 表示 1,000,000 个文件的
+紧急保险丝；有界的 user 和 extra-root overlay 仍可能报告 `depth-limit`。
+
 | 标志 | 含义 |
 |---|---|
 | `--config <file>` | 从指定路径加载配置 |
 | `--scope user` | 启用 user scope（逗号分隔：`user`、`system`） |
 | `--gate maturity\|effective` | `--min-level` 使用的分数 |
-| `--min-level <0-4>` | 完整 gated 分数低于等级时 exit 1；任何请求的 scope 不完整时始终 exit 2 |
+| `--min-level <0-4>` | 完整 gated 分数低于等级时 exit 1；gate 选择的 snapshot 不完整时 exit 2 |
 | `--json` | 完整报告，含 `scopes`、`gate`、`effective` 与 `verdicts` |
 
 ## GitHub Action 输入
@@ -198,7 +202,7 @@
 | `min-level` | `0` | gated 分数低于等级时失败 |
 
 Outputs：`level`、`level-name`、`percent`（maturity）；`effective-level`、`effective-percent`。
-若请求的 scope 不完整，Action 会在发布这些 outputs、badge、Markdown 报告、job summary 或 PR comment 前失败。
+Action 仅在 maturity 完整时发布 maturity outputs、badge 和报告，仅在 effective 完整时发布 effective outputs。若只有 effective 不完整，`gate: maturity` 可在给出警告后通过；`gate: effective` 返回 exit 2。Maturity 不完整时不发布 maturity outputs、badge、报告或 PR comment。
 
 ## 报告 JSON 字段（稳定）
 
@@ -221,6 +225,6 @@ Outputs：`level`、`level-name`、`percent`（maturity）；`effective-level`�
 | `verdicts.*.reasons[]` | `file-count-limit`、`depth-limit` 或 `unreadable-directory`，可带 `path` 与 `limit` |
 | `truncated` | 兼容别名；任一请求的 snapshot 因任何原因不完整时为 `true` |
 
-`level`、`score`、dimensions 与 checks 仍会保留用于诊断，但对应 verdict 为 `incomplete` 时仅是 provisional。Terminal 与 Markdown 会显示 maturity unavailable，badge 值为 `incomplete`，绝不显示 L0-L4。旧报告缺少 `verdicts` 时，`truncated: false` 视为完整，`truncated: true` 视为不完整。
+`level`、`score`、dimensions 与 checks 仍会保留用于诊断，但对应 verdict 为 `incomplete` 时仅是 provisional。Terminal 与 Markdown 会明确指出不可用的 snapshot。Badge 始终表示 maturity；当 maturity 不完整时值为 `incomplete`，绝不显示 L0-L4。旧报告缺少 `verdicts` 时，`truncated: false` 视为完整，`truncated: true` 视为不完整。
 
-`--diff` 默认比较 **maturity** 字段（顶层 `level` / `score` / `checks`），并拒绝不完整的 baseline 或当前结果。
+`--diff` 默认比较 **maturity** 字段（顶层 `level` / `score` / `checks`），并拒绝 maturity 不完整的 baseline 或当前结果。Effective 不完整不会阻止 maturity diff。

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,6 +17,14 @@ The scan reads your filesystem and parses config — that's it. No network
 calls, no telemetry, no model in the loop. Same repo in, same score out,
 every time.
 
+Repository discovery walks the complete relevant filesystem tree without a
+production depth cap, including tracked, untracked, and ignored files. Known
+dependency and generated directories are skipped, followed symlink targets
+must remain inside the scan root, and file bodies above 512 KiB are not read. A
+1,000,000-file emergency fuse protects against pathological trees; reaching it,
+finding an out-of-root symlink, or encountering an unreadable relevant path
+marks the affected snapshot as incomplete instead of authoritative.
+
 Full maturity model, check catalog, and remediation guide:
 **[paladini.github.io/harness-score](https://paladini.github.io/harness-score/)**
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -84,6 +84,12 @@ project before each release.
 - run: npx harness-score --min-level 3
 ```
 
+The exit status follows the snapshot selected by `--gate`. An incomplete gated
+snapshot exits 2. If `maturity` is complete and only an additional `effective`
+scope is incomplete, `--gate maturity` can still pass and reports the effective
+snapshot as unavailable. JSON output keeps incomplete values for diagnosis and
+marks their authority through `verdicts`.
+
 Or use the [packaged GitHub Action](https://github.com/paladini/harness-score/tree/main/action),
 which also emits the badge.
 

--- a/packages/cli/bench/scan.bench.mjs
+++ b/packages/cli/bench/scan.bench.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
 /**
  * Scan-time benchmark against a synthetic large repository. Not part of the
  * test suite (no pass/fail assertion) — a manual before/after measurement
@@ -8,7 +9,30 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { score } from '../dist/index.js';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+
+if (process.argv[2] === '--scan-root') {
+  const root = process.argv[3];
+  if (!root) throw new Error('Benchmark worker requires a scan root.');
+  const start = process.hrtime.bigint();
+  const report = score(root);
+  const end = process.hrtime.bigint();
+  if (report.verdicts?.maturity.status !== 'complete') {
+    throw new Error(`Benchmark scan was incomplete at ${root}.`);
+  }
+  process.stdout.write(
+    JSON.stringify({
+      ms: Number(end - start) / 1e6,
+      rss: process.resourceUsage().maxRSS * 1024,
+      level: report.level.name,
+      checks: report.checks.length,
+    }),
+  );
+  process.exit(0);
+}
 
 const FILE_COUNTS = String(process.argv[2] ?? '5000')
   .split(',')
@@ -57,18 +81,19 @@ for (const fileCount of FILE_COUNTS) {
   const timings = [];
   let peakRss = 0;
   for (let i = 0; i < ITERATIONS; i += 1) {
-    const start = process.hrtime.bigint();
-    const report = score(root);
-    const end = process.hrtime.bigint();
-    if (report.verdicts?.maturity.status !== 'complete') {
-      throw new Error(`Benchmark scan was incomplete at ${fileCount} files.`);
+    // Each sample gets a fresh process, matching normal CLI usage and avoiding
+    // V8 retention from an earlier sample inflating the next sample's RSS.
+    const child = spawnSync(process.execPath, [SCRIPT_PATH, '--scan-root', root], {
+      encoding: 'utf8',
+    });
+    if (child.status !== 0) {
+      throw new Error(child.stderr || `Benchmark worker exited ${child.status}.`);
     }
-    const ms = Number(end - start) / 1e6;
-    const rss = process.memoryUsage().rss;
+    const { ms, rss, level, checks } = JSON.parse(child.stdout);
     timings.push(ms);
     peakRss = Math.max(peakRss, rss);
     console.log(
-      `  run ${i + 1}/${ITERATIONS}: ${ms.toFixed(1)}ms, RSS ${formatMiB(rss)} (level ${report.level.name}, ${report.checks.length} checks)`,
+      `  run ${i + 1}/${ITERATIONS}: ${ms.toFixed(1)}ms, peak RSS ${formatMiB(rss)} (level ${level}, ${checks} checks)`,
     );
   }
 
@@ -78,7 +103,7 @@ for (const fileCount of FILE_COUNTS) {
   const median = sorted.length % 2 === 0 ? (sorted[midpoint - 1] + sorted[midpoint]) / 2 : sorted[midpoint];
   console.log(`Average over ${ITERATIONS} runs: ${avg.toFixed(1)}ms (${fileCount} files)`);
   console.log(`Median over ${ITERATIONS} runs: ${median.toFixed(1)}ms (${fileCount} files)`);
-  console.log(`Peak RSS over ${ITERATIONS} runs: ${formatMiB(peakRss)} (${fileCount} files)`);
+  console.log(`Peak process RSS over ${ITERATIONS} runs: ${formatMiB(peakRss)} (${fileCount} files)`);
 
   fs.rmSync(root, { recursive: true, force: true });
 }

--- a/packages/cli/bench/scan.bench.mjs
+++ b/packages/cli/bench/scan.bench.mjs
@@ -3,15 +3,21 @@
  * Scan-time benchmark against a synthetic large repository. Not part of the
  * test suite (no pass/fail assertion) — a manual before/after measurement
  * tool for changes to scan.ts, per the distribution/perf improvement plan.
- * Run with `npm run bench` (requires `npm run build` first).
+ * Run with `npm run bench -- 5000,25000 5` (requires `npm run build` first).
  */
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { score } from '../dist/index.js';
 
-const FILE_COUNT = Number(process.argv[2] ?? 5000);
+const FILE_COUNTS = String(process.argv[2] ?? '5000')
+  .split(',')
+  .map((value) => Number(value));
 const ITERATIONS = Number(process.argv[3] ?? 5);
+
+function formatMiB(bytes) {
+  return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+}
 
 function buildSyntheticRepo(root, fileCount) {
   fs.mkdirSync(path.join(root, '.cursor', 'rules'), { recursive: true });
@@ -43,27 +49,33 @@ function buildSyntheticRepo(root, fileCount) {
   }
 }
 
-const root = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-score-bench-'));
-console.log(`Building synthetic repo with ~${FILE_COUNT} files at ${root} ...`);
-buildSyntheticRepo(root, FILE_COUNT);
+for (const fileCount of FILE_COUNTS) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-score-bench-'));
+  console.log(`Building synthetic repo with ~${fileCount} files at ${root} ...`);
+  buildSyntheticRepo(root, fileCount);
 
-const timings = [];
-for (let i = 0; i < ITERATIONS; i += 1) {
-  const start = process.hrtime.bigint();
-  const report = score(root);
-  const end = process.hrtime.bigint();
-  const ms = Number(end - start) / 1e6;
-  timings.push(ms);
-  console.log(
-    `  run ${i + 1}/${ITERATIONS}: ${ms.toFixed(1)}ms (level ${report.level.name}, ${report.checks.length} checks)`,
-  );
+  const timings = [];
+  let peakRss = 0;
+  for (let i = 0; i < ITERATIONS; i += 1) {
+    const start = process.hrtime.bigint();
+    const report = score(root);
+    const end = process.hrtime.bigint();
+    const ms = Number(end - start) / 1e6;
+    const rss = process.memoryUsage().rss;
+    timings.push(ms);
+    peakRss = Math.max(peakRss, rss);
+    console.log(
+      `  run ${i + 1}/${ITERATIONS}: ${ms.toFixed(1)}ms, RSS ${formatMiB(rss)} (level ${report.level.name}, ${report.checks.length} checks)`,
+    );
+  }
+
+  const avg = timings.reduce((a, b) => a + b, 0) / timings.length;
+  const sorted = [...timings].sort((a, b) => a - b);
+  const midpoint = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 === 0 ? (sorted[midpoint - 1] + sorted[midpoint]) / 2 : sorted[midpoint];
+  console.log(`Average over ${ITERATIONS} runs: ${avg.toFixed(1)}ms (${fileCount} files)`);
+  console.log(`Median over ${ITERATIONS} runs: ${median.toFixed(1)}ms (${fileCount} files)`);
+  console.log(`Peak RSS over ${ITERATIONS} runs: ${formatMiB(peakRss)} (${fileCount} files)`);
+
+  fs.rmSync(root, { recursive: true, force: true });
 }
-
-const avg = timings.reduce((a, b) => a + b, 0) / timings.length;
-const sorted = [...timings].sort((a, b) => a - b);
-const midpoint = Math.floor(sorted.length / 2);
-const median = sorted.length % 2 === 0 ? (sorted[midpoint - 1] + sorted[midpoint]) / 2 : sorted[midpoint];
-console.log(`\nAverage over ${ITERATIONS} runs: ${avg.toFixed(1)}ms (${FILE_COUNT} files)`);
-console.log(`Median over ${ITERATIONS} runs: ${median.toFixed(1)}ms (${FILE_COUNT} files)`);
-
-fs.rmSync(root, { recursive: true, force: true });

--- a/packages/cli/bench/scan.bench.mjs
+++ b/packages/cli/bench/scan.bench.mjs
@@ -60,6 +60,9 @@ for (const fileCount of FILE_COUNTS) {
     const start = process.hrtime.bigint();
     const report = score(root);
     const end = process.hrtime.bigint();
+    if (report.verdicts?.maturity.status !== 'complete') {
+      throw new Error(`Benchmark scan was incomplete at ${fileCount} files.`);
+    }
     const ms = Number(end - start) / 1e6;
     const rss = process.memoryUsage().rss;
     timings.push(ms);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -34,7 +34,7 @@ Options:
   --version            Print version
   --help               Show this help
 
-Exit codes: 0 complete/pass, 1 complete scan below --min-level, 2 invalid usage or incomplete requested scan.
+Exit codes: 0 complete/pass, 1 complete scan below --min-level, 2 invalid usage or incomplete gated scan.
 
 Configuration file (optional): .harness-score.json in the scan root.
 See the guide: https://paladini.github.io/harness-score/guide/measure-and-improve
@@ -174,12 +174,20 @@ function gatedLevel(report: Report): Report['level'] {
 
 function requestedVerdictScopes(report: Report): Array<'maturity' | 'effective'> {
   const scopes: Array<'maturity' | 'effective'> = ['maturity'];
-  if (report.scopes.effective.some((scope) => scope !== 'repo')) scopes.push('effective');
+  if (report.gate === 'effective' || report.scopes.effective.some((scope) => scope !== 'repo')) {
+    scopes.push('effective');
+  }
   return scopes;
 }
 
 function incompleteRequestedScopes(report: Report): Array<'maturity' | 'effective'> {
   return requestedVerdictScopes(report).filter((scope) => !reportScopeIsComplete(report, scope));
+}
+
+function gateExitCode(report: Report, minLevel: number | null): 0 | 1 | 2 {
+  if (!reportScopeIsComplete(report, report.gate)) return 2;
+  if (minLevel !== null && gatedLevel(report).index < minLevel) return 1;
+  return 0;
 }
 
 const args = parseArgs(process.argv.slice(2));
@@ -249,25 +257,24 @@ if (args.badge !== null) {
 }
 
 const incompleteScopes = incompleteRequestedScopes(report);
-if (incompleteScopes.length > 0) {
-  for (const scope of incompleteScopes) {
-    const reasons = reportVerdict(report, scope).reasons.map(formatIncompleteReason).join('; ');
-    process.stderr.write(
-      `harness-score: ${scope} scan is incomplete; no authoritative verdict is available` +
-        `${reasons ? `: ${reasons}` : '.'}\n`,
-    );
-  }
+for (const scope of incompleteScopes) {
+  const reasons = reportVerdict(report, scope).reasons.map(formatIncompleteReason).join('; ');
+  process.stderr.write(
+    `harness-score: ${scope} scan is incomplete; no authoritative ${scope} verdict is available` +
+      `${reasons ? `: ${reasons}` : '.'}\n`,
+  );
+}
+
+const exitCode = gateExitCode(report, args.minLevel);
+if (exitCode === 2) {
   process.exit(2);
 }
 
-if (args.minLevel !== null) {
+if (exitCode === 1 && args.minLevel !== null) {
   const level = gatedLevel(report);
-  if (level.index < args.minLevel) {
-    const gateLabel = report.gate === 'effective' ? 'effective' : 'maturity';
-    process.stderr.write(
-      `harness-score: ${gateLabel} L${level.index} is below required L${args.minLevel} — ` +
-        `missing: ${level.nextLevelGaps.join('; ') || 'see failed checks'}\n`,
-    );
-    process.exit(1);
-  }
+  process.stderr.write(
+    `harness-score: ${report.gate} L${level.index} is below required L${args.minLevel} — ` +
+      `missing: ${level.nextLevelGaps.join('; ') || 'see failed checks'}\n`,
+  );
+  process.exit(1);
 }

--- a/packages/cli/src/report/markdown.ts
+++ b/packages/cli/src/report/markdown.ts
@@ -104,7 +104,12 @@ export function renderMarkdown(report: Report, diff?: ReportDiff | null): string
   }
   lines.push('');
   if (!maturityComplete || (showEffective && !effectiveComplete)) {
-    lines.push('> ⚠ This scan is incomplete. Provisional scores and checks are not authoritative.');
+    if (!maturityComplete) {
+      lines.push('> ⚠ Maturity scan is incomplete. Provisional maturity results are not authoritative.');
+    }
+    if (showEffective && !effectiveComplete) {
+      lines.push('> ⚠ Effective scan is incomplete. Provisional effective results are not authoritative.');
+    }
     lines.push('');
     lines.push('## Incomplete scan reasons');
     lines.push('');

--- a/packages/cli/src/report/terminal.ts
+++ b/packages/cli/src/report/terminal.ts
@@ -107,10 +107,23 @@ export function renderTerminal(report: Report, diff?: ReportDiff | null): string
   lines.push('');
   lines.push(bold(`  harness-score v${report.tool.version}`) + dim(`  ${report.root}`));
   lines.push('');
+  if (!maturityComplete) {
+    lines.push(
+      yellow(
+        `  ${WARN} Maturity scan incomplete ${MIDDOT} provisional maturity results are not authoritative.`,
+      ),
+    );
+    lines.push(...renderIncompleteReasons(report, 'maturity'));
+  }
+  if (showEffective && !effectiveComplete) {
+    lines.push(
+      yellow(
+        `  ${WARN} Effective scan incomplete ${MIDDOT} provisional effective results are not authoritative.`,
+      ),
+    );
+    lines.push(...renderIncompleteReasons(report, 'effective'));
+  }
   if (!maturityComplete || (showEffective && !effectiveComplete)) {
-    lines.push(yellow(`  ${WARN} Incomplete scan ${MIDDOT} provisional results are not authoritative.`));
-    if (!maturityComplete) lines.push(...renderIncompleteReasons(report, 'maturity'));
-    if (showEffective && !effectiveComplete) lines.push(...renderIncompleteReasons(report, 'effective'));
     lines.push('');
   }
   if (maturityComplete) {

--- a/packages/cli/src/scan.ts
+++ b/packages/cli/src/scan.ts
@@ -67,6 +67,7 @@ interface WalkOptions {
   maxDepth?: number;
   maxFiles?: number;
   readDirectory?: (directory: string) => fs.Dirent[];
+  statPath?: (path: string) => fs.Stats;
 }
 
 export interface WalkResult {
@@ -79,15 +80,30 @@ function addFirstReason(reasons: ScanIncompleteReason[], reason: ScanIncompleteR
   if (!reasons.some((existing) => existing.code === reason.code)) reasons.push(reason);
 }
 
+function isMissingOrBrokenSymlink(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException)?.code;
+  return code === 'ENOENT' || code === 'ENOTDIR' || code === 'ELOOP';
+}
+
+function isInsideRoot(rootReal: string, targetReal: string): boolean {
+  const relative = path.relative(rootReal, targetReal);
+  return (
+    relative === '' ||
+    (!path.isAbsolute(relative) && relative !== '..' && !relative.startsWith(`..${path.sep}`))
+  );
+}
+
 /** Internal/testable deterministic filesystem walker. `maxDepth` is a test seam only. */
 export function walkDirectory(root: string, options: WalkOptions = {}): WalkResult {
   const maxDepth = options.maxDepth;
   const maxFiles = options.maxFiles ?? MAX_FILES;
   const readDirectory =
     options.readDirectory ?? ((directory: string) => fs.readdirSync(directory, { withFileTypes: true }));
+  const statPath = options.statPath ?? fs.statSync;
   const files: string[] = [];
   const incompleteReasons: ScanIncompleteReason[] = [];
-  const visitedRealDirs = new Set<string>([safeRealpath(root) ?? root]);
+  const rootReal = safeRealpath(root) ?? path.resolve(root);
+  const visitedRealDirs = new Set<string>([rootReal]);
   const stack: Array<{ abs: string; rel: string; depth: number }> = [{ abs: root, rel: '', depth: 0 }];
 
   while (stack.length > 0) {
@@ -111,13 +127,26 @@ export function walkDirectory(root: string, options: WalkOptions = {}): WalkResu
       const abs = path.join(dir.abs, entry.name);
       let isDir = entry.isDirectory();
       let isFile = entry.isFile();
+      let symlinkReal: string | null = null;
 
       if (entry.isSymbolicLink()) {
         let stat: fs.Stats;
         try {
-          stat = fs.statSync(abs); // follows the symlink, unlike lstatSync
-        } catch {
-          continue; // broken symlink target
+          stat = statPath(abs); // follows the symlink, unlike lstatSync
+        } catch (error) {
+          if (!isMissingOrBrokenSymlink(error)) {
+            addFirstReason(incompleteReasons, { code: 'unreadable-path', path: rel });
+          }
+          continue;
+        }
+        symlinkReal = safeRealpath(abs);
+        if (symlinkReal === null) {
+          addFirstReason(incompleteReasons, { code: 'unreadable-path', path: rel });
+          continue;
+        }
+        if (!isInsideRoot(rootReal, symlinkReal)) {
+          addFirstReason(incompleteReasons, { code: 'outside-root-symlink', path: rel });
+          continue;
         }
         isDir = stat.isDirectory();
         isFile = stat.isFile();
@@ -132,7 +161,7 @@ export function walkDirectory(root: string, options: WalkOptions = {}): WalkResu
         // Dedup by real path so symlink cycles (and hardlink-style repeats)
         // can't loop forever; readdirSync/statSync below still follow the
         // symlink transparently via its own (non-resolved) `abs` path.
-        const real = safeRealpath(abs) ?? abs;
+        const real = symlinkReal ?? safeRealpath(abs) ?? abs;
         if (visitedRealDirs.has(real)) continue;
         visitedRealDirs.add(real);
         childDirs.push({ abs, rel, depth: dir.depth + 1 });
@@ -172,6 +201,7 @@ function buildContext(
   repoFiles: string[],
   incompleteReasons: ScanIncompleteReason[],
   overlayAbsByRel: Map<string, string>,
+  overlayLabelByRel: Map<string, string>,
 ): ScanContext {
   const repoSet = new Set(repoFiles);
   const fileSet = new Set(repoFiles);
@@ -185,7 +215,9 @@ function buildContext(
   return {
     root,
     files,
-    truncated: incompleteReasons.length > 0,
+    get truncated(): boolean {
+      return incompleteReasons.length > 0;
+    },
     incompleteReasons,
     has(relPath: string): boolean {
       return fileSet.has(relPath);
@@ -207,6 +239,12 @@ function buildContext(
           }
         } catch {
           content = null;
+          addFirstReason(incompleteReasons, {
+            code: 'unreadable-path',
+            path: repoSet.has(relPath)
+              ? relPath
+              : `${overlayLabelByRel.get(relPath) ?? 'overlay'}:${relPath}`,
+          });
         }
       }
       contentCache.set(relPath, content);
@@ -229,6 +267,7 @@ export function createScanContext(rootInput: string, options: CreateScanOptions 
   const overlays = options.overlays ?? [];
 
   const overlayAbsByRel = new Map<string, string>();
+  const overlayLabelByRel = new Map<string, string>();
   const effectiveReasons = normalizeReasons(repoTruncated, repoReasons);
   const repoSet = new Set(repoFiles);
 
@@ -242,12 +281,13 @@ export function createScanContext(rootInput: string, options: CreateScanOptions 
     for (const [rel, abs] of overlay.files) {
       if (repoSet.has(rel)) continue;
       overlayAbsByRel.set(rel, abs);
+      overlayLabelByRel.set(rel, overlay.label);
     }
   }
 
   if (overlays.length === 0) {
-    return buildContext(root, repoFiles, effectiveReasons, overlayAbsByRel);
+    return buildContext(root, repoFiles, effectiveReasons, overlayAbsByRel, overlayLabelByRel);
   }
 
-  return buildContext(root, repoFiles, effectiveReasons, overlayAbsByRel);
+  return buildContext(root, repoFiles, effectiveReasons, overlayAbsByRel, overlayLabelByRel);
 }

--- a/packages/cli/src/scan.ts
+++ b/packages/cli/src/scan.ts
@@ -38,8 +38,8 @@ const SKIP_DIRS = new Set([
  */
 const SKIP_RELATIVE_PATHS = new Set(['.yarn/cache', '.yarn/unplugged', '.yarn/install-state.gz']);
 
-const MAX_DEPTH = 10;
-const MAX_FILES = 20000;
+/** Emergency fuse against pathological repositories; normal scans should complete well below it. */
+const MAX_FILES = 1_000_000;
 /** Never read file bodies larger than this (binary/artifact protection). */
 const MAX_READ_BYTES = 512 * 1024;
 
@@ -79,9 +79,9 @@ function addFirstReason(reasons: ScanIncompleteReason[], reason: ScanIncompleteR
   if (!reasons.some((existing) => existing.code === reason.code)) reasons.push(reason);
 }
 
-/** Internal/testable deterministic filesystem walker. Production callers use fixed limits. */
+/** Internal/testable deterministic filesystem walker. `maxDepth` is a test seam only. */
 export function walkDirectory(root: string, options: WalkOptions = {}): WalkResult {
-  const maxDepth = options.maxDepth ?? MAX_DEPTH;
+  const maxDepth = options.maxDepth;
   const maxFiles = options.maxFiles ?? MAX_FILES;
   const readDirectory =
     options.readDirectory ?? ((directory: string) => fs.readdirSync(directory, { withFileTypes: true }));
@@ -125,7 +125,7 @@ export function walkDirectory(root: string, options: WalkOptions = {}): WalkResu
 
       if (isDir) {
         if (SKIP_DIRS.has(entry.name)) continue;
-        if (dir.depth >= maxDepth) {
+        if (maxDepth !== undefined && dir.depth >= maxDepth) {
           addFirstReason(incompleteReasons, { code: 'depth-limit', path: rel, limit: maxDepth });
           continue;
         }

--- a/packages/cli/src/scan.ts
+++ b/packages/cli/src/scan.ts
@@ -70,6 +70,13 @@ interface WalkOptions {
   statPath?: (path: string) => fs.Stats;
 }
 
+interface PendingDirectory {
+  abs: string;
+  rel: string;
+  depth: number;
+  real: string;
+}
+
 export interface WalkResult {
   files: string[];
   truncated: boolean;
@@ -103,11 +110,17 @@ export function walkDirectory(root: string, options: WalkOptions = {}): WalkResu
   const files: string[] = [];
   const incompleteReasons: ScanIncompleteReason[] = [];
   const rootReal = safeRealpath(root) ?? path.resolve(root);
-  const visitedRealDirs = new Set<string>([rootReal]);
-  const stack: Array<{ abs: string; rel: string; depth: number }> = [{ abs: root, rel: '', depth: 0 }];
+  const visitedRealDirs = new Set<string>();
+  const stack: PendingDirectory[] = [{ abs: root, rel: '', depth: 0, real: rootReal }];
+  const deferredSymlinkDirs: PendingDirectory[] = [];
 
-  while (stack.length > 0) {
-    const dir = stack.pop()!;
+  while (stack.length > 0 || deferredSymlinkDirs.length > 0) {
+    // Exhaust physical directories before aliases so a lexically earlier
+    // symlink cannot hide the canonical repository path for the same target.
+    const dir = stack.pop() ?? deferredSymlinkDirs.pop()!;
+    if (visitedRealDirs.has(dir.real)) continue;
+    visitedRealDirs.add(dir.real);
+
     let entries: fs.Dirent[];
     try {
       entries = readDirectory(dir.abs);
@@ -119,10 +132,16 @@ export function walkDirectory(root: string, options: WalkOptions = {}): WalkResu
       continue;
     }
     entries.sort((a, b) => compareLexically(a.name, b.name));
-    const childDirs: Array<{ abs: string; rel: string; depth: number }> = [];
+    const childDirs: PendingDirectory[] = [];
+    const childSymlinkDirs: PendingDirectory[] = [];
     for (const entry of entries) {
       const rel = dir.rel === '' ? entry.name : `${dir.rel}/${entry.name}`;
-      if (SKIP_RELATIVE_PATHS.has(rel)) continue;
+      if (
+        SKIP_RELATIVE_PATHS.has(rel) ||
+        (SKIP_DIRS.has(entry.name) && (entry.isDirectory() || entry.isSymbolicLink()))
+      ) {
+        continue;
+      }
 
       const abs = path.join(dir.abs, entry.name);
       let isDir = entry.isDirectory();
@@ -153,18 +172,17 @@ export function walkDirectory(root: string, options: WalkOptions = {}): WalkResu
       }
 
       if (isDir) {
-        if (SKIP_DIRS.has(entry.name)) continue;
         if (maxDepth !== undefined && dir.depth >= maxDepth) {
           addFirstReason(incompleteReasons, { code: 'depth-limit', path: rel, limit: maxDepth });
           continue;
         }
-        // Dedup by real path so symlink cycles (and hardlink-style repeats)
-        // can't loop forever; readdirSync/statSync below still follow the
-        // symlink transparently via its own (non-resolved) `abs` path.
         const real = symlinkReal ?? safeRealpath(abs) ?? abs;
-        if (visitedRealDirs.has(real)) continue;
-        visitedRealDirs.add(real);
-        childDirs.push({ abs, rel, depth: dir.depth + 1 });
+        const child = { abs, rel, depth: dir.depth + 1, real };
+        if (entry.isSymbolicLink()) {
+          childSymlinkDirs.push(child);
+        } else {
+          childDirs.push(child);
+        }
       } else if (isFile) {
         if (files.length >= maxFiles) {
           addFirstReason(incompleteReasons, {
@@ -179,6 +197,9 @@ export function walkDirectory(root: string, options: WalkOptions = {}): WalkResu
       }
     }
     for (let i = childDirs.length - 1; i >= 0; i -= 1) stack.push(childDirs[i]!);
+    for (let i = childSymlinkDirs.length - 1; i >= 0; i -= 1) {
+      deferredSymlinkDirs.push(childSymlinkDirs[i]!);
+    }
   }
   files.sort(compareLexically);
   return { files, truncated: incompleteReasons.length > 0, incompleteReasons };

--- a/packages/cli/src/score.ts
+++ b/packages/cli/src/score.ts
@@ -161,7 +161,7 @@ function snapshotsEqual(a: ScoreSnapshot, b: ScoreSnapshot): boolean {
 }
 
 function contextReasons(ctx: ScanContext): ScanIncompleteReason[] {
-  if (ctx.incompleteReasons && ctx.incompleteReasons.length > 0) return ctx.incompleteReasons;
+  if (ctx.incompleteReasons && ctx.incompleteReasons.length > 0) return [...ctx.incompleteReasons];
   return ctx.truncated ? [{ code: 'file-count-limit' }] : [];
 }
 
@@ -177,8 +177,6 @@ export function buildReportFromContext(
   resolvedRoots: Report['resolvedRoots'],
 ): Report {
   const severities = resolveSeverities(config);
-  const maturityVerdict = contextVerdict(maturityCtx);
-  const effectiveVerdict = contextVerdict(effectiveCtx);
   const maturity = buildSnapshot(maturityCtx, severities);
   let effective = maturity;
   if (effectiveCtx !== maturityCtx) {
@@ -187,6 +185,8 @@ export function buildReportFromContext(
       effective = effSnapshot;
     }
   }
+  const maturityVerdict = contextVerdict(maturityCtx);
+  const effectiveVerdict = contextVerdict(effectiveCtx);
 
   const resolvedEntries = [...severities.entries()]
     .filter(([, v]) => v.source !== 'default')

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -22,11 +22,11 @@ export interface ScanContext {
   files: string[];
   /** Compatibility alias: true whenever the scan is incomplete for any reason. */
   truncated: boolean;
-  /** Deterministic reasons the filesystem walk could not complete. */
+  /** Deterministic reasons the filesystem walk or a requested file read could not complete. */
   incompleteReasons?: ScanIncompleteReason[];
   /** True when the relative path exists as a file. */
   has(relPath: string): boolean;
-  /** File content as UTF-8, or null when missing/unreadable. Cached. */
+  /** File content as UTF-8, or null when missing/unreadable/over the read limit. Cached. */
   read(relPath: string): string | null;
   /** All files whose relative path matches the regex. */
   matching(re: RegExp): string[];
@@ -39,7 +39,12 @@ export interface ScanDiagnostic {
   source?: string;
 }
 
-export type ScanIncompleteReasonCode = 'file-count-limit' | 'depth-limit' | 'unreadable-directory';
+export type ScanIncompleteReasonCode =
+  | 'file-count-limit'
+  | 'depth-limit'
+  | 'unreadable-directory'
+  | 'unreadable-path'
+  | 'outside-root-symlink';
 
 export interface ScanIncompleteReason {
   code: ScanIncompleteReasonCode;
@@ -136,7 +141,7 @@ export interface PresetInfo {
 export interface Report {
   tool: { name: string; version: string };
   root: string;
-  /** Compatibility alias: true whenever either requested scan scope is incomplete. */
+  /** Compatibility alias: true whenever the maturity or effective snapshot is incomplete. */
   truncated: boolean;
   /** Authoritative completeness for repository-only and effective snapshots. */
   verdicts?: { maturity: ScanVerdict; effective: ScanVerdict };

--- a/packages/cli/test/badge.test.ts
+++ b/packages/cli/test/badge.test.ts
@@ -45,4 +45,16 @@ describe('renderBadge', () => {
     legacy.truncated = true;
     expect(renderBadge(legacy)).toContain('>incomplete<');
   });
+
+  test('remains maturity-only when effective is incomplete', () => {
+    const report = makeReport(4);
+    report.verdicts = {
+      maturity: { status: 'complete', reasons: [] },
+      effective: { status: 'incomplete', reasons: [{ code: 'depth-limit' }] },
+    };
+
+    const svg = renderBadge(report);
+    expect(svg).toContain('>L4<');
+    expect(svg).not.toContain('>incomplete<');
+  });
 });

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -16,12 +16,25 @@ function run(args: string[]) {
 
 function makeIncompleteRoot(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-incomplete-'));
-  let nested = root;
-  for (let depth = 0; depth < 11; depth += 1) {
-    nested = path.join(nested, `d${depth}`);
-    fs.mkdirSync(nested);
+  const unreadable = path.join(root, 'unreadable');
+  fs.mkdirSync(unreadable);
+  if (process.platform === 'win32') {
+    const denied = spawnSync('icacls', [unreadable, '/deny', '*S-1-1-0:(RD)'], { encoding: 'utf8' });
+    if (denied.status !== 0) throw new Error(`Could not create unreadable fixture: ${denied.stderr}`);
+  } else {
+    fs.chmodSync(unreadable, 0o000);
   }
   return root;
+}
+
+function removeIncompleteRoot(root: string): void {
+  const unreadable = path.join(root, 'unreadable');
+  if (process.platform === 'win32') {
+    spawnSync('icacls', [unreadable, '/remove:d', '*S-1-1-0'], { encoding: 'utf8' });
+  } else {
+    fs.chmodSync(unreadable, 0o700);
+  }
+  fs.rmSync(root, { recursive: true, force: true });
 }
 
 describe('cli', () => {
@@ -43,6 +56,23 @@ describe('cli', () => {
     expect(result.status).toBe(0);
   });
 
+  test.each([
+    ['maturity', 'level-1', 3, 1],
+    ['maturity', 'level-4', 4, 0],
+    ['effective', 'level-1', 3, 1],
+    ['effective', 'level-4', 4, 0],
+  ] as const)('uses the %s snapshot for a complete --min-level gate', (gate, fixture, minLevel, status) => {
+    const result = run([
+      path.join(FIXTURES, fixture),
+      '--gate',
+      gate,
+      '--min-level',
+      String(minLevel),
+      '--quiet',
+    ]);
+    expect(result.status).toBe(status);
+  });
+
   test('--badge writes a valid SVG', () => {
     const badgePath = path.join(os.tmpdir(), `hs-badge-${process.pid}.svg`);
     const result = run([path.join(FIXTURES, 'level-3'), '--badge', badgePath, '--quiet']);
@@ -62,12 +92,12 @@ describe('cli', () => {
       const report = JSON.parse(result.stdout);
       expect(report.verdicts.maturity.status).toBe('incomplete');
       expect(report.verdicts.maturity.reasons[0]).toMatchObject({
-        code: 'depth-limit',
-        limit: 10,
+        code: 'unreadable-directory',
+        path: 'unreadable',
       });
-      expect(result.stderr).toContain('no authoritative verdict is available');
+      expect(result.stderr).toContain('no authoritative maturity verdict is available');
     } finally {
-      fs.rmSync(root, { recursive: true, force: true });
+      removeIncompleteRoot(root);
     }
   });
 
@@ -81,29 +111,50 @@ describe('cli', () => {
       expect(svg).toContain('>incomplete<');
       expect(svg).not.toMatch(/>L[0-4]</);
     } finally {
-      fs.rmSync(root, { recursive: true, force: true });
+      removeIncompleteRoot(root);
       fs.rmSync(badgePath, { force: true });
     }
   });
 
-  test('exits 2 when only a requested effective scope is incomplete', () => {
+  test.each([
+    ['maturity', 0, 0],
+    ['maturity', 4, 1],
+    ['effective', 0, 2],
+  ] as const)('gate %s with --min-level L%i returns %i when only effective is incomplete', (gate, minLevel, expectedStatus) => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-effective-root-'));
     const shared = makeIncompleteRoot();
     fs.writeFileSync(
       path.join(root, '.harness-score.json'),
-      JSON.stringify({ extraRoots: [{ id: 'team', path: shared }], gate: 'maturity' }),
+      JSON.stringify({ extraRoots: [{ id: 'team', path: shared }], gate }),
       'utf8',
     );
     try {
-      const result = run([root, '--json', '--quiet', '--min-level', '0']);
-      expect(result.status).toBe(2);
+      const result = run([root, '--json', '--quiet', '--min-level', String(minLevel)]);
+      expect(result.status).toBe(expectedStatus);
       const report = JSON.parse(result.stdout);
       expect(report.verdicts.maturity.status).toBe('complete');
       expect(report.verdicts.effective.status).toBe('incomplete');
       expect(result.stderr).toContain('effective scan is incomplete');
+      if (expectedStatus === 1) expect(result.stderr).toContain('maturity L0 is below required L4');
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
-      fs.rmSync(shared, { recursive: true, force: true });
+      removeIncompleteRoot(shared);
+    }
+  });
+
+  test.each([
+    'maturity',
+    'effective',
+  ] as const)('exits 2 with gate %s when maturity is incomplete', (gate) => {
+    const root = makeIncompleteRoot();
+    try {
+      const result = run([root, '--json', '--quiet', '--gate', gate, '--min-level', '0']);
+      expect(result.status).toBe(2);
+      const report = JSON.parse(result.stdout);
+      expect(report.verdicts.maturity.status).toBe('incomplete');
+      expect(report.verdicts.effective.status).toBe('incomplete');
+    } finally {
+      removeIncompleteRoot(root);
     }
   });
 
@@ -181,7 +232,7 @@ describe('cli', () => {
       expect(result.status).toBe(2);
       expect(result.stderr).toContain('current maturity report is incomplete');
     } finally {
-      fs.rmSync(root, { recursive: true, force: true });
+      removeIncompleteRoot(root);
       fs.rmSync(baselinePath, { force: true });
     }
   });

--- a/packages/cli/test/diff.test.ts
+++ b/packages/cli/test/diff.test.ts
@@ -76,4 +76,19 @@ describe('computeDiff', () => {
       'incomplete maturity reports',
     );
   });
+
+  test('remains maturity-only when effective is incomplete', () => {
+    const complete = score(path.join(FIXTURES, 'level-4'));
+    const effectiveIncomplete = {
+      ...complete,
+      truncated: true,
+      verdicts: {
+        maturity: { status: 'complete' as const, reasons: [] },
+        effective: { status: 'incomplete' as const, reasons: [{ code: 'depth-limit' as const }] },
+      },
+    };
+
+    expect(() => computeDiff(complete, effectiveIncomplete)).not.toThrow();
+    expect(computeDiff(complete, effectiveIncomplete).level.delta).toBe(0);
+  });
 });

--- a/packages/cli/test/markdown.test.ts
+++ b/packages/cli/test/markdown.test.ts
@@ -119,6 +119,31 @@ describe('renderMarkdown', () => {
     expect(out).toContain('file-count-limit');
   });
 
+  test('keeps maturity authoritative and scopes the warning when only effective is incomplete', () => {
+    const out = renderMarkdown(
+      makeReport({
+        truncated: true,
+        scopes: { maturity: ['repo'], effective: ['repo', 'team'] },
+        verdicts: {
+          maturity: { status: 'complete', reasons: [] },
+          effective: {
+            status: 'incomplete',
+            reasons: [{ code: 'depth-limit', path: 'team:deep', limit: 8 }],
+          },
+        },
+      }),
+    );
+    expect(out).toContain('**Maturity level:** L1 · Documented');
+    expect(out).toContain('**Effective:** unavailable - incomplete scan');
+    expect(out).toContain(
+      '> ⚠ Effective scan is incomplete. Provisional effective results are not authoritative.',
+    );
+    expect(out).not.toContain('Maturity scan is incomplete');
+    expect(out).toContain('- **effective:** depth-limit at team:deep (limit 8)');
+    expect(out).toContain('## Dimensions');
+    expect(out).not.toContain('## Provisional dimensions');
+  });
+
   test('shows detected harnesses with display names, only when non-empty', () => {
     const detected = renderMarkdown(makeReport({ detectedHarnesses: ['cursor', 'claude-code'] }));
     expect(detected).toContain('**Detected harnesses:** Cursor, Claude Code');

--- a/packages/cli/test/plugins-sync.test.ts
+++ b/packages/cli/test/plugins-sync.test.ts
@@ -1,9 +1,17 @@
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, test } from 'vitest';
 import { TOOL_PATHS } from '../../../plugins/shared/tool-paths.mjs';
 import { TOOLS } from '../../../plugins/shared/tools.mjs';
 import { PLUGIN_TOOL_PATHS } from '../src/harness/registry.js';
+
+function writeFixture(root: string, relativePath: string, content: string): void {
+  const target = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content, 'utf8');
+}
 
 describe('plugins/shared path config sync', () => {
   test('the legacy GitHub Action entrypoint matches the canonical root action', () => {
@@ -20,6 +28,7 @@ describe('plugins/shared path config sync', () => {
     const packageJson = JSON.parse(
       fs.readFileSync(path.join(repoRoot, 'packages/cli/package.json'), 'utf8'),
     ) as { version: string };
+    const actionReadme = fs.readFileSync(path.join(repoRoot, 'action/README.md'), 'utf8');
 
     const descriptionBlock = metadata.match(/^description: >-\r?\n(?<lines>(?: {2}.+\r?\n)+)author:/m);
     const description = descriptionBlock?.groups?.lines
@@ -28,10 +37,95 @@ describe('plugins/shared path config sync', () => {
       .map((line) => line.trim())
       .join(' ');
     const actionVersion = metadata.match(/^ {2}version:\r?\n(?: {4}.+\r?\n)+? {4}default: '([^']+)'/m)?.[1];
+    const documentedActionVersion = actionReadme.match(
+      /^\| `version` \| `([^`]+)` \| harness-score npm version or package spec \|$/m,
+    )?.[1];
 
     expect(description).toBeDefined();
     expect(description!.length).toBeLessThan(125);
     expect(actionVersion).toBe(packageJson.version);
+    expect(documentedActionVersion).toBe(packageJson.version);
+  });
+
+  test('the GitHub Action documents gate-scoped failures and effective output availability', () => {
+    const repoRoot = path.resolve(import.meta.dirname, '../../..');
+    const metadata = fs.readFileSync(path.join(repoRoot, 'action.yml'), 'utf8');
+
+    expect(metadata).toContain(
+      "description: 'Fail below this level (0–4). An incomplete gated snapshot exits 2, including at 0.'",
+    );
+    expect(metadata).toContain(
+      "description: 'Effective level index when the effective snapshot is complete.'",
+    );
+    expect(metadata).toContain(
+      "description: 'Effective score percentage when the effective snapshot is complete.'",
+    );
+  });
+
+  test('the PR baseline and current diff receive the same explicit config without disabling autodiscovery', () => {
+    const repoRoot = path.resolve(import.meta.dirname, '../../..');
+    const metadata = fs.readFileSync(path.join(repoRoot, 'action.yml'), 'utf8');
+    const baseline = metadata.match(/ {4}- id: baseline\r?\n(?<body>[\s\S]*?)(?=\r?\n {4}- id: diff\r?\n)/)
+      ?.groups?.body;
+    const diff = metadata.match(/ {4}- id: diff\r?\n(?<body>[\s\S]*?)(?=\r?\n {4}- id: comment\r?\n)/)?.groups
+      ?.body;
+
+    expect(baseline).toContain('HS_CONFIG: ${{ inputs.config }}');
+    expect(baseline).toContain('[ -n "$HS_CONFIG" ] && BASELINE_ARGS+=(--config "$HS_CONFIG")');
+    expect(baseline).toContain('"${BASELINE_ARGS[@]}"');
+    expect(diff).toContain('HS_CONFIG: ${{ inputs.config }}');
+    expect(diff).toContain('[ -n "$HS_CONFIG" ] && DIFF_ARGS+=(--config "$HS_CONFIG")');
+    expect(diff).toContain('"${DIFF_ARGS[@]}"');
+  });
+
+  test('sync-version updates the documented GitHub Action version with the release surfaces', () => {
+    const sourceRoot = path.resolve(import.meta.dirname, '../../..');
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hs-version-sync-'));
+    fs.mkdirSync(path.join(root, 'scripts'), { recursive: true });
+    fs.copyFileSync(
+      path.join(sourceRoot, 'scripts/sync-version.mjs'),
+      path.join(root, 'scripts/sync-version.mjs'),
+    );
+    writeFixture(root, 'packages/cli/package.json', JSON.stringify({ version: '9.9.9' }));
+    writeFixture(root, 'packages/cli/src/score.ts', "export const TOOL_VERSION = '1.5.3';\n");
+    writeFixture(root, 'packages/cli/jsr.json', JSON.stringify({ version: '1.5.3' }));
+    writeFixture(
+      root,
+      'package-lock.json',
+      JSON.stringify({ packages: { 'packages/cli': { version: '1.5.3' } } }),
+    );
+    const action =
+      "inputs:\n  version:\n    description: 'version'\n    required: false\n    default: '1.5.3'\n";
+    writeFixture(root, 'action.yml', action);
+    writeFixture(root, 'action/action.yml', action);
+    writeFixture(
+      root,
+      'action/README.md',
+      '| `version` | `1.5.3` | harness-score npm version or package spec |\n',
+    );
+
+    const bin = path.join(root, 'bin');
+    fs.mkdirSync(bin);
+    if (process.platform === 'win32') {
+      writeFixture(root, 'bin/npx.cmd', '@exit /b 0\r\n');
+    } else {
+      writeFixture(root, 'bin/npx', '#!/bin/sh\nexit 0\n');
+      fs.chmodSync(path.join(bin, 'npx'), 0o755);
+    }
+
+    try {
+      const result = spawnSync(process.execPath, [path.join(root, 'scripts/sync-version.mjs')], {
+        cwd: root,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH ?? ''}` },
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(fs.readFileSync(path.join(root, 'action/README.md'), 'utf8')).toContain(
+        '| `version` | `9.9.9` | harness-score npm version or package spec |',
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test('generated TOOL_PATHS matches PLUGIN_TOOL_PATHS from the CLI harness registry exactly', () => {

--- a/packages/cli/test/scan.test.ts
+++ b/packages/cli/test/scan.test.ts
@@ -3,6 +3,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, test } from 'vitest';
 import { createScanContext, walkDirectory } from '../src/scan.js';
+import { buildReportFromScanContext } from '../src/score.js';
+import type { ScanContext } from '../src/types.js';
 
 const tmpDirs: string[] = [];
 
@@ -10,6 +12,15 @@ function mkTmpDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-score-scan-'));
   tmpDirs.push(dir);
   return dir;
+}
+
+function virtualDirent(name: string, type: 'directory' | 'file' | 'symlink'): fs.Dirent {
+  return {
+    name,
+    isDirectory: () => type === 'directory',
+    isFile: () => type === 'file',
+    isSymbolicLink: () => type === 'symlink',
+  } as fs.Dirent;
 }
 
 afterEach(() => {
@@ -36,35 +47,46 @@ describe('createScanContext — production limits', () => {
     expect(ctx.incompleteReasons).toEqual([]);
   });
 
-  test('scans a 25,000-file repository past the former 20,000-file limit', () => {
+  test('detects a relevant signal after the former 20,000-file limit', () => {
     const fileCount = 25_000;
     const virtualFiles = Array.from({ length: fileCount }, (_, index) => {
       const name = `file-${index.toString().padStart(5, '0')}.txt`;
-      return {
-        name,
-        isDirectory: () => false,
-        isFile: () => true,
-        isSymbolicLink: () => false,
-      } as fs.Dirent;
+      return virtualDirent(name, 'file');
     });
+    virtualFiles.push(virtualDirent('zzzz-signal', 'directory'));
 
-    const result = walkDirectory('virtual-root', { readDirectory: () => virtualFiles });
+    const result = walkDirectory('virtual-root', {
+      readDirectory: (directory) =>
+        directory.endsWith('zzzz-signal') ? [virtualDirent('AGENTS.md', 'file')] : virtualFiles,
+    });
+    const fileSet = new Set(result.files);
+    const ctx: ScanContext = {
+      root: 'virtual-root',
+      files: result.files,
+      truncated: result.truncated,
+      incompleteReasons: result.incompleteReasons,
+      has: (relPath) => fileSet.has(relPath),
+      read: (relPath) => (relPath === 'zzzz-signal/AGENTS.md' ? '# nested agent context' : null),
+      matching: (re) => result.files.filter((file) => re.test(file)),
+    };
+    const report = buildReportFromScanContext(ctx);
 
-    expect(result.files).toHaveLength(fileCount);
-    expect(result.files.at(-1)).toBe('file-24999.txt');
+    expect(result.files).toHaveLength(fileCount + 1);
+    expect(result.files.at(-1)).toBe('zzzz-signal/AGENTS.md');
     expect(result.truncated).toBe(false);
     expect(result.incompleteReasons).toEqual([]);
+    expect(report.checks.find((check) => check.id === 'CTX-03')?.passed).toBe(true);
   });
 });
 
 describe('createScanContext — symlinks', () => {
-  test('follows a symlinked directory into a sibling', () => {
+  test('follows a symlinked directory whose target is inside the scan root', () => {
     const root = mkTmpDir();
-    fs.mkdirSync(path.join(root, 'target'));
-    fs.writeFileSync(path.join(root, 'target', 'AGENTS.md'), '# hi');
     fs.mkdirSync(path.join(root, 'repo'));
+    fs.mkdirSync(path.join(root, 'repo', 'target'));
+    fs.writeFileSync(path.join(root, 'repo', 'target', 'AGENTS.md'), '# hi');
     try {
-      fs.symlinkSync(path.join(root, 'target'), path.join(root, 'repo', 'shared'), 'dir');
+      fs.symlinkSync(path.join(root, 'repo', 'target'), path.join(root, 'repo', 'shared'), 'dir');
     } catch {
       // Symlink creation can require elevated privileges on some Windows
       // setups; skip rather than fail the suite in that environment.
@@ -89,11 +111,187 @@ describe('createScanContext — symlinks', () => {
 
     const ctx = createScanContext(root);
     const occurrences = ctx.files.filter((f) => f.endsWith('file.txt'));
-    // The cycle must not be walked more than once — a handful of legitimate
-    // depth-bounded traversals through the loop is fine, an unbounded one
-    // (thousands of copies) is the bug this test guards against.
-    expect(occurrences.length).toBeLessThan(20);
+    expect(occurrences).toEqual(['a/file.txt']);
     expect(ctx.truncated).toBe(false);
+  });
+
+  test('walks only the first deterministic alias to the same directory', () => {
+    const root = mkTmpDir();
+    const repo = path.join(root, 'repo');
+    fs.mkdirSync(repo);
+    const target = path.join(repo, 'target');
+    fs.mkdirSync(target);
+    fs.writeFileSync(path.join(target, 'file.txt'), 'content');
+    try {
+      fs.symlinkSync(target, path.join(repo, 'alias-b'), 'dir');
+      fs.symlinkSync(target, path.join(repo, 'alias-a'), 'dir');
+    } catch {
+      return;
+    }
+
+    const ctx = createScanContext(repo);
+    expect(ctx.files).toEqual(['alias-a/file.txt']);
+    expect(ctx.truncated).toBe(false);
+  });
+
+  test('does not enumerate an external directory symlink and fails closed with its path', () => {
+    const root = mkTmpDir();
+    const repo = path.join(root, 'repo');
+    const outside = path.join(root, 'outside');
+    fs.mkdirSync(repo);
+    fs.mkdirSync(outside);
+    fs.writeFileSync(path.join(outside, 'AGENTS.md'), '# must stay outside');
+    try {
+      fs.symlinkSync(outside, path.join(repo, 'external-dir'), 'dir');
+    } catch {
+      return;
+    }
+
+    const ctx = createScanContext(repo);
+    const report = buildReportFromScanContext(ctx);
+
+    expect(ctx.files).toEqual([]);
+    expect(ctx.has('external-dir/AGENTS.md')).toBe(false);
+    expect(ctx.read('external-dir/AGENTS.md')).toBeNull();
+    expect(ctx.truncated).toBe(true);
+    expect(ctx.incompleteReasons).toEqual([{ code: 'outside-root-symlink', path: 'external-dir' }]);
+    expect(report.verdicts?.maturity).toEqual({
+      status: 'incomplete',
+      reasons: [{ code: 'outside-root-symlink', path: 'external-dir' }],
+    });
+  });
+
+  test('does not discover or read an external file symlink and fails closed with its path', () => {
+    const root = mkTmpDir();
+    const repo = path.join(root, 'repo');
+    const outsideFile = path.join(root, 'outside-AGENTS.md');
+    fs.mkdirSync(repo);
+    fs.writeFileSync(outsideFile, '# must not be read');
+    try {
+      fs.symlinkSync(outsideFile, path.join(repo, 'AGENTS.md'), 'file');
+    } catch {
+      return;
+    }
+
+    const ctx = createScanContext(repo);
+
+    expect(ctx.files).toEqual([]);
+    expect(ctx.has('AGENTS.md')).toBe(false);
+    expect(ctx.read('AGENTS.md')).toBeNull();
+    expect(ctx.truncated).toBe(true);
+    expect(ctx.incompleteReasons).toEqual([{ code: 'outside-root-symlink', path: 'AGENTS.md' }]);
+  });
+
+  test('records symlink stat permission and I/O errors as unreadable paths', () => {
+    for (const code of ['EACCES', 'EPERM', 'EIO']) {
+      const error = Object.assign(new Error(code), { code });
+      const result = walkDirectory('virtual-root', {
+        readDirectory: () => [virtualDirent('linked', 'symlink')],
+        statPath: () => {
+          throw error;
+        },
+      });
+      expect(result.incompleteReasons).toEqual([{ code: 'unreadable-path', path: 'linked' }]);
+      expect(result.truncated).toBe(true);
+    }
+  });
+
+  test('ignores only genuinely missing or broken symlink targets', () => {
+    for (const code of ['ENOENT', 'ENOTDIR', 'ELOOP']) {
+      const error = Object.assign(new Error(code), { code });
+      const result = walkDirectory('virtual-root', {
+        readDirectory: () => [virtualDirent('broken', 'symlink')],
+        statPath: () => {
+          throw error;
+        },
+      });
+      expect(result).toEqual({ files: [], truncated: false, incompleteReasons: [] });
+    }
+  });
+});
+
+describe('createScanContext — preserved safety boundaries', () => {
+  test('skips dependency and generated directories plus generated Yarn paths', () => {
+    const root = mkTmpDir();
+    const skippedDirectories = [
+      '.git',
+      'node_modules',
+      'dist',
+      'build',
+      'out',
+      'coverage',
+      'target',
+      'vendor',
+      '__pycache__',
+      '.venv',
+      'venv',
+      '.tox',
+      '.next',
+      '.nuxt',
+      '.cache',
+      '.turbo',
+      '.idea',
+      '.nx',
+      '.pnp',
+      '.parcel-cache',
+      '.angular',
+      '.pytest_cache',
+      '.mypy_cache',
+      '.ruff_cache',
+    ];
+    for (const directory of skippedDirectories) {
+      fs.mkdirSync(path.join(root, directory), { recursive: true });
+      fs.writeFileSync(path.join(root, directory, 'AGENTS.md'), '# skipped');
+    }
+    fs.mkdirSync(path.join(root, '.yarn', 'cache'), { recursive: true });
+    fs.mkdirSync(path.join(root, '.yarn', 'unplugged'), { recursive: true });
+    fs.mkdirSync(path.join(root, '.yarn', 'plugins'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.yarn', 'cache', 'AGENTS.md'), '# skipped');
+    fs.writeFileSync(path.join(root, '.yarn', 'unplugged', 'AGENTS.md'), '# skipped');
+    fs.writeFileSync(path.join(root, '.yarn', 'install-state.gz'), 'skipped');
+    fs.writeFileSync(path.join(root, '.yarn', 'plugins', 'kept.cjs'), 'kept');
+
+    const ctx = createScanContext(root);
+
+    expect(ctx.files).toEqual(['.yarn/plugins/kept.cjs']);
+    expect(ctx.truncated).toBe(false);
+  });
+
+  test('reads exactly 512 KiB but intentionally ignores larger file bodies', () => {
+    const root = mkTmpDir();
+    const atLimit = 'a'.repeat(512 * 1024);
+    fs.writeFileSync(path.join(root, 'at-limit.txt'), atLimit);
+    fs.writeFileSync(path.join(root, 'over-limit.txt'), `${atLimit}b`);
+
+    const ctx = createScanContext(root);
+
+    expect(ctx.read('at-limit.txt')).toBe(atLimit);
+    expect(ctx.read('over-limit.txt')).toBeNull();
+    expect(ctx.truncated).toBe(false);
+    expect(ctx.incompleteReasons).toEqual([]);
+  });
+
+  test('marks a discovered file that becomes unreadable when requested', () => {
+    const root = mkTmpDir();
+    const agentsPath = path.join(root, 'AGENTS.md');
+    fs.writeFileSync(agentsPath, '# present during discovery');
+    const ctx = createScanContext(root);
+    fs.unlinkSync(agentsPath);
+
+    expect(ctx.read('AGENTS.md')).toBeNull();
+    expect(ctx.truncated).toBe(true);
+    expect(ctx.incompleteReasons).toEqual([{ code: 'unreadable-path', path: 'AGENTS.md' }]);
+  });
+
+  test('prefixes an unreadable overlay path with its deterministic label', () => {
+    const root = mkTmpDir();
+    const missingOverlayFile = path.join(root, 'missing-AGENTS.md');
+    const ctx = createScanContext(root, {
+      overlays: [{ label: 'team', files: new Map([['shared/AGENTS.md', missingOverlayFile]]) }],
+    });
+
+    expect(ctx.read('shared/AGENTS.md')).toBeNull();
+    expect(ctx.incompleteReasons).toEqual([{ code: 'unreadable-path', path: 'team:shared/AGENTS.md' }]);
   });
 });
 

--- a/packages/cli/test/scan.test.ts
+++ b/packages/cli/test/scan.test.ts
@@ -19,6 +19,44 @@ afterEach(() => {
   }
 });
 
+describe('createScanContext — production limits', () => {
+  test('includes files beyond ten directory levels without truncating the scan', () => {
+    const root = mkTmpDir();
+    const segments = Array.from({ length: 12 }, (_, index) => `level-${index + 1}`);
+    const deepDirectory = path.join(root, ...segments);
+    fs.mkdirSync(deepDirectory, { recursive: true });
+    fs.writeFileSync(path.join(deepDirectory, 'AGENTS.md'), '# deep harness signal');
+
+    const ctx = createScanContext(root);
+    const deepFile = `${segments.join('/')}/AGENTS.md`;
+
+    expect(ctx.has(deepFile)).toBe(true);
+    expect(ctx.read(deepFile)).toBe('# deep harness signal');
+    expect(ctx.truncated).toBe(false);
+    expect(ctx.incompleteReasons).toEqual([]);
+  });
+
+  test('scans a 25,000-file repository past the former 20,000-file limit', () => {
+    const fileCount = 25_000;
+    const virtualFiles = Array.from({ length: fileCount }, (_, index) => {
+      const name = `file-${index.toString().padStart(5, '0')}.txt`;
+      return {
+        name,
+        isDirectory: () => false,
+        isFile: () => true,
+        isSymbolicLink: () => false,
+      } as fs.Dirent;
+    });
+
+    const result = walkDirectory('virtual-root', { readDirectory: () => virtualFiles });
+
+    expect(result.files).toHaveLength(fileCount);
+    expect(result.files.at(-1)).toBe('file-24999.txt');
+    expect(result.truncated).toBe(false);
+    expect(result.incompleteReasons).toEqual([]);
+  });
+});
+
 describe('createScanContext — symlinks', () => {
   test('follows a symlinked directory into a sibling', () => {
     const root = mkTmpDir();

--- a/packages/cli/test/scan.test.ts
+++ b/packages/cli/test/scan.test.ts
@@ -115,23 +115,65 @@ describe('createScanContext — symlinks', () => {
     expect(ctx.truncated).toBe(false);
   });
 
-  test('walks only the first deterministic alias to the same directory', () => {
+  test('prefers the canonical directory over lexically earlier aliases', () => {
     const root = mkTmpDir();
     const repo = path.join(root, 'repo');
     fs.mkdirSync(repo);
-    const target = path.join(repo, 'target');
-    fs.mkdirSync(target);
-    fs.writeFileSync(path.join(target, 'file.txt'), 'content');
+    const shared = path.join(repo, 'shared');
+    fs.mkdirSync(shared);
+    fs.writeFileSync(path.join(shared, 'file.txt'), 'content');
     try {
-      fs.symlinkSync(target, path.join(repo, 'alias-b'), 'dir');
-      fs.symlinkSync(target, path.join(repo, 'alias-a'), 'dir');
+      fs.symlinkSync(shared, path.join(repo, 'alias-b'), 'dir');
+      fs.symlinkSync(shared, path.join(repo, 'alias-a'), 'dir');
     } catch {
       return;
     }
 
     const ctx = createScanContext(repo);
-    expect(ctx.files).toEqual(['alias-a/file.txt']);
+    expect(ctx.files).toEqual(['shared/file.txt']);
     expect(ctx.truncated).toBe(false);
+  });
+
+  test('does not let a harness-shaped alias hide the canonical harness path', () => {
+    const root = mkTmpDir();
+    const cursorRules = path.join(root, '.cursor', 'rules');
+    fs.mkdirSync(cursorRules, { recursive: true });
+    fs.writeFileSync(
+      path.join(cursorRules, 'project.mdc'),
+      '---\ndescription: Project rules\nglobs: "src/**"\n---\n\nRule body.\n',
+    );
+    try {
+      fs.symlinkSync(path.join(root, '.cursor'), path.join(root, '.claude'), 'dir');
+    } catch {
+      return;
+    }
+
+    const ctx = createScanContext(root);
+    const report = buildReportFromScanContext(ctx);
+
+    expect(ctx.files).toEqual(['.cursor/rules/project.mdc']);
+    expect(report.detectedHarnesses).toContain('cursor');
+    expect(report.verdicts?.maturity).toEqual({ status: 'complete', reasons: [] });
+  });
+
+  test('skips generated-directory symlinks before inspecting their targets', () => {
+    const root = mkTmpDir();
+    const repo = path.join(root, 'repo');
+    const outside = path.join(root, 'outside');
+    fs.mkdirSync(repo);
+    fs.mkdirSync(outside);
+    fs.writeFileSync(path.join(outside, 'irrelevant.txt'), 'must stay outside');
+    try {
+      fs.symlinkSync(outside, path.join(repo, 'node_modules'), 'dir');
+    } catch {
+      return;
+    }
+
+    const ctx = createScanContext(repo);
+
+    expect(ctx.files).toEqual([]);
+    expect(ctx.truncated).toBe(false);
+    expect(ctx.incompleteReasons).toEqual([]);
   });
 
   test('does not enumerate an external directory symlink and fails closed with its path', () => {

--- a/packages/cli/test/score.test.ts
+++ b/packages/cli/test/score.test.ts
@@ -1,4 +1,8 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe, expect, test } from 'vitest';
+import { createScanContext } from '../src/scan.js';
 import { buildReportFromScanContext, LEVEL_REQUIREMENTS, TOOL_VERSION } from '../src/score.js';
 import type { DimensionId, DimensionScore } from '../src/types.js';
 import { DIMENSIONS } from '../src/types.js';
@@ -116,5 +120,54 @@ describe('buildReport shape', () => {
       status: 'incomplete',
       reasons: [{ code: 'depth-limit', path: 'a/b', limit: 10 }],
     });
+  });
+
+  test('computes the verdict after checks request discovered file contents', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-score-score-'));
+    const agentsPath = path.join(root, 'AGENTS.md');
+    fs.writeFileSync(agentsPath, '# present during discovery');
+    const ctx = createScanContext(root);
+    fs.unlinkSync(agentsPath);
+
+    try {
+      const report = buildReportFromScanContext(ctx);
+      expect(report.truncated).toBe(true);
+      expect(report.verdicts?.maturity).toEqual({
+        status: 'incomplete',
+        reasons: [{ code: 'unreadable-path', path: 'AGENTS.md' }],
+      });
+      expect(report.verdicts?.effective).toEqual(report.verdicts?.maturity);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('keeps oversized requested files complete because the read limit is intentional', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-score-score-'));
+    fs.writeFileSync(path.join(root, 'AGENTS.md'), 'a'.repeat(512 * 1024 + 1));
+
+    try {
+      const report = buildReportFromScanContext(createScanContext(root));
+      expect(report.truncated).toBe(false);
+      expect(report.verdicts?.maturity).toEqual({ status: 'complete', reasons: [] });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('does not fail closed for a discovered unreadable file that no check requests', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-score-score-'));
+    const unrelatedPath = path.join(root, 'unrelated.txt');
+    fs.writeFileSync(unrelatedPath, 'present during discovery');
+    const ctx = createScanContext(root);
+    fs.unlinkSync(unrelatedPath);
+
+    try {
+      const report = buildReportFromScanContext(ctx);
+      expect(report.truncated).toBe(false);
+      expect(report.verdicts?.maturity).toEqual({ status: 'complete', reasons: [] });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/test/terminal.test.ts
+++ b/packages/cli/test/terminal.test.ts
@@ -107,7 +107,9 @@ describe('renderTerminal', () => {
     );
     expect(out).toContain('Maturity: L1');
     expect(out).toContain('Effective: unavailable - incomplete scan');
+    expect(out).toContain('Effective scan incomplete · provisional effective results are not authoritative.');
     expect(out).toContain('effective: depth-limit at team:deep (limit 8)');
+    expect(out).not.toContain('Maturity scan incomplete');
     expect(out).not.toContain('Provisional dimensions:');
   });
 

--- a/packages/cli/test/types/smoke.ts
+++ b/packages/cli/test/types/smoke.ts
@@ -63,6 +63,11 @@ const checkOutcome: CheckOutcome = { passed: true, evidence: 'x' };
 const checkResult: CheckResult = scored.checks[0]!;
 const diagnostic: ScanDiagnostic = { code: 'future-event', message: 'x', source: '.claude/settings.json' };
 const incompleteReason: ScanIncompleteReason = { code: 'depth-limit', path: 'deep', limit: 10 };
+const unreadablePathReason: ScanIncompleteReason = { code: 'unreadable-path', path: 'AGENTS.md' };
+const outsideRootSymlinkReason: ScanIncompleteReason = {
+  code: 'outside-root-symlink',
+  path: 'shared/AGENTS.md',
+};
 const verdict: ScanVerdict = reportVerdict(scored, 'maturity');
 const verdictStatus: ScanVerdictStatus = verdict.status;
 const complete: boolean = reportScopeIsComplete(scored, 'maturity');
@@ -94,6 +99,8 @@ void [
   checkResult,
   diagnostic,
   incompleteReason,
+  unreadablePathReason,
+  outsideRootSymlinkReason,
   verdict,
   verdictStatus,
   complete,

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 /**
  * Mirrors packages/cli/package.json's version into every release surface:
- * TOOL_VERSION in score.ts, jsr.json, package-lock.json, and both GitHub
- * Action entrypoints. Run after `npx changeset version` (which only bumps
- * package.json + CHANGELOG.md) and before committing a release.
+ * TOOL_VERSION in score.ts, jsr.json, package-lock.json, both GitHub Action
+ * entrypoints, and the Action README input table. Run after
+ * `npx changeset version` (which only bumps package.json + CHANGELOG.md) and
+ * before committing a release.
  */
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
@@ -18,6 +19,7 @@ const scorePath = path.join(CLI_DIR, 'src', 'score.ts');
 const jsrPath = path.join(CLI_DIR, 'jsr.json');
 const lockPath = path.join(ROOT, 'package-lock.json');
 const actionPaths = [path.join(ROOT, 'action.yml'), path.join(ROOT, 'action', 'action.yml')];
+const actionReadmePath = path.join(ROOT, 'action', 'README.md');
 
 const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
 const version = pkg.version;
@@ -57,6 +59,15 @@ for (const actionPath of actionPaths) {
   fs.writeFileSync(actionPath, metadata.replace(actionVersionRe, `$1${version}$2`));
 }
 
+const actionReadme = fs.readFileSync(actionReadmePath, 'utf8');
+const actionReadmeVersionRe =
+  /^(\| `version` \| `)[^`]+(` \| harness-score npm version or package spec \|)$/m;
+if (!actionReadmeVersionRe.test(actionReadme)) {
+  console.error(`Could not find the version input row in ${path.relative(ROOT, actionReadmePath)}.`);
+  process.exit(1);
+}
+fs.writeFileSync(actionReadmePath, actionReadme.replace(actionReadmeVersionRe, `$1${version}$2`));
+
 // JSON.stringify expands short arrays onto multiple lines; Biome restores the
 // repository's canonical JSON formatting.
 const format = spawnSync('npx', ['biome', 'format', '--write', jsrPath, lockPath], {
@@ -69,4 +80,4 @@ if (format.status !== 0) {
   process.exit(format.status ?? 1);
 }
 
-console.log(`Synced CLI, JSR, lockfile, and GitHub Action versions to ${version}.`);
+console.log(`Synced CLI, JSR, lockfile, GitHub Action, and Action README versions to ${version}.`);


### PR DESCRIPTION
## What changed

- remove the production repository depth cap and raise the file-count emergency fuse from 20,000 to 1,000,000
- preserve the synchronous filesystem-backed `ScanContext` contract, existing skips, and 512 KiB read limit
- fail closed when a requested relevant path is unreadable
- follow internal symlinks, prefer canonical repository paths when deduplicating directory aliases, and reject targets outside the scan root
- apply dependency and generated-directory skips before inspecting symlink targets
- decide CLI exit status from the snapshot selected by `gate`
- keep maturity badges and diffs authoritative when only an effective overlay is incomplete
- publish GitHub Action outputs and artifacts only for complete snapshots
- propagate an explicit Action `config` consistently to the main scan, baseline, and current diff
- keep the documented Action version synchronized during the release workflow
- document the behavior in every maintained guide language and add a minor changeset

## Why

The scanner previously stopped at depth 10 or 20,000 files. A repository could therefore receive a provisional score even though relevant harness evidence existed after the cutoff. The CLI and Action also treated any requested incomplete scope as a global failure, even when the selected maturity gate was complete.

The filesystem remains the canonical source. This change removes the normal operational cutoff while retaining fail-closed behavior for unreadable paths, out-of-root symlinks, and pathological trees that reach the emergency fuse.

## User impact

- repositories deeper than 10 levels or larger than 20,000 relevant files can now produce complete results
- `gate: maturity` can pass when maturity is complete and only effective is incomplete
- `gate: effective` still exits 2 when effective is incomplete
- incomplete maturity never publishes maturity outputs, badges, reports, or PR comments
- files that checks need but cannot read make the affected snapshot incomplete
- symlinks cannot make a scan escape its configured root
- canonical repository paths cannot be hidden by lexically earlier directory aliases
- generated-directory symlinks remain skipped before their targets are inspected
- configured PR comments use the same rules and presets as the gated scan
- the report JSON shape and exit codes remain unchanged; the reason-code union gains `unreadable-path` and `outside-root-symlink`

## Validation

- `npm test`: 360 passed
- `npm run test:coverage`: 95.83% statements/lines, 86.22% branches, 100% functions
- `npm run lint`: passed with 18 pre-existing CSS warnings
- `npm run scan`: L4, 108/108
- `npm run plugins:sync-check`: passed
- `npm run docs:build`: passed
- CI run 31658217583: passed on Ubuntu Node 18, Ubuntu Node 22 full checks, and Windows Node 22
- Action manifests remain byte-identical; YAML, Bash syntax, metadata, config propagation, and release-version sync tests passed
- previously incomplete corpus scans now complete: Continue L3 (79/108), Goose L3 (80/108)
- isolated-process benchmark medians and peak RSS:
  - 5k: 67.6 ms, 61.4 MiB
  - 25k: 247.8 ms, 72.8 MiB
  - 100k: 904.6 ms, 119.4 MiB
  - 300k: 2.42 s, 248.0 MiB

## Scope boundary

Hook aggregation and parsing changes are intentionally excluded and will be handled separately.