### PR TITLE
release: v1.6.0

### DIFF
--- a/.changeset/calm-scanners-walk.md
+++ b/.changeset/calm-scanners-walk.md
@@ -1,9 +1,0 @@
----
-"harness-score": minor
----
-
-Scan the complete repository tree without a production depth cap, raise the
-file-count fuse to 1,000,000, and decide incomplete-scan failures from the
-selected gate while preserving authoritative maturity outputs. Discovered
-paths that cannot be inspected and symlinks that escape the scan root now also
-make the affected snapshot incomplete.

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
   version:
     description: 'harness-score npm version or package spec to run.'
     required: false
-    default: '1.5.3'
+    default: '1.6.0'
   comment:
     description: >-
       Post (or update) a sticky pull-request comment showing the harness

--- a/action/README.md
+++ b/action/README.md
@@ -96,7 +96,7 @@ concurrency:
 | `badge` | `harness-badge.svg` | SVG pill (`harness` + level); empty to skip |
 | `report` | _(empty)_ | Markdown report output path |
 | `working-directory` | `.` | Directory to scan |
-| `version` | `1.5.3` | harness-score npm version or package spec |
+| `version` | `1.6.0` | harness-score npm version or package spec |
 | `comment` | `false` | Post/update a sticky PR comment with the score delta (`pull_request` events only; requires `pull-requests: write`) |
 | `include-user-harness` | `false` | Include the user-level harness in the effective snapshot |
 | `include-system-harness` | `false` | Include the system-level harness in the effective snapshot |

--- a/action/action.yml
+++ b/action/action.yml
@@ -27,7 +27,7 @@ inputs:
   version:
     description: 'harness-score npm version or package spec to run.'
     required: false
-    default: '1.5.3'
+    default: '1.6.0'
   comment:
     description: >-
       Post (or update) a sticky pull-request comment showing the harness

--- a/package-lock.json
+++ b/package-lock.json
@@ -6799,7 +6799,7 @@
     },
     "packages/cli": {
       "name": "harness-score",
-      "version": "1.5.3",
+      "version": "1.6.0",
       "license": "MIT",
       "bin": {
         "harness-score": "dist/cli.js"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # harness-score
 
+## 1.6.0
+
+### Minor Changes
+
+- 22767b4: Scan the complete repository tree without a production depth cap, raise the
+  file-count fuse to 1,000,000, and decide incomplete-scan failures from the
+  selected gate while preserving authoritative maturity outputs. Discovered
+  paths that cannot be inspected and symlinks that escape the scan root now also
+  make the affected snapshot incomplete.
+
 ## 1.5.3
 
 ### Patch Changes

--- a/packages/cli/jsr.json
+++ b/packages/cli/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@paladini/harness-score",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-score",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "Deterministic AI coding harness-maturity scanner for AI-assisted repositories (Cursor-flagship, expanding to other AI-first dev tools). Zero LLM calls, zero network, zero runtime dependencies.",
   "type": "module",
   "bin": {

--- a/packages/cli/src/score.ts
+++ b/packages/cli/src/score.ts
@@ -19,7 +19,7 @@ import type {
 import { DIMENSIONS } from './types.js';
 
 export const DOCS_BASE_URL = 'https://paladini.github.io/harness-score/guide/measure-and-improve';
-export const TOOL_VERSION = '1.5.3';
+export const TOOL_VERSION = '1.6.0';
 
 export const LEVEL_NAMES = ['Unharnessed', 'Documented', 'Guided', 'Sensing', 'Self-correcting'] as const;
 


### PR DESCRIPTION
Releases harness-score 1.6.0 after PR #50. Consumes the minor changeset and synchronizes npm, JSR, changelog, lockfile, GitHub Action manifests, and Action documentation. Validated with 360 tests, lint, L4 self-scan, docs build, plugin sync, package-shape checks, and npm audit --omit=dev.