### PR TITLE
release: v1.6.3

### DIFF
--- a/.changeset/green-forgejo-detect.md
+++ b/.changeset/green-forgejo-detect.md
@@ -1,5 +1,0 @@
----
-"harness-score": patch
----
-
-Detect Forgejo Actions workflows in `.forgejo/workflows/` for CI checks.

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
   version:
     description: 'harness-score npm version or package spec to run.'
     required: false
-    default: '1.6.2'
+    default: '1.6.3'
   comment:
     description: >-
       Post (or update) a sticky pull-request comment showing the harness

--- a/action/README.md
+++ b/action/README.md
@@ -96,7 +96,7 @@ concurrency:
 | `badge` | `harness-badge.svg` | SVG pill (`harness` + level); empty to skip |
 | `report` | _(empty)_ | Markdown report output path |
 | `working-directory` | `.` | Directory to scan |
-| `version` | `1.6.2` | harness-score npm version or package spec |
+| `version` | `1.6.3` | harness-score npm version or package spec |
 | `comment` | `false` | Post/update a sticky PR comment with the score delta (`pull_request` events only; requires `pull-requests: write`) |
 | `include-user-harness` | `false` | Include the user-level harness in the effective snapshot |
 | `include-system-harness` | `false` | Include the system-level harness in the effective snapshot |

--- a/action/action.yml
+++ b/action/action.yml
@@ -27,7 +27,7 @@ inputs:
   version:
     description: 'harness-score npm version or package spec to run.'
     required: false
-    default: '1.6.2'
+    default: '1.6.3'
   comment:
     description: >-
       Post (or update) a sticky pull-request comment showing the harness

--- a/package-lock.json
+++ b/package-lock.json
@@ -6799,7 +6799,7 @@
     },
     "packages/cli": {
       "name": "harness-score",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "MIT",
       "bin": {
         "harness-score": "dist/cli.js"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # harness-score
 
+## 1.6.3
+
+### Patch Changes
+
+- 4212dab: Detect Forgejo Actions workflows in `.forgejo/workflows/` for CI checks.
+
 ## 1.6.2
 
 ### Patch Changes

--- a/packages/cli/jsr.json
+++ b/packages/cli/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@paladini/harness-score",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-score",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Deterministic AI coding harness-maturity scanner for AI-assisted repositories (Cursor-flagship, expanding to other AI-first dev tools). Zero LLM calls, zero network, zero runtime dependencies.",
   "type": "module",
   "bin": {

--- a/packages/cli/src/score.ts
+++ b/packages/cli/src/score.ts
@@ -19,7 +19,7 @@ import type {
 import { DIMENSIONS } from './types.js';
 
 export const DOCS_BASE_URL = 'https://paladini.github.io/harness-score/guide/measure-and-improve';
-export const TOOL_VERSION = '1.6.2';
+export const TOOL_VERSION = '1.6.3';
 
 export const LEVEL_NAMES = ['Unharnessed', 'Documented', 'Guided', 'Sensing', 'Self-correcting'] as const;
 


### PR DESCRIPTION
## Release v1.6.3

Patch release for #47: Forgejo Actions workflows in .forgejo/workflows/*.{yml,yaml} now contribute to CI-01 through CI-03.

## Version synchronization
- CLI package, TOOL_VERSION, JSR manifest, lockfile, both Action entrypoints, and Action README are all 1.6.3.
- packages/cli/CHANGELOG.md contains the release notes.

## Validation
- 
pm test - 370 passing
- targeted Biome validation for all changed format-aware files
- 
pm run scan - L4, 108/108
- 
pm run docs:build`n- 
pm run plugins:sync-check`n
The local full lint remains blocked only by unrelated untracked .harness-eval/ files; CI is the clean, full lint gate.