### PR TITLE
release: v1.6.1

### DIFF
--- a/.changeset/steady-ci-workspaces.md
+++ b/.changeset/steady-ci-workspaces.md
@@ -1,9 +1,0 @@
----
-"harness-score": patch
----
-
-Detect non-GitHub CI configuration files in nested workspace projects. Thanks
-to [@felipecontratres-gupy](https://github.com/felipecontratres-gupy) for
-reporting the issue and contributing the initial fix.
-Thanks also to [@dbtorrico](https://github.com/dbtorrico) for catching the
-guide locale parity gap and providing translation suggestions.

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
   version:
     description: 'harness-score npm version or package spec to run.'
     required: false
-    default: '1.6.0'
+    default: '1.6.1'
   comment:
     description: >-
       Post (or update) a sticky pull-request comment showing the harness

--- a/action/README.md
+++ b/action/README.md
@@ -96,7 +96,7 @@ concurrency:
 | `badge` | `harness-badge.svg` | SVG pill (`harness` + level); empty to skip |
 | `report` | _(empty)_ | Markdown report output path |
 | `working-directory` | `.` | Directory to scan |
-| `version` | `1.6.0` | harness-score npm version or package spec |
+| `version` | `1.6.1` | harness-score npm version or package spec |
 | `comment` | `false` | Post/update a sticky PR comment with the score delta (`pull_request` events only; requires `pull-requests: write`) |
 | `include-user-harness` | `false` | Include the user-level harness in the effective snapshot |
 | `include-system-harness` | `false` | Include the system-level harness in the effective snapshot |

--- a/action/action.yml
+++ b/action/action.yml
@@ -27,7 +27,7 @@ inputs:
   version:
     description: 'harness-score npm version or package spec to run.'
     required: false
-    default: '1.6.0'
+    default: '1.6.1'
   comment:
     description: >-
       Post (or update) a sticky pull-request comment showing the harness

--- a/package-lock.json
+++ b/package-lock.json
@@ -6799,7 +6799,7 @@
     },
     "packages/cli": {
       "name": "harness-score",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "bin": {
         "harness-score": "dist/cli.js"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # harness-score
 
+## 1.6.1
+
+### Patch Changes
+
+- 7124092: Detect non-GitHub CI configuration files in nested workspace projects. Thanks
+  to [@felipecontratres-gupy](https://github.com/felipecontratres-gupy) for
+  reporting the issue and contributing the initial fix.
+  Thanks also to [@dbtorrico](https://github.com/dbtorrico) for catching the
+  guide locale parity gap and providing translation suggestions.
+
 ## 1.6.0
 
 ### Minor Changes

--- a/packages/cli/jsr.json
+++ b/packages/cli/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@paladini/harness-score",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-score",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Deterministic AI coding harness-maturity scanner for AI-assisted repositories (Cursor-flagship, expanding to other AI-first dev tools). Zero LLM calls, zero network, zero runtime dependencies.",
   "type": "module",
   "bin": {

--- a/packages/cli/src/score.ts
+++ b/packages/cli/src/score.ts
@@ -19,7 +19,7 @@ import type {
 import { DIMENSIONS } from './types.js';
 
 export const DOCS_BASE_URL = 'https://paladini.github.io/harness-score/guide/measure-and-improve';
-export const TOOL_VERSION = '1.6.0';
+export const TOOL_VERSION = '1.6.1';
 
 export const LEVEL_NAMES = ['Unharnessed', 'Documented', 'Guided', 'Sensing', 'Self-correcting'] as const;
 


### PR DESCRIPTION
## Summary

- release `harness-score` 1.6.1 with nested workspace CI configuration detection
- keep the npm, JSR, CLI, and GitHub Action version surfaces synchronized
- include contributor acknowledgements in the changelog

## Contributors

Thanks to [@felipecontratres-gupy](https://github.com/felipecontratres-gupy) for reporting #54 and contributing the initial fix in #55.

Thanks to [@dbtorrico](https://github.com/dbtorrico) for catching the guide locale parity gap and providing translation suggestions.

## Validation

- `npm test`: 21 files, 365 tests passed
- `npm run lint`: passed with the 18 pre-existing CSS warnings
- `npm run scan`: L4, 108/108
- `npm run docs:build`: passed
- `npm run plugins:sync-check`: passed
- `npm audit --omit=dev`: 0 vulnerabilities
- `git diff --check`: passed
- npm package candidate: 12 files, zero runtime dependencies

The first full local test run encountered one isolated Windows child-process timeout. The affected test passed immediately in isolation, and the complete 365-test suite passed on the required rerun.

