### PR TITLE
fix(ci): detect Forgejo Actions workflows

### DIFF
--- a/.changeset/green-forgejo-detect.md
+++ b/.changeset/green-forgejo-detect.md
@@ -1,0 +1,5 @@
+---
+"harness-score": patch
+---
+
+Detect Forgejo Actions workflows in `.forgejo/workflows/` for CI checks.

--- a/docs/guide/measure-and-improve.md
+++ b/docs/guide/measure-and-improve.md
@@ -606,8 +606,8 @@ At least one actual test file in the tree.
 ### CI Feedback (14 pts)
 
 #### CI-01 · CI pipeline configured — 4 pts {#ci-01}
-GitHub Actions workflow (or GitLab/CircleCI/Jenkins equivalent), including a
-Google Cloud Build configuration under `cloudbuild/`.
+GitHub Actions or Forgejo Actions workflow (or GitLab/CircleCI/Jenkins
+equivalent), including a Google Cloud Build configuration under `cloudbuild/`.
 Detection is filesystem-based at any depth below the scan root, so CI files in
 nested workspace projects count. It does not verify that the provider actually
 executes the file.

--- a/packages/cli/src/checks/ci.ts
+++ b/packages/cli/src/checks/ci.ts
@@ -5,7 +5,7 @@ import { safeJsonParse } from '../util.js';
 // agent harness lives in a control repo at the root and the code repos are
 // subfolders, each carrying its own pipeline file. Matching only at depth 0
 // scored those repos 0/14 on CI while the harness itself was complete.
-const WORKFLOW_RE = /(^|\/)\.github\/workflows\/[^/]+\.(yml|yaml)$/;
+const WORKFLOW_RE = /(^|\/)\.(github|forgejo)\/workflows\/[^/]+\.(yml|yaml)$/;
 const OTHER_CI_RES = [
   /(^|\/)\.gitlab-ci\.yml$/,
   /(^|\/)azure-pipelines\.yml$/,

--- a/packages/cli/test/checks.test.ts
+++ b/packages/cli/test/checks.test.ts
@@ -351,6 +351,18 @@ describe('ci checks', () => {
     expect((await check('CI-01')).run(ctx).passed).toBe(true);
   });
 
+  test('CI-01, CI-02, and CI-03 recognize a Forgejo Actions workflow', async () => {
+    const file = '.forgejo/workflows/verify.yaml';
+    const ctx = fakeContext({ [file]: 'run: pnpm test\nrun: pnpm lint' });
+
+    expect((await check('CI-01')).run(ctx)).toMatchObject({
+      passed: true,
+      evidence: `Found: ${file}.`,
+    });
+    expect((await check('CI-02')).run(ctx).passed).toBe(true);
+    expect((await check('CI-03')).run(ctx).passed).toBe(true);
+  });
+
   test('CI-01 passes with a root Jenkinsfile', async () => {
     const ctx = fakeContext({ Jenkinsfile: 'pipeline { agent any }' });
     expect((await check('CI-01')).run(ctx).passed).toBe(true);


### PR DESCRIPTION
## Summary
- recognize .forgejo/workflows/*.{yml,yaml} as Forgejo Actions CI workflows
- inspect Forgejo workflow contents for CI-02 and CI-03
- document Forgejo support and add a patch changeset

Scope is Forgejo-only, matching issue #47. No points or maturity thresholds change.

Fixes #47

## Validation
- 
pm test - 370 passing
- targeted Biome check for changed source and test files
- 
pm run scan - L4, 108/108
- 
pm run docs:build`n- 
pm run plugins:sync-check`n
Local 
pm run lint is blocked only by pre-existing, untracked .harness-eval/ artifacts in the shared worktree; remote CI uses a clean checkout and remains the full lint gate.