### PR TITLE
fix: skip .devbox during scans

### DIFF
--- a/.changeset/skip-devbox-dir.md
+++ b/.changeset/skip-devbox-dir.md
@@ -1,0 +1,8 @@
+---
+"harness-score": patch
+---
+
+Skip `.devbox/` during scans. Devbox provisions this directory with binary
+symlinks (e.g. `.devbox/bin/devbox`) that resolve outside the repo root,
+which previously made the whole scan report incomplete via
+`outside-root-symlink`.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ trees above 1,000,000 files; hitting that fuse, finding an out-of-root symlink,
 or encountering an unreadable relevant path marks the affected snapshot as
 incomplete instead of publishing its score as authoritative.
 
+Repositories using [Devbox](https://www.jetify.com/docs/devbox) are supported:
+the scanner skips Devbox's generated `.devbox/` directory, including its
+`.devbox/bin/devbox` symlink and generated virtual-environment state. Project
+configuration such as `devbox.json`, `devbox.lock`, and `devbox.d/` remains
+visible to the scan. Devbox is an environment manager, not a detected AI
+harness, so it does not add maturity points or appear in `detectedHarnesses`.
+
 ## Stability & versioning
 
 As of **v1.0.0**, Harness Score follows [semantic versioning](https://semver.org/)

--- a/docs/es/guide/multi-harness.md
+++ b/docs/es/guide/multi-harness.md
@@ -38,6 +38,27 @@ Harness Score reconoce estos artefactos (patrones exactos en el registry del esc
 | **OpenCode** | — | — | — | `.opencode/agents/*.md` | — | — |
 | **Zed** | — | — | `.zed/commands/*.md` | — | — | — |
 
+### Compatibilidad con el entorno Devbox
+
+Harness Score admite repositorios que usan [Devbox](https://www.jetify.com/docs/devbox)
+como entorno de desarrollo. Esta es compatibilidad del sistema de archivos, no
+detección de un harness de IA: Devbox no aparece en `detectedHarnesses` y su
+configuración no suma puntos de madurez.
+
+Devbox crea un directorio `.devbox/` local al proyecto para el entorno aislado.
+Puede contener estado generado, como `.devbox/virtenv/`, y el enlace simbólico
+`.devbox/bin/devbox` que se usa dentro de un shell puro. Harness Score omite todo
+`.devbox/`, incluidos los enlaces simbólicos, para que los archivos generados del
+entorno no marquen el escaneo como incompleto. Consulta el
+[FAQ de Devbox](https://www.jetify.com/docs/devbox/faq) y la
+[implementación de Devbox](https://github.com/jetify-com/devbox/blob/main/internal/devbox/pure_shell.go)
+para conocer las rutas upstream.
+
+Mantén la configuración del proyecto en `devbox.json`, `devbox.lock` y `devbox.d/`
+en la raíz del proyecto. Esas rutas siguen siendo visibles para el escaneo. Los
+archivos dentro de `.devbox/` no se puntúan intencionadamente como artefactos de
+harness.
+
 Archivos de contexto en raíz (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) cuentan para toda herramienta.
 Y los artefactos más importantes son **agnósticos de herramienta**: tests, CI, linters, type checkers, `.gitignore`, lockfiles y `SECURITY.md` puntúan igual sin importar la herramienta.
 

--- a/docs/guide/multi-harness.md
+++ b/docs/guide/multi-harness.md
@@ -38,6 +38,25 @@ harness registry — [`registry.ts`](https://github.com/paladini/harness-score/b
 | **OpenCode** | — | — | — | `.opencode/agents/*.md` | — | — |
 | **Zed** | — | — | `.zed/commands/*.md` | — | — | — |
 
+### Devbox environment compatibility
+
+Harness Score supports repositories that use [Devbox](https://www.jetify.com/docs/devbox)
+as their development environment. This is filesystem compatibility, not AI-harness
+detection: Devbox does not appear in `detectedHarnesses`, and its configuration does
+not earn maturity points.
+
+Devbox creates a project-local `.devbox/` directory for the isolated environment.
+That directory can contain generated state such as `.devbox/virtenv/` and the
+`.devbox/bin/devbox` symlink used inside a pure shell. Harness Score skips the entire
+`.devbox/` directory, including symlinks, so generated environment files do not make
+the scan incomplete. See the [Devbox FAQ](https://www.jetify.com/docs/devbox/faq)
+and the [Devbox implementation](https://github.com/jetify-com/devbox/blob/main/internal/devbox/pure_shell.go)
+for the upstream paths.
+
+Keep project configuration in `devbox.json`, `devbox.lock`, and `devbox.d/` at the
+project root. Those paths remain scan-visible. Files placed under `.devbox/` are
+intentionally not scored as harness artifacts.
+
 Root context files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) count for every tool.
 And the most important artifacts are **tool-agnostic** anyway: tests, CI pipelines, linters, type checkers, `.gitignore`, lockfiles, and `SECURITY.md` score the same no matter which tool you use.
 

--- a/docs/hi-IN/guide/multi-harness.md
+++ b/docs/hi-IN/guide/multi-harness.md
@@ -37,6 +37,22 @@ Harness Score ये artifacts पहचानता है (exact patterns scan
 | **OpenCode** | — | — | — | `.opencode/agents/*.md` | — | — |
 | **Zed** | — | — | `.zed/commands/*.md` | — | — | — |
 
+### Devbox environment compatibility
+
+Harness Score उन repositories को support करता है जो [Devbox](https://www.jetify.com/docs/devbox)
+को development environment के रूप में उपयोग करते हैं। यह filesystem compatibility है, AI-harness
+detection नहीं: Devbox `detectedHarnesses` में दिखाई नहीं देता और उसकी configuration maturity points
+नहीं देती।
+
+Devbox isolated environment के लिए project में `.devbox/` directory बनाता है। इसमें `.devbox/virtenv/`
+जैसा generated state और pure shell में उपयोग होने वाला `.devbox/bin/devbox` symlink हो सकता है।
+Harness Score पूरी `.devbox/` directory, symlinks सहित, skip करता है ताकि generated environment files
+scan को incomplete न बनाएं। Paths के लिए [Devbox FAQ](https://www.jetify.com/docs/devbox/faq) और
+[Devbox implementation](https://github.com/jetify-com/devbox/blob/main/internal/devbox/pure_shell.go) देखें।
+
+Project configuration को project root में `devbox.json`, `devbox.lock`, और `devbox.d/` में रखें। ये paths
+scan में दिखाई देते हैं। `.devbox/` के अंदर की files को harness artifacts के रूप में score नहीं किया जाता।
+
 Root context files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) हर tool के लिए गिनती हैं।
 और सबसे महत्वपूर्ण artifacts **tool-agnostic** हैं: tests, CI pipelines, linters, type checkers, `.gitignore`, lockfiles, और `SECURITY.md` — कौन सा tool उपयोग करें, score समान।
 

--- a/docs/pt-BR/guide/multi-harness.md
+++ b/docs/pt-BR/guide/multi-harness.md
@@ -38,6 +38,26 @@ O Harness Score reconhece estes artefatos (padrões exatos no registry do scanne
 | **OpenCode** | — | — | — | `.opencode/agents/*.md` | — | — |
 | **Zed** | — | — | `.zed/commands/*.md` | — | — | — |
 
+### Compatibilidade com o ambiente Devbox
+
+O Harness Score é compatível com repositórios que usam o
+[Devbox](https://www.jetify.com/docs/devbox) como ambiente de desenvolvimento.
+Isso é compatibilidade de filesystem, não detecção de harness de IA: o Devbox não
+aparece em `detectedHarnesses`, e sua configuração não gera pontos de maturidade.
+
+O Devbox cria um diretório `.devbox/` local ao projeto para o ambiente isolado.
+Esse diretório pode conter estado gerado, como `.devbox/virtenv/`, e o symlink
+`.devbox/bin/devbox` usado dentro de um shell puro. O Harness Score ignora todo o
+diretório `.devbox/`, incluindo symlinks, para que arquivos do ambiente gerado não
+deixem o scan incompleto. Consulte o
+[FAQ do Devbox](https://www.jetify.com/docs/devbox/faq) e a
+[implementação do Devbox](https://github.com/jetify-com/devbox/blob/main/internal/devbox/pure_shell.go)
+para os paths upstream.
+
+Mantenha a configuração do projeto em `devbox.json`, `devbox.lock` e `devbox.d/`
+na raiz do projeto. Esses paths continuam visíveis para o scan. Arquivos colocados
+em `.devbox/` não são intencionalmente pontuados como artefatos de harness.
+
 Arquivos de contexto na raiz (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) contam para toda ferramenta.
 E os artefatos mais importantes são **agnósticos de ferramenta**: testes, CI, linters, type checkers, `.gitignore`, lockfiles e `SECURITY.md` pontuam igual independente da ferramenta.
 

--- a/docs/zh-CN/guide/multi-harness.md
+++ b/docs/zh-CN/guide/multi-harness.md
@@ -37,6 +37,21 @@ Harness Score 识别以下工件（精确模式见扫描器 harness registry —
 | **OpenCode** | — | — | — | `.opencode/agents/*.md` | — | — |
 | **Zed** | — | — | `.zed/commands/*.md` | — | — | — |
 
+### Devbox 环境兼容性
+
+Harness Score 支持使用 [Devbox](https://www.jetify.com/docs/devbox) 作为开发环境的仓库。
+这表示文件系统兼容，而不是 AI harness 检测：Devbox 不会出现在 `detectedHarnesses` 中，
+其配置也不会获得成熟度分数。
+
+Devbox 会在项目中创建本地 `.devbox/` 目录，用于隔离环境。该目录可能包含
+`.devbox/virtenv/` 等生成状态，以及纯 shell 中使用的 `.devbox/bin/devbox` 符号链接。
+Harness Score 会跳过整个 `.devbox/` 目录（包括符号链接），因此生成的环境文件不会把扫描
+标记为不完整。有关 upstream 路径，请参阅 [Devbox FAQ](https://www.jetify.com/docs/devbox/faq)
+和 [Devbox 实现](https://github.com/jetify-com/devbox/blob/main/internal/devbox/pure_shell.go)。
+
+请将项目配置保存在项目根目录的 `devbox.json`、`devbox.lock` 和 `devbox.d/` 中。
+这些路径仍会被扫描。`.devbox/` 下的文件不会被计为 harness 工件，这是有意为之。
+
 根上下文文件（`AGENTS.md`、`CLAUDE.md`、`GEMINI.md`）对所有工具均计数。
 而最重要的工件**本就与工具无关**：测试、CI 流水线、linter、类型检查器、`.gitignore`、锁文件与 `SECURITY.md`，无论使用哪种工具，得分方式相同。
 

--- a/packages/cli/src/scan.ts
+++ b/packages/cli/src/scan.ts
@@ -29,6 +29,7 @@ const SKIP_DIRS = new Set([
   '.pytest_cache',
   '.mypy_cache',
   '.ruff_cache',
+  '.devbox',
 ]);
 
 /**

--- a/packages/cli/test/scan.test.ts
+++ b/packages/cli/test/scan.test.ts
@@ -176,6 +176,28 @@ describe('createScanContext — symlinks', () => {
     expect(ctx.incompleteReasons).toEqual([]);
   });
 
+  test('skips a devbox binary symlink that resolves outside the repo root', () => {
+    const root = mkTmpDir();
+    const repo = path.join(root, 'repo');
+    const outside = path.join(root, 'outside');
+    fs.mkdirSync(repo);
+    fs.mkdirSync(outside);
+    const devboxBin = path.join(outside, 'devbox');
+    fs.writeFileSync(devboxBin, 'must stay outside');
+    fs.mkdirSync(path.join(repo, '.devbox', 'bin'), { recursive: true });
+    try {
+      fs.symlinkSync(devboxBin, path.join(repo, '.devbox', 'bin', 'devbox'), 'file');
+    } catch {
+      return;
+    }
+
+    const ctx = createScanContext(repo);
+
+    expect(ctx.files).toEqual([]);
+    expect(ctx.truncated).toBe(false);
+    expect(ctx.incompleteReasons).toEqual([]);
+  });
+
   test('does not enumerate an external directory symlink and fails closed with its path', () => {
     const root = mkTmpDir();
     const repo = path.join(root, 'repo');
@@ -280,6 +302,7 @@ describe('createScanContext — preserved safety boundaries', () => {
       '.pytest_cache',
       '.mypy_cache',
       '.ruff_cache',
+      '.devbox',
     ];
     for (const directory of skippedDirectories) {
       fs.mkdirSync(path.join(root, directory), { recursive: true });


### PR DESCRIPTION
## What & why

Devbox provisions a `.devbox/` directory with binary symlinks (e.g.
`.devbox/bin/devbox`) that resolve outside the repo root — into Devbox's own
cache or the Nix store. The scanner didn't skip `.devbox` the way it already
skips other generated/tooling directories (`node_modules`, `.venv`, `.cache`,
etc.), so it walked into it, hit the out-of-root symlink, and reported the
**entire scan as incomplete** via `outside-root-symlink`, with no maturity
verdict at all — on any repo using Devbox.

This adds `.devbox` to `SKIP_DIRS` in `scan.ts`, matching the existing
pattern for directories that never carry harness signal.

No issue opened first — this is an "obvious bug" fix per CONTRIBUTING.md
(single check-list category: false positive/negative in scan completeness,
not a check/scoring change).

## Type of change

- [x] Bug fix (false positive/negative in a check, incorrect output)
- [ ] New or changed check (check change — see checklist below)
- [ ] Docs
- [ ] Other (plugin, GitHub Action, tooling)

## Check-change checklist (skip if not touching `score.ts`/checks)

N/A — this only touches the filesystem walker (`scan.ts`), not `score.ts` or
any check.

## Checklist

- [x] `npm test` passes (371 tests)
- [x] `npm run lint` passes (clean on changed files)
- [x] `npm run scan` still reports **L4** for this repo (108/108, 100%)
- [ ] `npm run docs:build` — not applicable, no docs changed
