### PR TITLE
docs: sync score tables across locales

### DIFF
--- a/docs/es/guide/metrics-and-codes.md
+++ b/docs/es/guide/metrics-and-codes.md
@@ -113,21 +113,21 @@ IDs estables — vinculados a remediación en [Medir y mejorar](./measure-and-im
 |---|---|---|---|
 | CI-01 | 4 | Archivo de pipeline CI presente (GitHub Actions, GitLab CI, …) | [ci-01](./measure-and-improve#ci-01) |
 | CI-02 | 4 | CI ejecuta la suite de tests | [ci-02](./measure-and-improve#ci-02) |
-| CI-03 | 4 | CI ejecuta lint o typecheck | [ci-03](./measure-and-improve#ci-03) |
-| CI-04 | 2 | Herramienta pre-commit o git hook instalada | [ci-04](./measure-and-improve#ci-04) |
+| CI-03 | 3 | CI ejecuta lint o typecheck | [ci-03](./measure-and-improve#ci-03) |
+| CI-04 | 3 | Herramienta pre-commit o git hook instalada | [ci-04](./measure-and-improve#ci-04) |
 
 ### Hygiene & Safety
 
 | ID | Pts | Analiza exactamente | Remediación |
 |---|---|---|---|
-| HYG-01 | 4 | `.gitignore` presente | [hyg-01](./measure-and-improve#hyg-01) |
+| HYG-01 | 2 | `.gitignore` presente | [hyg-01](./measure-and-improve#hyg-01) |
 | HYG-02 | 3 | `.gitignore` cubre archivos de entorno | [hyg-02](./measure-and-improve#hyg-02) |
 | HYG-03 | 4 | Sin archivos `.env` desprotegidos (sin patrón `.env.example`) | [hyg-03](./measure-and-improve#hyg-03) |
 | HYG-04 | 4 | Configs JSON de MCP sin patrones inline de credencial | [hyg-04](./measure-and-improve#hyg-04) |
 | HYG-05 | 2 | Archivo `LICENSE` presente | [hyg-05](./measure-and-improve#hyg-05) |
-| HYG-06 | 3 | Sin firmas tipo credencial en markdown/JSON de harness | [hyg-06](./measure-and-improve#hyg-06) |
+| HYG-06 | 2 | Sin firmas tipo credencial en markdown/JSON de harness | [hyg-06](./measure-and-improve#hyg-06) |
 | HYG-07 | 3 | Lockfile de dependencias commiteado | [hyg-07](./measure-and-improve#hyg-07) |
-| HYG-08 | 4 | Configs MCP usan interpolación de env para secretos | [hyg-08](./measure-and-improve#hyg-08) |
+| HYG-08 | 3 | Configs MCP usan interpolación de env para secretos | [hyg-08](./measure-and-improve#hyg-08) |
 
 ## Archivo de configuración (`.harness-score.json`) {#configuration-file-harness-scorejson}
 

--- a/docs/guide/metrics-and-codes.md
+++ b/docs/guide/metrics-and-codes.md
@@ -113,21 +113,21 @@ Stable IDs — linked to remediation in [Measure & Improve](./measure-and-improv
 |---|---|---|---|
 | CI-01 | 4 | CI pipeline file present (GitHub Actions, GitLab CI, …) | [ci-01](./measure-and-improve#ci-01) |
 | CI-02 | 4 | CI runs the test suite | [ci-02](./measure-and-improve#ci-02) |
-| CI-03 | 4 | CI runs lint or typecheck | [ci-03](./measure-and-improve#ci-03) |
-| CI-04 | 2 | Pre-commit or git hook tooling installed | [ci-04](./measure-and-improve#ci-04) |
+| CI-03 | 3 | CI runs lint or typecheck | [ci-03](./measure-and-improve#ci-03) |
+| CI-04 | 3 | Pre-commit or git hook tooling installed | [ci-04](./measure-and-improve#ci-04) |
 
 ### Hygiene & Safety
 
 | ID | Pts | Analyzes exactly | Remediation |
 |---|---|---|---|
-| HYG-01 | 4 | `.gitignore` present | [hyg-01](./measure-and-improve#hyg-01) |
+| HYG-01 | 2 | `.gitignore` present | [hyg-01](./measure-and-improve#hyg-01) |
 | HYG-02 | 3 | `.gitignore` covers environment files | [hyg-02](./measure-and-improve#hyg-02) |
 | HYG-03 | 4 | No unprotected `.env` files (without `.env.example` pattern) | [hyg-03](./measure-and-improve#hyg-03) |
 | HYG-04 | 4 | MCP JSON configs contain no inline credential patterns | [hyg-04](./measure-and-improve#hyg-04) |
 | HYG-05 | 2 | `LICENSE` file present | [hyg-05](./measure-and-improve#hyg-05) |
-| HYG-06 | 3 | No credential-like signatures in harness markdown/JSON | [hyg-06](./measure-and-improve#hyg-06) |
+| HYG-06 | 2 | No credential-like signatures in harness markdown/JSON | [hyg-06](./measure-and-improve#hyg-06) |
 | HYG-07 | 3 | Dependency lockfile committed | [hyg-07](./measure-and-improve#hyg-07) |
-| HYG-08 | 4 | MCP configs use env interpolation for secrets | [hyg-08](./measure-and-improve#hyg-08) |
+| HYG-08 | 3 | MCP configs use env interpolation for secrets | [hyg-08](./measure-and-improve#hyg-08) |
 
 ## Configuration file (`.harness-score.json`)
 

--- a/docs/hi-IN/guide/metrics-and-codes.md
+++ b/docs/hi-IN/guide/metrics-and-codes.md
@@ -113,21 +113,21 @@ Stable IDs — remediation से linked [मापन और सुधार](.
 |---|---|---|---|
 | CI-01 | 4 | CI pipeline file present (GitHub Actions, GitLab CI, …) | [ci-01](./measure-and-improve#ci-01) |
 | CI-02 | 4 | CI test suite चलाता है | [ci-02](./measure-and-improve#ci-02) |
-| CI-03 | 4 | CI lint या typecheck चलाता है | [ci-03](./measure-and-improve#ci-03) |
-| CI-04 | 2 | Pre-commit या git hook tooling installed | [ci-04](./measure-and-improve#ci-04) |
+| CI-03 | 3 | CI lint या typecheck चलाता है | [ci-03](./measure-and-improve#ci-03) |
+| CI-04 | 3 | Pre-commit या git hook tooling installed | [ci-04](./measure-and-improve#ci-04) |
 
 ### Hygiene & Safety
 
 | ID | Pts | Analyzes exactly | Remediation |
 |---|---|---|---|
-| HYG-01 | 4 | `.gitignore` present | [hyg-01](./measure-and-improve#hyg-01) |
+| HYG-01 | 2 | `.gitignore` present | [hyg-01](./measure-and-improve#hyg-01) |
 | HYG-02 | 3 | `.gitignore` environment files cover करता है | [hyg-02](./measure-and-improve#hyg-02) |
 | HYG-03 | 4 | Unprotected `.env` files नहीं (`.env.example` pattern के बिना) | [hyg-03](./measure-and-improve#hyg-03) |
 | HYG-04 | 4 | MCP JSON configs में inline credential patterns नहीं | [hyg-04](./measure-and-improve#hyg-04) |
 | HYG-05 | 2 | `LICENSE` file present | [hyg-05](./measure-and-improve#hyg-05) |
-| HYG-06 | 3 | Harness markdown/JSON में credential-like signatures नहीं | [hyg-06](./measure-and-improve#hyg-06) |
+| HYG-06 | 2 | Harness markdown/JSON में credential-like signatures नहीं | [hyg-06](./measure-and-improve#hyg-06) |
 | HYG-07 | 3 | Dependency lockfile committed | [hyg-07](./measure-and-improve#hyg-07) |
-| HYG-08 | 4 | MCP configs secrets के लिए env interpolation use करते हैं | [hyg-08](./measure-and-improve#hyg-08) |
+| HYG-08 | 3 | MCP configs secrets के लिए env interpolation use करते हैं | [hyg-08](./measure-and-improve#hyg-08) |
 
 ## कॉन्फ़िगरेशन फ़ाइल (`.harness-score.json`) {#configuration-file-harness-scorejson}
 

--- a/docs/pt-BR/guide/metrics-and-codes.md
+++ b/docs/pt-BR/guide/metrics-and-codes.md
@@ -113,21 +113,21 @@ IDs estáveis — vinculados à remediação em [Medir e melhorar](./measure-and
 |---|---|---|---|
 | CI-01 | 4 | Arquivo de pipeline CI presente (GitHub Actions, GitLab CI, …) | [ci-01](./measure-and-improve#ci-01) |
 | CI-02 | 4 | CI executa a suíte de testes | [ci-02](./measure-and-improve#ci-02) |
-| CI-03 | 4 | CI executa lint ou typecheck | [ci-03](./measure-and-improve#ci-03) |
-| CI-04 | 2 | Ferramenta pre-commit ou git hook instalada | [ci-04](./measure-and-improve#ci-04) |
+| CI-03 | 3 | CI executa lint ou typecheck | [ci-03](./measure-and-improve#ci-03) |
+| CI-04 | 3 | Ferramenta pre-commit ou git hook instalada | [ci-04](./measure-and-improve#ci-04) |
 
 ### Hygiene & Safety
 
 | ID | Pts | Analisa exatamente | Remediação |
 |---|---|---|---|
-| HYG-01 | 4 | `.gitignore` presente | [hyg-01](./measure-and-improve#hyg-01) |
+| HYG-01 | 2 | `.gitignore` presente | [hyg-01](./measure-and-improve#hyg-01) |
 | HYG-02 | 3 | `.gitignore` cobre arquivos de ambiente | [hyg-02](./measure-and-improve#hyg-02) |
 | HYG-03 | 4 | Sem arquivos `.env` desprotegidos (sem padrão `.env.example`) | [hyg-03](./measure-and-improve#hyg-03) |
 | HYG-04 | 4 | Configs JSON de MCP sem padrões inline de credencial | [hyg-04](./measure-and-improve#hyg-04) |
 | HYG-05 | 2 | Arquivo `LICENSE` presente | [hyg-05](./measure-and-improve#hyg-05) |
-| HYG-06 | 3 | Sem assinaturas tipo credencial em markdown/JSON de harness | [hyg-06](./measure-and-improve#hyg-06) |
+| HYG-06 | 2 | Sem assinaturas tipo credencial em markdown/JSON de harness | [hyg-06](./measure-and-improve#hyg-06) |
 | HYG-07 | 3 | Lockfile de dependências commitado | [hyg-07](./measure-and-improve#hyg-07) |
-| HYG-08 | 4 | Configs MCP usam interpolação de env para segredos | [hyg-08](./measure-and-improve#hyg-08) |
+| HYG-08 | 3 | Configs MCP usam interpolação de env para segredos | [hyg-08](./measure-and-improve#hyg-08) |
 
 ## Arquivo de configuração (`.harness-score.json`) {#configuration-file-harness-scorejson}
 

--- a/docs/zh-CN/guide/metrics-and-codes.md
+++ b/docs/zh-CN/guide/metrics-and-codes.md
@@ -108,21 +108,21 @@
 |---|---|---|---|
 | CI-01 | 4 | 存在 CI pipeline 文件（GitHub Actions、GitLab CI 等） | [ci-01](./measure-and-improve#ci-01) |
 | CI-02 | 4 | CI 运行测试套件 | [ci-02](./measure-and-improve#ci-02) |
-| CI-03 | 4 | CI 运行 lint 或 typecheck | [ci-03](./measure-and-improve#ci-03) |
-| CI-04 | 2 | 安装了 pre-commit 或 git hook 工具 | [ci-04](./measure-and-improve#ci-04) |
+| CI-03 | 3 | CI 运行 lint 或 typecheck | [ci-03](./measure-and-improve#ci-03) |
+| CI-04 | 3 | 安装了 pre-commit 或 git hook 工具 | [ci-04](./measure-and-improve#ci-04) |
 
 ### Hygiene & Safety
 
 | ID | 分 | 精确分析 | 修复 |
 |---|---|---|---|
-| HYG-01 | 4 | 存在 `.gitignore` | [hyg-01](./measure-and-improve#hyg-01) |
+| HYG-01 | 2 | 存在 `.gitignore` | [hyg-01](./measure-and-improve#hyg-01) |
 | HYG-02 | 3 | `.gitignore` 覆盖环境文件 | [hyg-02](./measure-and-improve#hyg-02) |
 | HYG-03 | 4 | 无未保护的 `.env` 文件（无 `.env.example` 模式） | [hyg-03](./measure-and-improve#hyg-03) |
 | HYG-04 | 4 | MCP JSON 配置无 inline 凭证模式 | [hyg-04](./measure-and-improve#hyg-04) |
 | HYG-05 | 2 | 存在 `LICENSE` 文件 | [hyg-05](./measure-and-improve#hyg-05) |
-| HYG-06 | 3 | harness markdown/JSON 中无类凭证签名 | [hyg-06](./measure-and-improve#hyg-06) |
+| HYG-06 | 2 | harness markdown/JSON 中无类凭证签名 | [hyg-06](./measure-and-improve#hyg-06) |
 | HYG-07 | 3 | 已提交依赖 lockfile | [hyg-07](./measure-and-improve#hyg-07) |
-| HYG-08 | 4 | MCP 配置对 secrets 使用 env 插值 | [hyg-08](./measure-and-improve#hyg-08) |
+| HYG-08 | 3 | MCP 配置对 secrets 使用 env 插值 | [hyg-08](./measure-and-improve#hyg-08) |
 
 ## 配置文件（`.harness-score.json`）{#configuration-file-harness-scorejson}
 

--- a/packages/cli/test/docs.test.ts
+++ b/packages/cli/test/docs.test.ts
@@ -6,10 +6,18 @@ import { ALL_CHECKS, PRESET_REGISTRY } from '../src/index.js';
 
 const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
-const GUIDE = path.join(REPO, 'docs', 'guide', 'measure-and-improve.md');
+const LOCALES = ['en', 'pt-BR', 'es', 'zh-CN', 'hi-IN'] as const;
+type Locale = (typeof LOCALES)[number];
+
 const GUIDE_DIR = path.join(REPO, 'docs', 'guide');
-const METRICS = path.join(REPO, 'docs', 'guide', 'metrics-and-codes.md');
-const LOCALES = ['pt-BR', 'es', 'zh-CN', 'hi-IN'] as const;
+const GUIDE = path.join(GUIDE_DIR, 'measure-and-improve.md');
+const METRICS = path.join(GUIDE_DIR, 'metrics-and-codes.md');
+
+function localeGuidePath(locale: Locale, file: string): string {
+  return locale === 'en'
+    ? path.join(REPO, 'docs', 'guide', file)
+    : path.join(REPO, 'docs', locale, 'guide', file);
+}
 
 function listGuideFiles(dir: string): string[] {
   return fs
@@ -23,35 +31,56 @@ function extractAnchors(content: string): string[] {
   return [...matches].map((m) => m[1]).sort();
 }
 
-describe('docs stay in sync with the scanner', () => {
-  const content = fs.readFileSync(GUIDE, 'utf8');
+interface CatalogRow {
+  id: string;
+  points: number;
+}
 
-  test('every check has a remediation anchor in the guide', () => {
-    const missing = ALL_CHECKS.map((c) => c.id.toLowerCase()).filter(
-      (anchor) => !content.includes(`{#${anchor}}`),
-    );
-    expect(missing).toEqual([]);
-  });
+function extractCatalogRows(content: string): CatalogRow[] {
+  return content
+    .split(/\r?\n/)
+    .filter((line) => /^\|\s*[A-Z]+-\d+\s*\|/.test(line))
+    .map((line) => {
+      const columns = line.split('|').map((column) => column.trim());
+      return { id: columns[1]!, points: Number(columns[2]) };
+    });
+}
 
-  test('documented point values match the implementation', () => {
-    for (const check of ALL_CHECKS) {
-      const anchorIdx = content.indexOf(`{#${check.id.toLowerCase()}}`);
-      const heading = content.lastIndexOf('####', anchorIdx);
-      const line = content.slice(heading, anchorIdx);
-      expect(line, `heading for ${check.id}`).toContain(`${check.points} pt`);
-    }
-  });
-});
+function dimensionPoints(): Map<string, number> {
+  return new Map(
+    [...new Set(ALL_CHECKS.map((check) => check.dimension))].map((dimension) => [
+      dimension,
+      ALL_CHECKS.filter((check) => check.dimension === dimension).reduce(
+        (sum, check) => sum + check.points,
+        0,
+      ),
+    ]),
+  );
+}
 
-describe('translated measure-and-improve guides preserve anchors', () => {
+describe('measure-and-improve guides stay in sync with the scanner', () => {
   const enAnchors = extractAnchors(fs.readFileSync(GUIDE, 'utf8'));
 
   for (const locale of LOCALES) {
-    test(`${locale} has the same anchor set as English`, () => {
-      const translated = path.join(REPO, 'docs', locale, 'guide', 'measure-and-improve.md');
-      expect(fs.existsSync(translated), `${locale} guide missing`).toBe(true);
-      const localeAnchors = extractAnchors(fs.readFileSync(translated, 'utf8'));
+    const guide = localeGuidePath(locale, 'measure-and-improve.md');
+
+    test(`${locale} has the English remediation anchor set`, () => {
+      expect(fs.existsSync(guide), `${locale} guide missing`).toBe(true);
+      const localeAnchors = extractAnchors(fs.readFileSync(guide, 'utf8'));
       expect(localeAnchors).toEqual(enAnchors);
+    });
+
+    test(`${locale} documents every check's implemented point value`, () => {
+      const content = fs.readFileSync(guide, 'utf8');
+      for (const check of ALL_CHECKS) {
+        const anchorIdx = content.indexOf(`{#${check.id.toLowerCase()}}`);
+        const headingStart = content.lastIndexOf('####', anchorIdx);
+        const headingEnd = content.indexOf('\n', headingStart);
+        const heading = content.slice(headingStart, headingEnd);
+        expect(heading, `${locale}: heading for ${check.id}`).toMatch(
+          new RegExp(`\\b${check.points}\\s*pts?\\b`),
+        );
+      }
     });
   }
 });
@@ -67,10 +96,50 @@ describe('built-in presets stay in sync with metrics-and-codes.md', () => {
   });
 });
 
+describe('metrics-and-codes check catalogs stay in sync with the scanner', () => {
+  const expectedIds = ALL_CHECKS.map((check) => check.id).sort();
+  const expectedDimensionPoints = dimensionPoints();
+
+  for (const locale of LOCALES) {
+    const metrics = localeGuidePath(locale, 'metrics-and-codes.md');
+
+    test(`${locale} has one complete table row for every check`, () => {
+      const content = fs.readFileSync(metrics, 'utf8');
+      const checkLines = content.split(/\r?\n/).filter((line) => /^\|\s*[A-Z]+-\d+\s*\|/.test(line));
+      const malformed = checkLines.filter(
+        (line) => !/^\|\s*[A-Z]+-\d+\s*\|\s*\d+\s*\|\s*\S.+\|\s*\S.+\|\s*$/.test(line),
+      );
+
+      expect(malformed, `${locale}: incomplete catalog rows`).toEqual([]);
+      expect(
+        extractCatalogRows(content)
+          .map((row) => row.id)
+          .sort(),
+      ).toEqual(expectedIds);
+    });
+
+    test(`${locale} uses the implemented check weights and dimension totals`, () => {
+      const content = fs.readFileSync(metrics, 'utf8');
+      const rows = new Map(extractCatalogRows(content).map((row) => [row.id, row]));
+      for (const check of ALL_CHECKS) {
+        expect(rows.get(check.id), `${locale}: missing ${check.id}`).toBeDefined();
+        expect(rows.get(check.id)!.points, `${locale}: ${check.id}`).toBe(check.points);
+      }
+
+      for (const [dimension, points] of expectedDimensionPoints) {
+        const rowRe = new RegExp(`\\|\\s*\\\`${dimension}\\\`\\s*\\|[^|]*\\|\\s*(\\d+)\\s*\\|`);
+        const row = rowRe.exec(content);
+        expect(row, `${locale}: no dimension row for ${dimension}`).not.toBeNull();
+        expect(Number(row![1]), `${locale}: ${dimension} total`).toBe(points);
+      }
+    });
+  }
+});
+
 describe('translated guides mirror English chapter set', () => {
   const enFiles = listGuideFiles(GUIDE_DIR);
 
-  for (const locale of LOCALES) {
+  for (const locale of LOCALES.filter((locale) => locale !== 'en')) {
     test(`${locale} has the same guide files as English`, () => {
       const localeDir = path.join(REPO, 'docs', locale, 'guide');
       expect(fs.existsSync(localeDir), `${locale} guide dir missing`).toBe(true);

--- a/packages/cli/test/maturity-sync.test.ts
+++ b/packages/cli/test/maturity-sync.test.ts
@@ -6,17 +6,35 @@ import { ALL_CHECKS } from '../src/checks/index.js';
 import { LEVEL_REQUIREMENTS } from '../src/score.js';
 import { DIMENSIONS } from '../src/types.js';
 
-const MATURITY_MODEL = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  '..',
-  '..',
-  '..',
-  'docs',
-  'guide',
-  'maturity-model.md',
-);
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
-const content = fs.readFileSync(MATURITY_MODEL, 'utf8');
+const MATURITY_MODELS = [
+  {
+    locale: 'en',
+    path: path.join(REPO, 'docs', 'guide', 'maturity-model.md'),
+    totalRe: /(\d+) points across/,
+  },
+  {
+    locale: 'pt-BR',
+    path: path.join(REPO, 'docs', 'pt-BR', 'guide', 'maturity-model.md'),
+    totalRe: /(\d+) pontos em/,
+  },
+  {
+    locale: 'es',
+    path: path.join(REPO, 'docs', 'es', 'guide', 'maturity-model.md'),
+    totalRe: /(\d+) puntos en/,
+  },
+  {
+    locale: 'zh-CN',
+    path: path.join(REPO, 'docs', 'zh-CN', 'guide', 'maturity-model.md'),
+    totalRe: /共\s*(\d+)\s*分/,
+  },
+  {
+    locale: 'hi-IN',
+    path: path.join(REPO, 'docs', 'hi-IN', 'guide', 'maturity-model.md'),
+    totalRe: /(?:^|\n)(\d+) points, छह dimensions में:/,
+  },
+] as const;
 
 function shortLabel(id: string): string {
   const dim = DIMENSIONS.find((d) => d.id === id);
@@ -24,10 +42,10 @@ function shortLabel(id: string): string {
   return dim.title.split(' ')[0]!;
 }
 
-function levelSection(level: number): string {
+function levelSection(content: string, level: number, locale: string): string {
   const startRe = new RegExp(`### L${level} ·`);
   const startMatch = startRe.exec(content);
-  if (!startMatch) throw new Error(`maturity-model.md has no "### L${level} ·" heading`);
+  if (!startMatch) throw new Error(`${locale} maturity-model.md has no "### L${level} ·" heading`);
   const from = startMatch.index;
   const afterHeading = content.slice(from + startMatch[0].length);
   const nextHeading = /\n#{2,3} /.exec(afterHeading);
@@ -48,60 +66,62 @@ function extractPairs(label: string): Array<{ id: string; pct: string }> {
 }
 
 describe('maturity-model.md stays in sync with the implementation (score.ts + types.ts)', () => {
-  test('per-dimension point totals in the guide match the sum of ALL_CHECKS', () => {
-    for (const dim of DIMENSIONS) {
-      const computed = ALL_CHECKS.filter((c) => c.dimension === dim.id).reduce((sum, c) => sum + c.points, 0);
-      const escaped = dim.title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const rowRe = new RegExp(`\\|\\s*${escaped}\\s*\\|\\s*(\\d+)\\s*\\|`);
-      const row = rowRe.exec(content);
+  for (const model of MATURITY_MODELS) {
+    const content = fs.readFileSync(model.path, 'utf8');
+
+    test(`${model.locale}: per-dimension point totals match the sum of ALL_CHECKS`, () => {
+      for (const dim of DIMENSIONS) {
+        const computed = ALL_CHECKS.filter((c) => c.dimension === dim.id).reduce(
+          (sum, c) => sum + c.points,
+          0,
+        );
+        const escaped = dim.title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const rowRe = new RegExp(`\\|\\s*${escaped}\\s*\\|\\s*(\\d+)\\s*\\|`);
+        const row = rowRe.exec(content);
+        expect(row, `${model.locale}: no dimension-points table row found for "${dim.title}"`).not.toBeNull();
+        const documented = Number(row![1]);
+        expect(
+          documented,
+          `${model.locale}: ${dim.title} says ${documented} pts, ALL_CHECKS sums to ${computed}`,
+        ).toBe(computed);
+      }
+    });
+
+    test(`${model.locale}: total point count matches the sum of ALL_CHECKS`, () => {
+      const computed = ALL_CHECKS.reduce((sum, c) => sum + c.points, 0);
+      const match = model.totalRe.exec(content);
+      expect(match, `${model.locale}: no total-points sentence found`).not.toBeNull();
       expect(
-        row,
-        `no dimension-points table row found for "${dim.title}" in maturity-model.md`,
-      ).not.toBeNull();
-      const documented = Number(row![1]);
-      expect(documented, `${dim.title}: guide says ${documented} pts, ALL_CHECKS sums to ${computed}`).toBe(
-        computed,
-      );
-    }
-  });
+        Number(match![1]),
+        `${model.locale}: guide says ${match![1]} points, ALL_CHECKS sums to ${computed}`,
+      ).toBe(computed);
+    });
 
-  test('the total point count in the guide matches the sum of ALL_CHECKS', () => {
-    const computed = ALL_CHECKS.reduce((sum, c) => sum + c.points, 0);
-    const totalRe = /(\d+) points across/;
-    const match = totalRe.exec(content);
-    expect(match, 'no "<N> points across ..." sentence found in maturity-model.md').not.toBeNull();
-    expect(Number(match![1]), `guide says ${match![1]} points, ALL_CHECKS sums to ${computed}`).toBe(
-      computed,
-    );
-  });
-
-  test('every LEVEL_REQUIREMENTS percentage is mirrored in the matching level section', () => {
-    for (const [levelIdx, requirements] of LEVEL_REQUIREMENTS.entries()) {
-      const level = levelIdx + 1;
-      const section = levelSection(level);
-      for (const requirement of requirements) {
-        const pairs = extractPairs(requirement.label);
-        for (const { id, pct } of pairs) {
-          if (id === 'total') {
-            const hasTotal = section.includes(`total ≥ ${pct}%`) || section.includes(`total score ≥ ${pct}%`);
+    test(`${model.locale}: every LEVEL_REQUIREMENTS percentage is mirrored in the matching level section`, () => {
+      for (const [levelIdx, requirements] of LEVEL_REQUIREMENTS.entries()) {
+        const level = levelIdx + 1;
+        const section = levelSection(content, level, model.locale);
+        for (const requirement of requirements) {
+          const pairs = extractPairs(requirement.label);
+          for (const { id, pct } of pairs) {
+            if (id === 'total') {
+              const totalLabels = ['total', 'total score', 'pontuação total', 'puntuación total', '总分'];
+              const hasTotal = totalLabels.some((label) => section.includes(`${label} ≥ ${pct}%`));
+              expect(hasTotal, `${model.locale}: L${level} has no total-score threshold of ${pct}%`).toBe(
+                true,
+              );
+              continue;
+            }
+            const dim = DIMENSIONS.find((d) => d.id === id)!;
+            const short = `${shortLabel(id)} ≥ ${pct}%`;
+            const full = `${dim.title} ≥ ${pct}%`;
             expect(
-              hasTotal,
-              `L${level}: expected "total (score) ≥ ${pct}%" somewhere in its guide section`,
+              section.includes(short) || section.includes(full),
+              `${model.locale}: L${level} is missing "${short}" or "${full}" from "${requirement.label}"`,
             ).toBe(true);
-            continue;
           }
-          const dim = DIMENSIONS.find((d) => d.id === id)!;
-          // Accept either the full dimension title ("Context & Guides ≥ 40%",
-          // used in the L1 prose) or its short form ("Context ≥ 60%", used
-          // from L2 on) — both unambiguously name the same dimension.
-          const short = `${shortLabel(id)} ≥ ${pct}%`;
-          const full = `${dim.title} ≥ ${pct}%`;
-          expect(
-            section.includes(short) || section.includes(full),
-            `L${level}: expected "${short}" or "${full}" (derived from LEVEL_REQUIREMENTS label "${requirement.label}") in its guide section, got:\n${section}`,
-          ).toBe(true);
         }
       }
-    }
-  });
+    });
+  }
 });


### PR DESCRIPTION
## Summary

- Synchronizes the five stale check weights in the compact Metrics & Codes catalog for English, Portuguese, Spanish, Chinese, and Hindi.
- Extends documentation synchronization coverage to all five locales: complete and unique check rows, implementation weights from ALL_CHECKS, six dimension totals, detailed-catalog heading points, overall totals, and level thresholds from LEVEL_REQUIREMENTS.
- Adds table-row validation so a split Markdown row, including the Hindi HYG-03 regression shape, is caught automatically.

## Drift corrected

The compact catalog retained older values while the implementation and detailed catalog were already correct:

- CI-03: 4 to 3
- CI-04: 2 to 3
- HYG-01: 4 to 2
- HYG-06: 3 to 2
- HYG-08: 4 to 3

The six dimension totals remain 20, 17, 14, 20, 14, and 23 points, for 108 overall. The drift passed because prior synchronization tests checked English detailed headings and translated anchors, but did not validate compact-catalog weights or numeric maturity content in every locale.

## Scope and validation

There are no changes to score calculation, checks, thresholds, fixtures, public APIs, package version, or published package.

- 
pm test - 396 passed
- 
pm run scan - L4, 108/108
- 
pm run docs:build - passed
- git diff --check - passed
- 
pm run lint still reports 18 existing CSS !important warnings outside this diff; the two changed test files pass Biome directly.
- Built pages were rendered and visually checked locally in all five locales.

No Changeset is included because this is documentation and internal test coverage only. This draft does not release or publish anything; after review and merge, pages.yml will publish the corrected documentation.