### PR TITLE
fix(ci): detect non-GitHub CI files below the scan root

### DIFF
--- a/.changeset/steady-ci-workspaces.md
+++ b/.changeset/steady-ci-workspaces.md
@@ -1,0 +1,5 @@
+---
+"harness-score": patch
+---
+
+Detect non-GitHub CI configuration files in nested workspace projects.

--- a/.changeset/steady-ci-workspaces.md
+++ b/.changeset/steady-ci-workspaces.md
@@ -2,4 +2,6 @@
 "harness-score": patch
 ---
 
-Detect non-GitHub CI configuration files in nested workspace projects.
+Detect non-GitHub CI configuration files in nested workspace projects. Thanks
+to [@felipecontratres-gupy](https://github.com/felipecontratres-gupy) for
+reporting the issue and contributing the initial fix.

--- a/.changeset/steady-ci-workspaces.md
+++ b/.changeset/steady-ci-workspaces.md
@@ -5,3 +5,5 @@
 Detect non-GitHub CI configuration files in nested workspace projects. Thanks
 to [@felipecontratres-gupy](https://github.com/felipecontratres-gupy) for
 reporting the issue and contributing the initial fix.
+Thanks also to [@dbtorrico](https://github.com/dbtorrico) for catching the
+guide locale parity gap and providing translation suggestions.

--- a/docs/es/guide/measure-and-improve.md
+++ b/docs/es/guide/measure-and-improve.md
@@ -606,6 +606,10 @@ At least one actual test file in the tree.
 
 #### CI-01 · CI pipeline configured — 4 pts {#ci-01}
 GitHub Actions workflow (or GitLab/CircleCI/Jenkins equivalent).
+La detección se basa en el filesystem y funciona a cualquier profundidad por
+debajo de la raíz del scan. Por lo tanto, también cuentan los archivos de CI en
+proyectos anidados de un workspace. No verifica si el proveedor realmente
+ejecuta el archivo.
 **Corrección:** add `.github/workflows/ci.yml` running your sensors on every push.
 
 #### CI-02 · CI runs the tests — 4 pts {#ci-02}

--- a/docs/guide/measure-and-improve.md
+++ b/docs/guide/measure-and-improve.md
@@ -607,6 +607,9 @@ At least one actual test file in the tree.
 
 #### CI-01 · CI pipeline configured — 4 pts {#ci-01}
 GitHub Actions workflow (or GitLab/CircleCI/Jenkins equivalent).
+Detection is filesystem-based at any depth below the scan root, so CI files in
+nested workspace projects count. It does not verify that the provider actually
+executes the file.
 **Fix:** add `.github/workflows/ci.yml` running your sensors on every push.
 
 #### CI-02 · CI runs the tests — 4 pts {#ci-02}

--- a/docs/hi-IN/guide/measure-and-improve.md
+++ b/docs/hi-IN/guide/measure-and-improve.md
@@ -574,6 +574,9 @@ tree में कम से कम एक वास्तविक test फ़�
 
 #### CI-01 · CI pipeline configured — 4 pts {#ci-01}
 GitHub Actions workflow (या GitLab/CircleCI/Jenkins equivalent)।
+Detection filesystem पर आधारित है और scan root के नीचे किसी भी depth पर लागू
+होती है; इसलिए nested workspace projects की CI files भी count होती हैं। यह
+verify नहीं करती कि provider वास्तव में उस file को execute करता है।
 **सुधार:** `.github/workflows/ci.yml` जोड़ें जो हर push पर sensors चलाए।
 
 #### CI-02 · CI runs the tests — 4 pts {#ci-02}

--- a/docs/pt-BR/guide/measure-and-improve.md
+++ b/docs/pt-BR/guide/measure-and-improve.md
@@ -606,6 +606,9 @@ At least one actual test file in the tree.
 
 #### CI-01 · CI pipeline configured — 4 pts {#ci-01}
 GitHub Actions workflow (or GitLab/CircleCI/Jenkins equivalent).
+A detecção se baseia no filesystem e funciona em qualquer profundidade abaixo
+da raiz do scan. Portanto, arquivos de CI em projetos aninhados de um workspace
+também contam. Ela não verifica se o provedor realmente executa o arquivo.
 **Correção:** add `.github/workflows/ci.yml` running your sensors on every push.
 
 #### CI-02 · CI runs the tests — 4 pts {#ci-02}

--- a/docs/zh-CN/guide/measure-and-improve.md
+++ b/docs/zh-CN/guide/measure-and-improve.md
@@ -561,6 +561,7 @@ prettier/biome、black/ruff-format、gofmt/rustfmt。
 
 #### CI-01 · CI pipeline configured — 4 pts {#ci-01}
 GitHub Actions workflow（或 GitLab/CircleCI/Jenkins 等价物）。
+检测基于文件系统，会计入扫描根目录下任意深度的文件，因此嵌套工作区项目中的 CI 文件也算。它不会验证 CI 平台是否实际执行该文件。
 **修复：** 添加 `.github/workflows/ci.yml`，每次 push 运行传感器。
 
 #### CI-02 · CI runs the tests — 4 pts {#ci-02}

--- a/packages/cli/src/checks/ci.ts
+++ b/packages/cli/src/checks/ci.ts
@@ -15,7 +15,7 @@ const OTHER_CI_RES = [
 ];
 
 function ciFiles(ctx: ScanContext): string[] {
-  return [WORKFLOW_RE, ...OTHER_CI_RES].flatMap((re) => ctx.matching(re));
+  return [...new Set([WORKFLOW_RE, ...OTHER_CI_RES].flatMap((re) => ctx.matching(re)))];
 }
 
 function ciContent(ctx: ScanContext): string {

--- a/packages/cli/src/checks/ci.ts
+++ b/packages/cli/src/checks/ci.ts
@@ -1,17 +1,21 @@
 import type { Check, ScanContext } from '../types.js';
 import { safeJsonParse } from '../util.js';
 
+// Every provider is matched depth-independently: in a workspace layout the
+// agent harness lives in a control repo at the root and the code repos are
+// subfolders, each carrying its own pipeline file. Matching only at depth 0
+// scored those repos 0/14 on CI while the harness itself was complete.
 const WORKFLOW_RE = /(^|\/)\.github\/workflows\/[^/]+\.(yml|yaml)$/;
-const OTHER_CI = [
-  '.gitlab-ci.yml',
-  'azure-pipelines.yml',
-  '.circleci/config.yml',
-  'Jenkinsfile',
-  'bitbucket-pipelines.yml',
+const OTHER_CI_RES = [
+  /(^|\/)\.gitlab-ci\.yml$/,
+  /(^|\/)azure-pipelines\.yml$/,
+  /(^|\/)\.circleci\/config\.yml$/,
+  /(^|\/)Jenkinsfile$/,
+  /(^|\/)bitbucket-pipelines\.yml$/,
 ];
 
 function ciFiles(ctx: ScanContext): string[] {
-  return [...ctx.matching(WORKFLOW_RE), ...OTHER_CI.filter((f) => ctx.has(f))];
+  return [WORKFLOW_RE, ...OTHER_CI_RES].flatMap((re) => ctx.matching(re));
 }
 
 function ciContent(ctx: ScanContext): string {

--- a/packages/cli/test/checks.test.ts
+++ b/packages/cli/test/checks.test.ts
@@ -351,6 +351,38 @@ describe('ci checks', () => {
     expect((await check('CI-01')).run(ctx).passed).toBe(true);
   });
 
+  test('CI-01 passes with a root Jenkinsfile', async () => {
+    const ctx = fakeContext({ Jenkinsfile: 'pipeline { agent any }' });
+    expect((await check('CI-01')).run(ctx).passed).toBe(true);
+  });
+
+  // Workspace layout: the harness lives in a control repo at the root and each
+  // code repo is a subfolder with its own pipeline file. GitHub Actions already
+  // matched at depth; the other providers did not.
+  test('CI-01 detects non-GitHub CI files below the scan root', async () => {
+    for (const file of [
+      'backend/Jenkinsfile',
+      'services/api/.gitlab-ci.yml',
+      'apps/web/azure-pipelines.yml',
+      'packages/cli/.circleci/config.yml',
+      'infra/bitbucket-pipelines.yml',
+    ]) {
+      const ctx = fakeContext({ [file]: 'sh "npm test"' });
+      expect((await check('CI-01')).run(ctx).passed, file).toBe(true);
+    }
+  });
+
+  test('CI-02 and CI-03 inspect a nested pipeline file', async () => {
+    const ctx = fakeContext({ 'backend/Jenkinsfile': 'sh "npm test"\nsh "npm run lint"' });
+    expect((await check('CI-02')).run(ctx).passed).toBe(true);
+    expect((await check('CI-03')).run(ctx).passed).toBe(true);
+  });
+
+  test('CI-01 does not match a filename that merely ends with a CI file name', async () => {
+    const ctx = fakeContext({ 'docs/not-a-Jenkinsfile': 'x', 'docs/Jenkinsfile.md': 'x' });
+    expect((await check('CI-01')).run(ctx).passed).toBe(false);
+  });
+
   test('CI-02 recognizes turbo/nx/pnpm-filter monorepo test invocations', async () => {
     const turbo = fakeContext({ '.github/workflows/ci.yml': 'run: turbo run test' });
     expect((await check('CI-02')).run(turbo).passed).toBe(true);

--- a/packages/cli/test/checks.test.ts
+++ b/packages/cli/test/checks.test.ts
@@ -356,6 +356,15 @@ describe('ci checks', () => {
     expect((await check('CI-01')).run(ctx).passed).toBe(true);
   });
 
+  test('CI-01 de-duplicates files that match multiple provider patterns', async () => {
+    const file = '.github/workflows/bitbucket-pipelines.yml';
+    const ctx = fakeContext({ [file]: 'run: npm test' });
+    const outcome = (await check('CI-01')).run(ctx);
+
+    expect(outcome.passed).toBe(true);
+    expect(outcome.evidence).toBe(`Found: ${file}.`);
+  });
+
   // Workspace layout: the harness lives in a control repo at the root and each
   // code repo is a subfolder with its own pipeline file. GitHub Actions already
   // matched at depth; the other providers did not.


### PR DESCRIPTION
Fixes the false negative reported in #54.

## The bug

`CI-01` matched GitHub Actions workflows through `ctx.matching()` — depth-independent — but the other five providers through `ctx.has()`, an exact-path lookup. So `Jenkinsfile`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `.circleci/config.yml` and `bitbucket-pipelines.yml` were only ever found at depth 0, and `CI-02`/`CI-03` short-circuit on the same empty list. GitHub Actions was the only provider that worked below the root.

Before / after, four scratch repos each holding one CI file:

| CI file | before | after |
|---|---|---|
| `Jenkinsfile` at the root | 8/14 | 8/14 |
| `sub/Jenkinsfile` | **0/14** | **8/14** |
| `.github/workflows/ci.yml` at the root | 8/14 | 8/14 |
| `sub/.github/workflows/ci.yml` | 8/14 | 8/14 |

## Why it matters

The layout that surfaced it is a "workspace": a control repo at the root holding the whole agent harness (`CLAUDE.md`, commands, workflows, hooks, docs), with the code repos as independent git repos in subfolders, each carrying its own `Jenkinsfile`. Everything else in the scanner already handles that shape — context files and skills in a subfolder are picked up at repo scope — so CI was the one dimension reading zero on repos that were otherwise well harnessed.

Two of ours, scanned at the control root:

| repo | before | after |
|---|---|---|
| A | L2 · 87/108 (81%) · CI 0/14 | **L4 · 98/108 (91%) · CI 11/14** |
| B | L2 · 84/108 (78%) · CI 3/14 | **L4 · 92/108 (85%) · CI 11/14** |

Two maturity levels, from a detector that was looking one directory too shallow.

## The change

`OTHER_CI` becomes `OTHER_CI_RES`, five anchored regexes matched the same way as `WORKFLOW_RE`. Deliberately narrow:

- Check IDs, points and dimension totals are untouched. The CI-01 catalog now documents the any-depth filesystem semantics, while `docs.test.ts` and `maturity-sync.test.ts` confirm the maturity model remains unchanged.
- Evidence ordering is preserved (workflows first, then the providers in their original order), and overlapping matchers are de-duplicated in first-seen order.
- Anchoring on `(^|\/)` keeps `docs/not-a-Jenkinsfile` and `docs/Jenkinsfile.md` from matching — there is a test for that.
- `SKIP_DIRS` already excludes `node_modules`, `vendor`, `dist` and friends, so recursive matching does not start rewarding vendored pipeline files.
- Zero runtime dependencies, no new I/O, still fully deterministic.
- A patch changeset records the user-facing detection fix for the next release.

## Tests

Five regression cases in `packages/cli/test/checks.test.ts`: root `Jenkinsfile`; all five non-GitHub providers below the root; `CI-02`/`CI-03` reading a nested pipeline file; overlapping provider matchers producing one evidence path; and near-miss filenames that must not match.

Local and remote validation:

- `npm test`: **21 files, 365 tests passing**.
- `npm run lint`: passes with the 18 pre-existing `noImportantStyles` warnings under `docs/.vitepress/theme/`.
- `npm run scan`: **L4, 108/108**.
- `npm run docs:build` and `git diff --check`: pass.
- Real CLI matrix: all five nested non-GitHub providers plus root/nested GitHub Actions pass CI-01/02/03; overlapping evidence is unique; near-miss filenames fail.
- 100,000-file benchmark, seven runs: base median **812.1 ms / 120.0 MiB**, final median **824.4 ms / 120.0 MiB** (+1.5%).
- [CI run 32499965216](https://github.com/paladini/harness-score/actions/runs/32499965216): Ubuntu Node 18, Windows Node 22, and full Ubuntu Node 22 checks all pass.
