### PR TITLE
release: v1.6.4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
   version:
     description: 'harness-score npm version or package spec to run.'
     required: false
-    default: '1.6.3'
+    default: '1.6.4'
   comment:
     description: >-
       Post (or update) a sticky pull-request comment showing the harness

--- a/action/README.md
+++ b/action/README.md
@@ -96,7 +96,7 @@ concurrency:
 | `badge` | `harness-badge.svg` | SVG pill (`harness` + level); empty to skip |
 | `report` | _(empty)_ | Markdown report output path |
 | `working-directory` | `.` | Directory to scan |
-| `version` | `1.6.3` | harness-score npm version or package spec |
+| `version` | `1.6.4` | harness-score npm version or package spec |
 | `comment` | `false` | Post/update a sticky PR comment with the score delta (`pull_request` events only; requires `pull-requests: write`) |
 | `include-user-harness` | `false` | Include the user-level harness in the effective snapshot |
 | `include-system-harness` | `false` | Include the system-level harness in the effective snapshot |

--- a/action/action.yml
+++ b/action/action.yml
@@ -27,7 +27,7 @@ inputs:
   version:
     description: 'harness-score npm version or package spec to run.'
     required: false
-    default: '1.6.3'
+    default: '1.6.4'
   comment:
     description: >-
       Post (or update) a sticky pull-request comment showing the harness

--- a/package-lock.json
+++ b/package-lock.json
@@ -6799,7 +6799,7 @@
     },
     "packages/cli": {
       "name": "harness-score",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "license": "MIT",
       "bin": {
         "harness-score": "dist/cli.js"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # harness-score
 
+## 1.6.4
+
+### Patch Changes
+
+- Synchronize the compact check catalog with the implemented Harness Score weights in English,
+  Portuguese, Spanish, Simplified Chinese, and Hindi. Documentation tests now protect check
+  weights, complete table rows, dimension totals, detailed catalog headings, overall totals,
+  and maturity thresholds across all five locales.
+
 ## 1.6.3
 
 ### Patch Changes

--- a/packages/cli/jsr.json
+++ b/packages/cli/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@paladini/harness-score",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-score",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Deterministic AI coding harness-maturity scanner for AI-assisted repositories (Cursor-flagship, expanding to other AI-first dev tools). Zero LLM calls, zero network, zero runtime dependencies.",
   "type": "module",
   "bin": {

--- a/packages/cli/src/score.ts
+++ b/packages/cli/src/score.ts
@@ -19,7 +19,7 @@ import type {
 import { DIMENSIONS } from './types.js';
 
 export const DOCS_BASE_URL = 'https://paladini.github.io/harness-score/guide/measure-and-improve';
-export const TOOL_VERSION = '1.6.3';
+export const TOOL_VERSION = '1.6.4';
 
 export const LEVEL_NAMES = ['Unharnessed', 'Documented', 'Guided', 'Sensing', 'Self-correcting'] as const;
 


### PR DESCRIPTION
## Summary

- Bump Harness Score from 1.6.3 to 1.6.4 after the multilingual documentation parity fix in #62.
- Synchronize the CLI, TOOL_VERSION, JSR manifest, workspace lockfile, both GitHub Action entrypoints, and Action README.
- Add the 1.6.4 changelog entry and release notes source.

## Release scope

This patch corrects the compact check catalog in English, Portuguese, Spanish, Simplified Chinese, and Hindi, and ships the multilingual synchronization tests merged in #62. There are no changes to score calculation, check behavior, thresholds, fixtures, or public APIs.

## Validation

- 
pm test - 396 passed
- 
pm run lint - passed with the 18 existing CSS !important warnings
- 
pm run scan - L4, 108/108, reporting v1.6.4
- 
pm run docs:build - passed
- 
pm run plugins:sync-check - passed
- git diff --check - passed

After merge, the 1.6.4 GitHub Release will publish npm, GitHub Packages, and JSR through the repository release workflow. The stable 1 Action tag will move only after those jobs pass.